### PR TITLE
자체 로그인 기능 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -60,6 +60,9 @@ dependencies {
 
     // Redis
     implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+
+    // message
+    implementation 'net.nurigo:sdk:4.2.7'
 }
 
 tasks.named('test') {

--- a/build.gradle
+++ b/build.gradle
@@ -57,6 +57,9 @@ dependencies {
     
     // Swagger
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.6.0'
+
+    // Redis
+    implementation 'org.springframework.boot:spring-boot-starter-data-redis'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/widyu/auth/api/AuthController.java
+++ b/src/main/java/com/widyu/auth/api/AuthController.java
@@ -1,6 +1,7 @@
 package com.widyu.auth.api;
 
 import com.widyu.auth.application.AuthService;
+import com.widyu.auth.dto.request.EmailCheckRequest;
 import com.widyu.auth.dto.request.LocalGuardianSignupRequest;
 import com.widyu.auth.dto.request.SmsCodeRequest;
 import com.widyu.auth.dto.request.SmsVerificationRequest;
@@ -41,11 +42,20 @@ public class AuthController implements AuthDocs {
                 .body(response);
     }
 
+    @PostMapping("/signup/email/check")
+    public ApiResponseTemplate<Boolean> isEmailRegistered(@RequestBody @Valid final EmailCheckRequest request) {
+        boolean isRegistered = authService.isEmailRegistered(request);
+        return ApiResponseTemplate.ok()
+                .code("AUTH_2001")
+                .message("이메일 등록 여부 확인 완료")
+                .body(isRegistered);
+    }
+
     @PostMapping("/signup/local/guardian")
     public ApiResponseTemplate<TokenPairResponse> localGuardianSignup(HttpServletRequest httpServletRequest,
                                                                       @RequestBody @Valid final LocalGuardianSignupRequest request) {
         return ApiResponseTemplate.ok()
-                .code("AUTH_2001")
+                .code("AUTH_2002")
                 .message("로컬 보호자 회원가입이 성공적으로 완료되었습니다.")
                 .body(authService.localGuardianSignup(httpServletRequest, request));
     }

--- a/src/main/java/com/widyu/auth/api/AuthController.java
+++ b/src/main/java/com/widyu/auth/api/AuthController.java
@@ -20,7 +20,7 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/v1/auth")
-public class AuthController {
+public class AuthController implements AuthDocs {
     private final AuthService authService;
 
     @PostMapping("/sms/send")

--- a/src/main/java/com/widyu/auth/api/AuthController.java
+++ b/src/main/java/com/widyu/auth/api/AuthController.java
@@ -1,0 +1,53 @@
+package com.widyu.auth.api;
+
+import com.widyu.auth.application.AuthService;
+import com.widyu.auth.dto.request.LocalGuardianSignupRequest;
+import com.widyu.auth.dto.request.SmsCodeRequest;
+import com.widyu.auth.dto.request.SmsVerificationRequest;
+import com.widyu.auth.dto.response.TemporaryTokenResponse;
+import com.widyu.auth.dto.response.TokenPairResponse;
+import com.widyu.global.response.ApiResponseTemplate;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Slf4j
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/auth")
+public class AuthController {
+    private final AuthService authService;
+
+    @PostMapping("/sms/send")
+    public ApiResponseTemplate<Void> sendSmsVerification(@Valid @RequestBody final SmsVerificationRequest request) {
+        authService.sendSmsVerification(request);
+        return ApiResponseTemplate.ok()
+                .code("AUTH_2001")
+                .message("문자가 성공적으로 전송되었습니다.")
+                .body(null);
+    }
+
+    @PostMapping("/sms/verify")
+    public ApiResponseTemplate<TemporaryTokenResponse> verifySmsCode(@RequestBody @Valid final SmsCodeRequest request) {
+        TemporaryTokenResponse response = authService.verifySmsCode(request);
+        return ApiResponseTemplate.ok()
+                .code("AUTH_2002")
+                .message("SMS 인증이 성공적으로 완료되었습니다.")
+                .body(response);
+    }
+
+    @PostMapping("/local-guardian/signup")
+    public ApiResponseTemplate<TokenPairResponse> localGuardianSignup(HttpServletRequest httpServletRequest,
+                                                                      @RequestBody @Valid final LocalGuardianSignupRequest request) {
+        return ApiResponseTemplate.ok()
+                .code("AUTH_2003")
+                .message("로컬 가디언 회원가입이 성공적으로 완료되었습니다.")
+                .body(authService.localGuardianSignup(httpServletRequest, request));
+    }
+
+}

--- a/src/main/java/com/widyu/auth/api/AuthController.java
+++ b/src/main/java/com/widyu/auth/api/AuthController.java
@@ -27,7 +27,7 @@ public class AuthController implements AuthDocs {
     public ApiResponseTemplate<Void> sendSmsVerification(@Valid @RequestBody final SmsVerificationRequest request) {
         authService.sendSmsVerification(request);
         return ApiResponseTemplate.ok()
-                .code("AUTH_2001")
+                .code("SMS_2001")
                 .message("문자가 성공적으로 전송되었습니다.")
                 .body(null);
     }
@@ -36,18 +36,17 @@ public class AuthController implements AuthDocs {
     public ApiResponseTemplate<TemporaryTokenResponse> verifySmsCode(@RequestBody @Valid final SmsCodeRequest request) {
         TemporaryTokenResponse response = authService.verifySmsCode(request);
         return ApiResponseTemplate.ok()
-                .code("AUTH_2002")
+                .code("SMS_2002")
                 .message("SMS 인증이 성공적으로 완료되었습니다.")
                 .body(response);
     }
 
-    @PostMapping("/local-guardian/signup")
+    @PostMapping("/signup/local/guardian")
     public ApiResponseTemplate<TokenPairResponse> localGuardianSignup(HttpServletRequest httpServletRequest,
                                                                       @RequestBody @Valid final LocalGuardianSignupRequest request) {
         return ApiResponseTemplate.ok()
-                .code("AUTH_2003")
-                .message("로컬 가디언 회원가입이 성공적으로 완료되었습니다.")
+                .code("AUTH_2001")
+                .message("로컬 보호자 회원가입이 성공적으로 완료되었습니다.")
                 .body(authService.localGuardianSignup(httpServletRequest, request));
     }
-
 }

--- a/src/main/java/com/widyu/auth/api/AuthDocs.java
+++ b/src/main/java/com/widyu/auth/api/AuthDocs.java
@@ -1,0 +1,155 @@
+package com.widyu.auth.api;
+
+import com.widyu.auth.dto.request.LocalGuardianSignupRequest;
+import com.widyu.auth.dto.request.SmsCodeRequest;
+import com.widyu.auth.dto.request.SmsVerificationRequest;
+import com.widyu.auth.dto.response.TemporaryTokenResponse;
+import com.widyu.auth.dto.response.TokenPairResponse;
+import com.widyu.global.response.ApiResponseTemplate;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.validation.Valid;
+import org.springframework.web.bind.annotation.RequestBody;
+
+@Tag(name = "Auth", description = "인증/회원가입 API")
+public interface AuthDocs {
+
+    @Operation(
+            summary = "SMS 인증번호 전송",
+            description = "사용자의 이름과 전화번호를 받아 인증번호를 전송합니다."
+    )
+    @ApiResponse(
+            responseCode = "200",
+            description = "전송 성공",
+            content = @Content(
+                    schema = @Schema(implementation = ApiResponseTemplate.class),
+                    examples = @ExampleObject(
+                            name = "성공 응답",
+                            value = """
+                                    {
+                                      "code": "AUTH_2001",
+                                      "message": "문자가 성공적으로 전송되었습니다.",
+                                      "data": null
+                                    }
+                                    """
+                    )
+            )
+    )
+    ApiResponseTemplate<Void> sendSmsVerification(
+            @Valid @RequestBody
+            @io.swagger.v3.oas.annotations.parameters.RequestBody(
+                    required = true,
+                    description = "이름과 전화번호",
+                    content = @Content(
+                            schema = @Schema(implementation = SmsVerificationRequest.class),
+                            examples = @ExampleObject(
+                                    name = "요청 예시",
+                                    value = """
+                                            {
+                                              "name": "홍길동",
+                                              "phoneNumber": "01012345678"
+                                            }
+                                            """
+                            )
+                    )
+            ) final SmsVerificationRequest request
+    );
+
+    @Operation(
+            summary = "SMS 인증번호 검증",
+            description = "전화번호와 인증코드를 검증하고, 성공 시 30분 유효의 임시 토큰을 발급합니다."
+    )
+    @ApiResponse(
+            responseCode = "200",
+            description = "검증 성공",
+            content = @Content(
+                    schema = @Schema(implementation = ApiResponseTemplate.class),
+                    examples = @ExampleObject(
+                            name = "성공 응답",
+                            value = """
+                                    {
+                                      "code": "AUTH_2002",
+                                      "message": "SMS 인증이 성공적으로 완료되었습니다.",
+                                      "data": {
+                                        "temporaryToken": "Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9..."
+                                      }
+                                    }
+                                    """
+                    )
+            )
+    )
+    ApiResponseTemplate<TemporaryTokenResponse> verifySmsCode(
+            @Valid @RequestBody
+            @io.swagger.v3.oas.annotations.parameters.RequestBody(
+                    required = true,
+                    description = "전화번호와 인증코드",
+                    content = @Content(
+                            schema = @Schema(implementation = SmsCodeRequest.class),
+                            examples = @ExampleObject(
+                                    name = "요청 예시",
+                                    value = """
+                                            {
+                                              "phoneNumber": "01012345678",
+                                              "code": "123456"
+                                            }
+                                            """
+                            )
+                    )
+            ) final SmsCodeRequest request
+    );
+
+    @Operation(
+            summary = "로컬 보호자 회원가입",
+            description = """
+                    SMS 인증 후 발급받은 임시 토큰을 Authorization 헤더(스킴: `Bearer`)로 전달해야 합니다.
+                    임시 토큰이 유효하면 이메일/비밀번호로 로컬 계정을 생성하고 Access/Refresh 토큰을 발급합니다.
+                    """
+    )
+    @ApiResponse(
+            responseCode = "200",
+            description = "가입 성공",
+            content = @Content(
+                    schema = @Schema(implementation = ApiResponseTemplate.class),
+                    examples = @ExampleObject(
+                            name = "성공 응답",
+                            value = """
+                                    {
+                                      "code": "AUTH_2003",
+                                      "message": "로컬 가디언 회원가입이 성공적으로 완료되었습니다.",
+                                      "data": {
+                                        "accessToken": "Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...",
+                                        "refreshToken": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9..."
+                                      }
+                                    }
+                                    """
+                    )
+            )
+    )
+    ApiResponseTemplate<TokenPairResponse> localGuardianSignup(
+            HttpServletRequest httpServletRequest,
+            @Valid @RequestBody
+            @io.swagger.v3.oas.annotations.parameters.RequestBody(
+                    required = true,
+                    description = "이메일/비밀번호/이름/전화번호",
+                    content = @Content(
+                            schema = @Schema(implementation = LocalGuardianSignupRequest.class),
+                            examples = @ExampleObject(
+                                    name = "요청 예시",
+                                    value = """
+                                            {
+                                              "email": "widyu123",
+                                              "password": "Test@1234",
+                                              "name": "홍길동",
+                                              "phoneNumber": "01012345678"
+                                            }
+                                            """
+                            )
+                    )
+            ) final LocalGuardianSignupRequest request
+    );
+}

--- a/src/main/java/com/widyu/auth/application/AuthService.java
+++ b/src/main/java/com/widyu/auth/application/AuthService.java
@@ -1,0 +1,108 @@
+package com.widyu.auth.application;
+
+import com.widyu.auth.domain.TemporaryMember;
+import com.widyu.auth.dto.TemporaryTokenDto;
+import com.widyu.auth.dto.request.LocalGuardianSignupRequest;
+import com.widyu.auth.dto.request.SmsCodeRequest;
+import com.widyu.auth.dto.request.SmsVerificationRequest;
+import com.widyu.auth.dto.response.TemporaryTokenResponse;
+import com.widyu.auth.dto.response.TokenPairResponse;
+import com.widyu.auth.repository.TemporaryMemberRepository;
+import com.widyu.auth.repository.VerificationCodeRepository;
+import com.widyu.global.error.BusinessException;
+import com.widyu.global.error.ErrorCode;
+import com.widyu.global.security.JwtTokenProvider;
+import com.widyu.global.util.JwtUtil;
+import com.widyu.member.domain.LocalAccount;
+import com.widyu.member.domain.Member;
+import com.widyu.member.domain.MemberType;
+import com.widyu.member.repository.LocalAccountRepository;
+import com.widyu.member.repository.MemberRepository;
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class AuthService {
+    private final PasswordEncoder passwordEncoder;
+    private final JwtTokenProvider jwtTokenProvider;
+    private final SmsService smsService;
+    private final VerificationCodeRepository verificationCodeRepository;
+    private final MemberRepository memberRepository;
+    private final LocalAccountRepository localAccountRepository;
+    private final TemporaryMemberRepository temporaryMemberRepository;
+
+    @Transactional
+    public void sendSmsVerification(final SmsVerificationRequest request) {
+        smsService.sendVerificationSms(request.phoneNumber(), request.name());
+    }
+
+    @Transactional
+    public TemporaryTokenResponse verifySmsCode(final SmsCodeRequest request) {
+        if (smsService.verifyCode(request.phoneNumber(), request.code())) {
+            String name = verificationCodeRepository.findById(request.phoneNumber())
+                    .orElseThrow(() -> new BusinessException(ErrorCode.SMS_VERIFICATION_CODE_NOT_FOUND))
+                    .getName();
+            TemporaryMember temporaryMember = TemporaryMember.createTemporaryMember(
+                    request.phoneNumber(),
+                    name
+            );
+            clearVerificationData(request.phoneNumber());
+            temporaryMemberRepository.save(temporaryMember);
+
+            return jwtTokenProvider.generateTemporaryToken(temporaryMember);
+
+        }
+        throw new IllegalArgumentException("Invalid verification code.");
+
+    }
+
+    @Transactional
+    public TokenPairResponse localGuardianSignup(HttpServletRequest httpServletRequest,
+                                                 final LocalGuardianSignupRequest request) {
+        if (localAccountRepository.existsByEmail(request.email())) {
+            throw new BusinessException(ErrorCode.ALREADY_REGISTERED_EMAIL);
+        }
+        String temporaryToken = JwtUtil.extractTemporaryTokenFromHeader(httpServletRequest);
+        if (temporaryToken == null) {
+            throw new BusinessException(ErrorCode.INVALID_TEMPORARY_TOKEN);
+        }
+
+        TemporaryTokenDto temporaryTokenDto = jwtTokenProvider.retrieveTemporaryToken(temporaryToken);
+        if (temporaryTokenDto == null) {
+            throw new BusinessException(ErrorCode.INVALID_TEMPORARY_TOKEN);
+        }
+
+        TemporaryMember temporaryMember = temporaryMemberRepository.findById(temporaryTokenDto.temporaryMemberId())
+                .orElseThrow(() -> new IllegalArgumentException("Temporary member not found."));
+
+        Member member = Member.createMember(
+                MemberType.GUARDIAN,
+                temporaryMember.getName(),
+                temporaryMember.getPhoneNumber()
+        );
+
+        LocalAccount localAccount = LocalAccount.createLocalAccount(
+                member,
+                request.email(),
+                passwordEncoder.encode(request.password())
+        );
+
+        memberRepository.save(member);
+        localAccountRepository.save(localAccount);
+
+        clearTemporaryMemberData(temporaryMember.getId());
+        return jwtTokenProvider.generateTokenPair(member.getId(), member.getRole());
+    }
+
+    private void clearVerificationData(String phoneNumber) {
+        verificationCodeRepository.deleteById(phoneNumber);
+    }
+
+    private void clearTemporaryMemberData(String temporaryMemberId) {
+        temporaryMemberRepository.deleteById(temporaryMemberId);
+    }
+}

--- a/src/main/java/com/widyu/auth/application/AuthService.java
+++ b/src/main/java/com/widyu/auth/application/AuthService.java
@@ -1,39 +1,25 @@
 package com.widyu.auth.application;
 
-import com.widyu.auth.domain.TemporaryMember;
 import com.widyu.auth.dto.TemporaryTokenDto;
 import com.widyu.auth.dto.request.LocalGuardianSignupRequest;
 import com.widyu.auth.dto.request.SmsCodeRequest;
 import com.widyu.auth.dto.request.SmsVerificationRequest;
 import com.widyu.auth.dto.response.TemporaryTokenResponse;
 import com.widyu.auth.dto.response.TokenPairResponse;
-import com.widyu.auth.repository.TemporaryMemberRepository;
-import com.widyu.auth.repository.VerificationCodeRepository;
-import com.widyu.global.error.BusinessException;
-import com.widyu.global.error.ErrorCode;
-import com.widyu.global.security.JwtTokenProvider;
-import com.widyu.global.util.JwtUtil;
-import com.widyu.member.domain.LocalAccount;
-import com.widyu.member.domain.Member;
-import com.widyu.member.domain.MemberType;
-import com.widyu.member.repository.LocalAccountRepository;
-import com.widyu.member.repository.MemberRepository;
+import com.widyu.auth.domain.TemporaryMember;
 import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
-import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
 public class AuthService {
-    private final PasswordEncoder passwordEncoder;
-    private final JwtTokenProvider jwtTokenProvider;
+
     private final SmsService smsService;
-    private final VerificationCodeRepository verificationCodeRepository;
-    private final MemberRepository memberRepository;
-    private final LocalAccountRepository localAccountRepository;
-    private final TemporaryMemberRepository temporaryMemberRepository;
+    private final VerificationService verificationService;
+    private final TemporaryTokenService temporaryTokenService;
+    private final SignupService signupService;
 
     @Transactional
     public void sendSmsVerification(final SmsVerificationRequest request) {
@@ -42,67 +28,20 @@ public class AuthService {
 
     @Transactional
     public TemporaryTokenResponse verifySmsCode(final SmsCodeRequest request) {
-        if (smsService.verifyCode(request.phoneNumber(), request.code())) {
-            String name = verificationCodeRepository.findById(request.phoneNumber())
-                    .orElseThrow(() -> new BusinessException(ErrorCode.SMS_VERIFICATION_CODE_NOT_FOUND))
-                    .getName();
-            TemporaryMember temporaryMember = TemporaryMember.createTemporaryMember(
-                    request.phoneNumber(),
-                    name
-            );
-            clearVerificationData(request.phoneNumber());
-            temporaryMemberRepository.save(temporaryMember);
-
-            return jwtTokenProvider.generateTemporaryToken(temporaryMember);
-
-        }
-        throw new IllegalArgumentException("Invalid verification code.");
-
+        return verificationService.verifyAndIssueTemporaryToken(request.phoneNumber(), request.code());
     }
 
+    // 로컬 보호자 회원가입
     @Transactional
     public TokenPairResponse localGuardianSignup(HttpServletRequest httpServletRequest,
                                                  final LocalGuardianSignupRequest request) {
-        if (localAccountRepository.existsByEmail(request.email())) {
-            throw new BusinessException(ErrorCode.ALREADY_REGISTERED_EMAIL);
-        }
-        String temporaryToken = JwtUtil.extractTemporaryTokenFromHeader(httpServletRequest);
-        if (temporaryToken == null) {
-            throw new BusinessException(ErrorCode.INVALID_TEMPORARY_TOKEN);
-        }
+        String tempToken = temporaryTokenService.extractFrom(httpServletRequest);
+        TemporaryTokenDto dto = temporaryTokenService.parseAndValidate(tempToken);
+        TemporaryMember temp = temporaryTokenService.loadTemporaryMemberOrThrow(dto.temporaryMemberId());
 
-        TemporaryTokenDto temporaryTokenDto = jwtTokenProvider.retrieveTemporaryToken(temporaryToken);
-        if (temporaryTokenDto == null) {
-            throw new BusinessException(ErrorCode.INVALID_TEMPORARY_TOKEN);
-        }
+        TokenPairResponse tokens = signupService.signupGuardianWithLocal(temp, request.email(), request.password());
 
-        TemporaryMember temporaryMember = temporaryMemberRepository.findById(temporaryTokenDto.temporaryMemberId())
-                .orElseThrow(() -> new IllegalArgumentException("Temporary member not found."));
-
-        Member member = Member.createMember(
-                MemberType.GUARDIAN,
-                temporaryMember.getName(),
-                temporaryMember.getPhoneNumber()
-        );
-
-        LocalAccount localAccount = LocalAccount.createLocalAccount(
-                member,
-                request.email(),
-                passwordEncoder.encode(request.password())
-        );
-
-        memberRepository.save(member);
-        localAccountRepository.save(localAccount);
-
-        clearTemporaryMemberData(temporaryMember.getId());
-        return jwtTokenProvider.generateTokenPair(member.getId(), member.getRole());
-    }
-
-    private void clearVerificationData(String phoneNumber) {
-        verificationCodeRepository.deleteById(phoneNumber);
-    }
-
-    private void clearTemporaryMemberData(String temporaryMemberId) {
-        temporaryMemberRepository.deleteById(temporaryMemberId);
+        temporaryTokenService.deleteTemporaryMember(temp.getId());
+        return tokens;
     }
 }

--- a/src/main/java/com/widyu/auth/application/AuthService.java
+++ b/src/main/java/com/widyu/auth/application/AuthService.java
@@ -1,12 +1,13 @@
 package com.widyu.auth.application;
 
+import com.widyu.auth.domain.TemporaryMember;
 import com.widyu.auth.dto.TemporaryTokenDto;
+import com.widyu.auth.dto.request.EmailCheckRequest;
 import com.widyu.auth.dto.request.LocalGuardianSignupRequest;
 import com.widyu.auth.dto.request.SmsCodeRequest;
 import com.widyu.auth.dto.request.SmsVerificationRequest;
 import com.widyu.auth.dto.response.TemporaryTokenResponse;
 import com.widyu.auth.dto.response.TokenPairResponse;
-import com.widyu.auth.domain.TemporaryMember;
 import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -43,5 +44,10 @@ public class AuthService {
 
         temporaryTokenService.deleteTemporaryMember(temp.getId());
         return tokens;
+    }
+
+    @Transactional(readOnly = true)
+    public boolean isEmailRegistered(EmailCheckRequest request) {
+        return signupService.isEmailRegistered(request);
     }
 }

--- a/src/main/java/com/widyu/auth/application/SignupService.java
+++ b/src/main/java/com/widyu/auth/application/SignupService.java
@@ -1,6 +1,7 @@
 package com.widyu.auth.application;
 
 import com.widyu.auth.domain.TemporaryMember;
+import com.widyu.auth.dto.request.EmailCheckRequest;
 import com.widyu.auth.dto.response.TokenPairResponse;
 import com.widyu.global.error.BusinessException;
 import com.widyu.global.error.ErrorCode;
@@ -46,5 +47,10 @@ public class SignupService {
         localAccountRepository.save(local);
 
         return jwtTokenProvider.generateTokenPair(member.getId(), member.getRole());
+    }
+
+    @Transactional(readOnly = true)
+    public boolean isEmailRegistered(EmailCheckRequest request) {
+        return !localAccountRepository.existsByEmail(request.email());
     }
 }

--- a/src/main/java/com/widyu/auth/application/SignupService.java
+++ b/src/main/java/com/widyu/auth/application/SignupService.java
@@ -1,0 +1,50 @@
+package com.widyu.auth.application;
+
+import com.widyu.auth.domain.TemporaryMember;
+import com.widyu.auth.dto.response.TokenPairResponse;
+import com.widyu.global.error.BusinessException;
+import com.widyu.global.error.ErrorCode;
+import com.widyu.global.security.JwtTokenProvider;
+import com.widyu.member.domain.LocalAccount;
+import com.widyu.member.domain.Member;
+import com.widyu.member.domain.MemberType;
+import com.widyu.member.repository.LocalAccountRepository;
+import com.widyu.member.repository.MemberRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class SignupService {
+
+    private final PasswordEncoder passwordEncoder;
+    private final MemberRepository memberRepository;
+    private final LocalAccountRepository localAccountRepository;
+    private final JwtTokenProvider jwtTokenProvider;
+
+    @Transactional
+    public TokenPairResponse signupGuardianWithLocal(TemporaryMember temp, String email, String rawPassword) {
+        if (localAccountRepository.existsByEmail(email)) {
+            throw new BusinessException(ErrorCode.ALREADY_REGISTERED_EMAIL);
+        }
+
+        Member member = Member.createMember(
+                MemberType.GUARDIAN,
+                temp.getName(),
+                temp.getPhoneNumber()
+        );
+
+        LocalAccount local = LocalAccount.createLocalAccount(
+                member,
+                email,
+                passwordEncoder.encode(rawPassword)
+        );
+
+        memberRepository.save(member);
+        localAccountRepository.save(local);
+
+        return jwtTokenProvider.generateTokenPair(member.getId(), member.getRole());
+    }
+}

--- a/src/main/java/com/widyu/auth/application/SmsService.java
+++ b/src/main/java/com/widyu/auth/application/SmsService.java
@@ -1,0 +1,130 @@
+package com.widyu.auth.application;
+
+import com.widyu.auth.domain.VerificationCode;
+import com.widyu.auth.repository.VerificationCodeRepository;
+import com.widyu.global.error.BusinessException;
+import com.widyu.global.error.ErrorCode;
+import com.widyu.global.properties.CoolsmsProperties;
+import java.security.SecureRandom;
+import java.util.regex.Pattern;
+import lombok.extern.slf4j.Slf4j;
+import net.nurigo.sdk.NurigoApp;
+import net.nurigo.sdk.message.exception.NurigoMessageNotReceivedException;
+import net.nurigo.sdk.message.model.Message;
+import net.nurigo.sdk.message.service.DefaultMessageService;
+import org.springframework.stereotype.Service;
+
+@Slf4j
+@Service
+public class SmsService {
+
+    private final CoolsmsProperties coolsmsProperties;
+    private final DefaultMessageService messageService;
+    private final SecureRandom secureRandom;
+    private final VerificationCodeRepository verificationCodeRepository;
+
+    private static final Pattern PHONE_PATTERN = Pattern.compile("^01[016789]\\d{7,8}$");
+
+    public SmsService(final CoolsmsProperties coolsmsProperties,
+                      final VerificationCodeRepository verificationCodeRepository) {
+        this.coolsmsProperties = coolsmsProperties;
+        this.verificationCodeRepository = verificationCodeRepository;
+        this.messageService = NurigoApp.INSTANCE.initialize(
+                coolsmsProperties.apiKey(),
+                coolsmsProperties.apiSecret(),
+                coolsmsProperties.apiUrl()
+        );
+        this.secureRandom = new SecureRandom();
+    }
+
+    public void sendVerificationSms(final String toPhoneNumber, final String name) {
+        validatePhoneNumber(toPhoneNumber);
+
+        String code = generateVerificationCode();
+        saveVerificationCode(toPhoneNumber, code, name);
+
+        String messageText = createMessageText(code);
+
+        try {
+            Message message = createMessage(toPhoneNumber, messageText);
+            messageService.send(message);
+
+            log.info("SMS 전송 성공 - 수신번호: {}, 이름: {}", maskPhoneNumber(toPhoneNumber), name);
+
+        } catch (NurigoMessageNotReceivedException exception) {
+            log.error("SMS 전송 실패 - 수신 불가: 수신번호={}, 실패목록={}",
+                    maskPhoneNumber(toPhoneNumber), exception.getFailedMessageList());
+            throw new BusinessException(ErrorCode.SMS_SEND_FAILED);
+
+        } catch (Exception exception) {
+            log.error("SMS 전송 중 알 수 없는 오류 발생: 수신번호={}, 오류={}",
+                    maskPhoneNumber(toPhoneNumber), exception.getMessage(), exception);
+            throw new BusinessException(ErrorCode.SMS_SEND_FAILED);
+        }
+    }
+
+    public boolean verifyCode(final String phoneNumber, final String inputCode) {
+        return verificationCodeRepository.findById(phoneNumber)
+                .map(verification -> verification.getCode().equals(inputCode))
+                .orElseThrow(
+                        () -> new BusinessException(ErrorCode.SMS_VERIFICATION_CODE_NOT_FOUND, "인증 코드가 존재하지 않습니다."));
+    }
+
+    private void saveVerificationCode(final String phoneNumber, final String code, final String name) {
+        VerificationCode verificationCode = VerificationCode.builder()
+                .phoneNumber(phoneNumber)
+                .code(code)
+                .name(name)
+                .ttl(coolsmsProperties.verificationCodeTtl())
+                .build();
+
+        verificationCodeRepository.save(verificationCode);
+    }
+
+    private void validatePhoneNumber(final String phoneNumber) {
+        if (phoneNumber == null || phoneNumber.trim().isEmpty()) {
+            throw new BusinessException(ErrorCode.PHONE_NUMBER_REQUIRED);
+        }
+
+        if (!PHONE_PATTERN.matcher(phoneNumber).matches()) {
+            throw new BusinessException(ErrorCode.INVALID_PHONE_NUMBER);
+        }
+    }
+
+    private String generateVerificationCode() {
+        StringBuilder code = new StringBuilder();
+        int length = coolsmsProperties.verificationCodeLength();
+
+        for (int i = 0; i < length; i++) {
+            code.append(secureRandom.nextInt(10));
+        }
+
+        return code.toString();
+    }
+
+    private String createMessageText(final String verificationCode) {
+        return coolsmsProperties.messageTemplate()
+                .replace("{code}", verificationCode);
+    }
+
+    private Message createMessage(final String toPhoneNumber, final String messageText) {
+        Message message = new Message();
+        message.setFrom(coolsmsProperties.fromPhoneNumber());
+        message.setTo(toPhoneNumber);
+        message.setText(messageText);
+        return message;
+    }
+
+    private String maskPhoneNumber(final String phoneNumber) {
+        if (phoneNumber == null || phoneNumber.length() < 8) {
+            return "***";
+        }
+
+        // 01012345678 -> 010****5678
+        if (phoneNumber.length() >= 11) {
+            return phoneNumber.substring(0, 3) + "****" + phoneNumber.substring(7);
+        }
+
+        return phoneNumber.substring(0, 3) + "****";
+    }
+}

--- a/src/main/java/com/widyu/auth/application/TemporaryTokenService.java
+++ b/src/main/java/com/widyu/auth/application/TemporaryTokenService.java
@@ -1,0 +1,45 @@
+package com.widyu.auth.application;
+
+import com.widyu.auth.domain.TemporaryMember;
+import com.widyu.auth.dto.TemporaryTokenDto;
+import com.widyu.auth.repository.TemporaryMemberRepository;
+import com.widyu.global.error.BusinessException;
+import com.widyu.global.error.ErrorCode;
+import com.widyu.global.security.JwtTokenProvider;
+import com.widyu.global.util.JwtUtil;
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class TemporaryTokenService {
+
+    private final JwtTokenProvider jwtTokenProvider;
+    private final TemporaryMemberRepository temporaryMemberRepository;
+
+    public String extractFrom(HttpServletRequest httpServletRequest) {
+        String token = JwtUtil.extractTemporaryTokenFromHeader(httpServletRequest);
+        if (token == null) {
+            throw new BusinessException(ErrorCode.INVALID_TEMPORARY_TOKEN);
+        }
+        return token;
+    }
+
+    public TemporaryTokenDto parseAndValidate(String temporaryToken) {
+        TemporaryTokenDto dto = jwtTokenProvider.retrieveTemporaryToken(temporaryToken);
+        if (dto == null) {
+            throw new BusinessException(ErrorCode.INVALID_TEMPORARY_TOKEN);
+        }
+        return dto;
+    }
+
+    public TemporaryMember loadTemporaryMemberOrThrow(String temporaryMemberId) {
+        return temporaryMemberRepository.findById(temporaryMemberId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.MEMBER_NOT_FOUND));
+    }
+
+    public void deleteTemporaryMember(String temporaryMemberId) {
+        temporaryMemberRepository.deleteById(temporaryMemberId);
+    }
+}

--- a/src/main/java/com/widyu/auth/application/VerificationService.java
+++ b/src/main/java/com/widyu/auth/application/VerificationService.java
@@ -1,0 +1,51 @@
+package com.widyu.auth.application;
+
+import com.widyu.auth.domain.TemporaryMember;
+import com.widyu.auth.dto.response.TemporaryTokenResponse;
+import com.widyu.auth.repository.TemporaryMemberRepository;
+import com.widyu.auth.repository.VerificationCodeRepository;
+import com.widyu.global.error.BusinessException;
+import com.widyu.global.error.ErrorCode;
+import com.widyu.global.security.JwtTokenProvider;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class VerificationService {
+
+    private final SmsService smsService;
+    private final VerificationCodeRepository verificationCodeRepository;
+    private final JwtTokenProvider jwtTokenProvider;
+    private final TemporaryMemberRepository temporaryMemberRepository;
+
+
+    public TemporaryTokenResponse verifyAndIssueTemporaryToken(String phoneNumber, String code) {
+        validateVerificationCode(phoneNumber, code);
+
+        TemporaryMember temp = createTemporaryMember(phoneNumber);
+
+        cleanupVerificationData(phoneNumber);
+
+        return jwtTokenProvider.generateTemporaryToken(temp);
+    }
+
+    private void validateVerificationCode(String phoneNumber, String code) {
+        if (!smsService.verifyCode(phoneNumber, code)) {
+            throw new BusinessException(ErrorCode.SMS_VERIFICATION_CODE_MISMATCH);
+        }
+    }
+
+    private TemporaryMember createTemporaryMember(String phoneNumber) {
+        String name = verificationCodeRepository.findById(phoneNumber)
+                .orElseThrow(() -> new BusinessException(ErrorCode.SMS_VERIFICATION_CODE_NOT_FOUND))
+                .getName();
+
+        TemporaryMember temp = TemporaryMember.createTemporaryMember(phoneNumber, name);
+        return temporaryMemberRepository.save(temp);
+    }
+
+    private void cleanupVerificationData(String phoneNumber) {
+        verificationCodeRepository.deleteById(phoneNumber);
+    }
+}

--- a/src/main/java/com/widyu/auth/domain/RefreshToken.java
+++ b/src/main/java/com/widyu/auth/domain/RefreshToken.java
@@ -1,0 +1,29 @@
+package com.widyu.auth.domain;
+
+import lombok.Builder;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.redis.core.RedisHash;
+import org.springframework.data.redis.core.TimeToLive;
+
+@Getter
+@EqualsAndHashCode(of = "memberId")
+@RedisHash(value = "refreshToken")
+public class RefreshToken {
+
+    @Id
+    private Long memberId;
+
+    private final String token;
+
+    @TimeToLive
+    private final long ttl;
+
+    @Builder
+    public RefreshToken(final Long memberId, final String token, final long ttl) {
+        this.memberId = memberId;
+        this.token = token;
+        this.ttl = ttl;
+    }
+}

--- a/src/main/java/com/widyu/auth/domain/TemporaryMember.java
+++ b/src/main/java/com/widyu/auth/domain/TemporaryMember.java
@@ -1,0 +1,42 @@
+package com.widyu.auth.domain;
+
+import java.util.UUID;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.redis.core.RedisHash;
+import org.springframework.data.redis.core.TimeToLive;
+
+@Getter
+@EqualsAndHashCode(of = "id")
+@RedisHash(value = "temporaryMember")
+public class TemporaryMember {
+
+    @Id
+    private String id;
+
+    private String name;
+    private String phoneNumber;
+
+    @TimeToLive
+    private final long ttl;
+
+    @Builder(access = AccessLevel.PRIVATE)
+    private TemporaryMember(final String id, final String name, final String phoneNumber, final long ttl) {
+        this.id = id;
+        this.name = name;
+        this.phoneNumber = phoneNumber;
+        this.ttl = ttl;
+    }
+
+    public static TemporaryMember createTemporaryMember(final String name, final String phoneNumber) {
+        return TemporaryMember.builder()
+                .id(UUID.randomUUID().toString())
+                .name(name)
+                .phoneNumber(phoneNumber)
+                .ttl(1800)
+                .build();
+    }
+}

--- a/src/main/java/com/widyu/auth/domain/TokenType.java
+++ b/src/main/java/com/widyu/auth/domain/TokenType.java
@@ -1,0 +1,14 @@
+package com.widyu.auth.domain;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+@Getter
+public enum TokenType {
+    ACCESS("access"),
+    REFRESH("refresh"),
+    TEMPORARY("temporary")
+    ;
+    private final String value;
+}

--- a/src/main/java/com/widyu/auth/domain/VerificationCode.java
+++ b/src/main/java/com/widyu/auth/domain/VerificationCode.java
@@ -1,0 +1,34 @@
+package com.widyu.auth.domain;
+
+import lombok.Builder;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.redis.core.RedisHash;
+import org.springframework.data.redis.core.TimeToLive;
+
+@Getter
+@NoArgsConstructor
+@EqualsAndHashCode(of = "phoneNumber")
+@RedisHash(value = "verificationCode")
+public class VerificationCode {
+
+    @Id
+    private String phoneNumber;
+
+    private String name;
+
+    private String code;
+
+    @TimeToLive
+    private long ttl;
+
+    @Builder
+    public VerificationCode(final String phoneNumber, final String name, final String code, final long ttl) {
+        this.phoneNumber = phoneNumber;
+        this.name = name;
+        this.code = code;
+        this.ttl = ttl;
+    }
+}

--- a/src/main/java/com/widyu/auth/dto/AccessTokenDto.java
+++ b/src/main/java/com/widyu/auth/dto/AccessTokenDto.java
@@ -1,0 +1,19 @@
+package com.widyu.auth.dto;
+
+import com.widyu.member.domain.MemberRole;
+import lombok.Builder;
+
+@Builder
+public record AccessTokenDto(
+        Long memberId,
+        MemberRole memberRole,
+        String tokenValue
+) {
+    public static AccessTokenDto of(final Long memberId, final MemberRole memberRole, final String tokenValue) {
+        return AccessTokenDto.builder()
+                .memberId(memberId)
+                .memberRole(memberRole)
+                .tokenValue(tokenValue)
+                .build();
+    }
+}

--- a/src/main/java/com/widyu/auth/dto/RefreshTokenDto.java
+++ b/src/main/java/com/widyu/auth/dto/RefreshTokenDto.java
@@ -1,0 +1,11 @@
+package com.widyu.auth.dto;
+
+import com.widyu.member.domain.MemberRole;
+
+public record RefreshTokenDto(
+        Long memberId,
+        MemberRole memberRole,
+        String tokenValue,
+        Long ttl
+) {
+}

--- a/src/main/java/com/widyu/auth/dto/TemporaryTokenDto.java
+++ b/src/main/java/com/widyu/auth/dto/TemporaryTokenDto.java
@@ -1,0 +1,11 @@
+package com.widyu.auth.dto;
+
+import com.widyu.member.domain.MemberRole;
+
+public record TemporaryTokenDto(
+        String temporaryMemberId,
+        MemberRole memberRole,
+        String tokenValue,
+        Long ttl
+) {
+}

--- a/src/main/java/com/widyu/auth/dto/request/EmailCheckRequest.java
+++ b/src/main/java/com/widyu/auth/dto/request/EmailCheckRequest.java
@@ -1,0 +1,6 @@
+package com.widyu.auth.dto.request;
+
+public record EmailCheckRequest(
+        String email
+) {
+}

--- a/src/main/java/com/widyu/auth/dto/request/LocalGuardianSignupRequest.java
+++ b/src/main/java/com/widyu/auth/dto/request/LocalGuardianSignupRequest.java
@@ -1,0 +1,27 @@
+package com.widyu.auth.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
+
+public record LocalGuardianSignupRequest(
+
+        @NotBlank(message = "이메일은 필수입니다")
+        @Size(min = 6, max = 12, message = "이메일은 6~12자 사이여야 합니다")
+        @Pattern(regexp = "^[a-zA-Z0-9]+$", message = "이메일은 영문과 숫자만 사용 가능합니다")
+        String email,
+
+        @NotBlank(message = "비밀번호는 필수입니다")
+        @Size(min = 8, max = 12, message = "비밀번호는 8~12자 사이여야 합니다")
+        @Pattern(regexp = "^(?=.*[a-zA-Z])(?=.*\\d)(?=.*[!@#$%^&*(),.?\":{}|<>]).{8,12}$",
+                message = "비밀번호는 영문, 숫자, 특수기호를 모두 포함해야 합니다")
+        String password,
+
+        @NotBlank(message = "이름은 필수입니다")
+        String name,
+
+        @NotBlank(message = "전화번호는 필수입니다")
+        @Pattern(regexp = "^\\d{10,11}$", message = "전화번호는 10~11자리 숫자여야 합니다")
+        String phoneNumber
+) {
+}

--- a/src/main/java/com/widyu/auth/dto/request/SmsCodeRequest.java
+++ b/src/main/java/com/widyu/auth/dto/request/SmsCodeRequest.java
@@ -1,0 +1,17 @@
+package com.widyu.auth.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
+
+public record SmsCodeRequest(
+
+        @NotBlank(message = "전화번호는 필수입니다.")
+        @Pattern(regexp = "^01[016789]\\d{7,8}$", message = "올바른 전화번호 형식이 아닙니다.")
+        String phoneNumber,
+
+        @NotBlank(message = "인증 코드는 필수입니다.")
+        @Size(min = 6, max = 6, message = "인증 코드는 6자리여야 합니다.")
+        String code
+) {
+}

--- a/src/main/java/com/widyu/auth/dto/request/SmsVerificationRequest.java
+++ b/src/main/java/com/widyu/auth/dto/request/SmsVerificationRequest.java
@@ -1,0 +1,15 @@
+package com.widyu.auth.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+
+public record SmsVerificationRequest(
+
+        @NotBlank(message = "이름은 필수입니다.")
+        String name,
+
+        @NotBlank(message = "전화번호는 필수입니다.")
+        @Pattern(regexp = "^01[016789]\\d{7,8}$", message = "올바른 전화번호 형식이 아닙니다.")
+        String phoneNumber
+) {
+}

--- a/src/main/java/com/widyu/auth/dto/response/AccessTokenResponse.java
+++ b/src/main/java/com/widyu/auth/dto/response/AccessTokenResponse.java
@@ -1,0 +1,9 @@
+package com.widyu.auth.dto.response;
+
+public record AccessTokenResponse(
+        String accessToken
+) {
+    public static AccessTokenResponse of(final String accessToken) {
+        return new AccessTokenResponse(accessToken);
+    }
+}

--- a/src/main/java/com/widyu/auth/dto/response/TemporaryTokenResponse.java
+++ b/src/main/java/com/widyu/auth/dto/response/TemporaryTokenResponse.java
@@ -1,0 +1,14 @@
+package com.widyu.auth.dto.response;
+
+import lombok.Builder;
+
+@Builder
+public record TemporaryTokenResponse(
+        String temporaryToken
+) {
+    public static TemporaryTokenResponse from(final String temporaryToken) {
+        return TemporaryTokenResponse.builder()
+                .temporaryToken(temporaryToken)
+                .build();
+    }
+}

--- a/src/main/java/com/widyu/auth/dto/response/TokenPairResponse.java
+++ b/src/main/java/com/widyu/auth/dto/response/TokenPairResponse.java
@@ -1,0 +1,12 @@
+package com.widyu.auth.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+public record TokenPairResponse(
+        @Schema(description = "액세스 토큰", defaultValue = "accessToken") String accessToken,
+        @Schema(description = "리프레시 토큰", defaultValue = "refreshToken") String refreshToken) {
+
+    public static TokenPairResponse of(final String accessToken, final String refreshToken) {
+        return new TokenPairResponse(accessToken, refreshToken);
+    }
+}

--- a/src/main/java/com/widyu/auth/repository/RefreshTokenRepository.java
+++ b/src/main/java/com/widyu/auth/repository/RefreshTokenRepository.java
@@ -1,0 +1,9 @@
+package com.widyu.auth.repository;
+
+import com.widyu.auth.domain.RefreshToken;
+import org.springframework.data.repository.CrudRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface RefreshTokenRepository extends CrudRepository<RefreshToken, Long> {
+}

--- a/src/main/java/com/widyu/auth/repository/TemporaryMemberRepository.java
+++ b/src/main/java/com/widyu/auth/repository/TemporaryMemberRepository.java
@@ -1,0 +1,9 @@
+package com.widyu.auth.repository;
+
+import com.widyu.auth.domain.TemporaryMember;
+import org.springframework.data.repository.CrudRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface TemporaryMemberRepository extends CrudRepository<TemporaryMember, String> {
+}

--- a/src/main/java/com/widyu/auth/repository/VerificationCodeRepository.java
+++ b/src/main/java/com/widyu/auth/repository/VerificationCodeRepository.java
@@ -1,0 +1,9 @@
+package com.widyu.auth.repository;
+
+import com.widyu.auth.domain.VerificationCode;
+import org.springframework.data.repository.CrudRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface VerificationCodeRepository extends CrudRepository<VerificationCode, String> {
+}

--- a/src/main/java/com/widyu/global/constant/SecurityConstant.java
+++ b/src/main/java/com/widyu/global/constant/SecurityConstant.java
@@ -1,0 +1,10 @@
+package com.widyu.global.constant;
+
+public final class SecurityConstant {
+
+    // security
+    public static final String TOKEN_ROLE_NAME = "role";
+    public static final String TOKEN_PREFIX = "Bearer ";
+
+    private SecurityConstant() {}
+}

--- a/src/main/java/com/widyu/global/domain/BaseTimeEntity.java
+++ b/src/main/java/com/widyu/global/domain/BaseTimeEntity.java
@@ -1,0 +1,24 @@
+package com.widyu.global.domain;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import java.time.LocalDateTime;
+import lombok.Getter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+@Getter
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
+public abstract class BaseTimeEntity {
+
+    @CreatedDate
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    @LastModifiedDate
+    @Column(name = "updated_at", nullable = false)
+    private LocalDateTime updatedAt;
+}

--- a/src/main/java/com/widyu/global/domain/Status.java
+++ b/src/main/java/com/widyu/global/domain/Status.java
@@ -1,0 +1,10 @@
+package com.widyu.global.domain;
+
+public enum Status {
+    ACTIVE("활성화"),
+    INACTIVE("비활성화"),
+    DELETED("삭제");
+
+    Status(String description) {
+    }
+}

--- a/src/main/java/com/widyu/global/error/ErrorCode.java
+++ b/src/main/java/com/widyu/global/error/ErrorCode.java
@@ -10,7 +10,24 @@ public enum ErrorCode {
 
     // 인증/인가
     UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "AUTH_4010", "인증이 필요합니다."),
+    INVALID_REFRESH_TOKEN(HttpStatus.UNAUTHORIZED, "AUTH_4013", "리프레시 토큰이 유효하지 않습니다."),
     FORBIDDEN(HttpStatus.FORBIDDEN, "AUTH_4030", "접근 권한이 없습니다."),
+    TEMPORARY_TOKEN_EXPIRED(HttpStatus.UNAUTHORIZED, "AUTH_4014", "임시 토큰이 만료되었습니다."),
+    ALREADY_REGISTERED_EMAIL(HttpStatus.BAD_REQUEST, "AUTH_4001", "이미 등록된 이메일입니다."),
+    INVALID_TEMPORARY_TOKEN(HttpStatus.UNAUTHORIZED, "AUTH_4015", "유효하지 않은 임시 토큰입니다."),
+
+    // 문자 인증
+    SMS_VERIFICATION_CODE_NOT_FOUND(HttpStatus.NOT_FOUND, "SMS_4040", "문자 인증 코드가 존재하지 않습니다."),
+    SMS_VERIFICATION_CODE_MISMATCH(HttpStatus.BAD_REQUEST, "SMS_4000", "문자 인증 코드가 일치하지 않습니다."),
+    SMS_SEND_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "SMS_5000", "SMS 전송에 실패했습니다."),
+    INVALID_PHONE_NUMBER(HttpStatus.BAD_REQUEST, "SMS_4001", "유효하지 않은 전화번호 형식입니다."),
+    PHONE_NUMBER_REQUIRED(HttpStatus.BAD_REQUEST, "SMS_4002", "전화번호는 필수입니다."),
+
+    // 회원 관련
+    MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, "MEMBER_4041", "회원을 찾을 수 없습니다."),
+
+    // 잘못된 요청
+    BAD_REQUEST(HttpStatus.BAD_REQUEST, "REQ_4000", "잘못된 요청입니다."),
 
     // 서버 오류
     INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "SRV_5000", "서버 내부 오류가 발생했습니다."),

--- a/src/main/java/com/widyu/global/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/com/widyu/global/filter/JwtAuthenticationFilter.java
@@ -1,0 +1,66 @@
+package com.widyu.global.filter;
+
+import static com.widyu.global.constant.SecurityConstant.TOKEN_PREFIX;
+
+import com.widyu.auth.dto.AccessTokenDto;
+import com.widyu.global.security.JwtTokenProvider;
+import com.widyu.global.security.PrincipalDetails;
+import com.widyu.member.domain.MemberRole;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.util.Optional;
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpHeaders;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+@Slf4j
+@RequiredArgsConstructor
+public class JwtAuthenticationFilter extends OncePerRequestFilter {
+
+    private final JwtTokenProvider jwtTokenProvider;
+
+    @Override
+    protected void doFilterInternal(
+            @NonNull HttpServletRequest request,
+            @NonNull HttpServletResponse response,
+            @NonNull FilterChain filterChain)
+            throws ServletException, IOException {
+
+        String accessTokenHeaderValue = extractAccessTokenFromHeader(request);
+
+        if (accessTokenHeaderValue != null) {
+            AccessTokenDto accessTokenDto =
+                    jwtTokenProvider.retrieveAccessToken(accessTokenHeaderValue);
+            if (accessTokenDto != null) {
+                setAuthenticationToContext(accessTokenDto.memberId(), accessTokenDto.memberRole());
+                filterChain.doFilter(request, response);
+                return;
+            }
+        }
+
+        filterChain.doFilter(request, response);
+    }
+
+    private void setAuthenticationToContext(final Long memberId, final MemberRole memberRole) {
+        UserDetails userDetails = new PrincipalDetails(memberId, memberRole);
+        Authentication authentication =
+                new UsernamePasswordAuthenticationToken(userDetails, null, userDetails.getAuthorities());
+        SecurityContextHolder.getContext().setAuthentication(authentication);
+    }
+
+    private static String extractAccessTokenFromHeader(HttpServletRequest request) {
+        return Optional.ofNullable(request.getHeader(HttpHeaders.AUTHORIZATION))
+                .filter(header -> header.startsWith(TOKEN_PREFIX))
+                .map(header -> header.replace(TOKEN_PREFIX, ""))
+                .orElse(null);
+    }
+}

--- a/src/main/java/com/widyu/global/log/BusinessExceptionLogEntry.java
+++ b/src/main/java/com/widyu/global/log/BusinessExceptionLogEntry.java
@@ -11,6 +11,7 @@ public class BusinessExceptionLogEntry {
     private String exceptionType;
     private String message;
     private String requestUri;
+    private String stackTrace;
 
     public String toLogString() {
         return String.format("""
@@ -20,12 +21,15 @@ public class BusinessExceptionLogEntry {
               ExceptionType : %s
               Message       : %s
               Request URI   : %s
+            -------------------- Stack Trace -------------------
+            %s
             ----------------------------------------------------
             """,
                 timestamp,
                 exceptionType,
                 message,
-                requestUri
+                requestUri,
+                stackTrace
         );
     }
 }

--- a/src/main/java/com/widyu/global/properties/CoolsmsProperties.java
+++ b/src/main/java/com/widyu/global/properties/CoolsmsProperties.java
@@ -1,0 +1,15 @@
+package com.widyu.global.properties;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties(prefix = "coolsms")
+public record CoolsmsProperties(
+        String apiKey,
+        String apiSecret,
+        String apiUrl,
+        String fromPhoneNumber,
+        int verificationCodeLength,
+        int verificationCodeTtl,
+        String messageTemplate
+) {
+}

--- a/src/main/java/com/widyu/global/properties/JwtProperties.java
+++ b/src/main/java/com/widyu/global/properties/JwtProperties.java
@@ -1,0 +1,22 @@
+package com.widyu.global.properties;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties(prefix = "jwt")
+public record JwtProperties(
+        String accessTokenSecret,
+        Long accessTokenExpirationTime,
+        String refreshTokenSecret,
+        Long refreshTokenExpirationTime,
+        String temporaryTokenSecret,
+        Long temporaryTokenExpirationTime
+) {
+
+    public Long accessTokenExpirationMilliTime() {
+        return accessTokenExpirationTime * 1000;
+    }
+
+    public Long refreshTokenExpirationMilliTime() {
+        return refreshTokenExpirationTime * 1000;
+    }
+}

--- a/src/main/java/com/widyu/global/properties/RedisProperties.java
+++ b/src/main/java/com/widyu/global/properties/RedisProperties.java
@@ -1,0 +1,11 @@
+package com.widyu.global.properties;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties(prefix = "spring.data.redis")
+public record RedisProperties(
+        String host,
+        int port,
+        String password
+) {
+}

--- a/src/main/java/com/widyu/global/response/ApiResponseTemplate.java
+++ b/src/main/java/com/widyu/global/response/ApiResponseTemplate.java
@@ -16,10 +16,17 @@ public class ApiResponseTemplate<T> {
         return new DefaultBodyBuilder();
     }
 
+    public static BodyBuilder error() {
+        return new DefaultBodyBuilder();
+    }
+
     public interface BodyBuilder {
         BodyBuilder code(final String code);
+
         BodyBuilder message(final String message);
+
         <T> ApiResponseTemplate<T> body(final T data);
+
         <T> ApiResponseTemplate<T> build();
     }
 

--- a/src/main/java/com/widyu/global/security/JwtTokenProvider.java
+++ b/src/main/java/com/widyu/global/security/JwtTokenProvider.java
@@ -1,0 +1,130 @@
+package com.widyu.global.security;
+
+import static com.widyu.global.constant.SecurityConstant.TOKEN_ROLE_NAME;
+
+import com.widyu.auth.domain.RefreshToken;
+import com.widyu.auth.domain.TemporaryMember;
+import com.widyu.auth.dto.AccessTokenDto;
+import com.widyu.auth.dto.RefreshTokenDto;
+import com.widyu.auth.dto.TemporaryTokenDto;
+import com.widyu.auth.dto.response.TemporaryTokenResponse;
+import com.widyu.auth.dto.response.TokenPairResponse;
+import com.widyu.auth.repository.RefreshTokenRepository;
+import com.widyu.global.error.BusinessException;
+import com.widyu.global.error.ErrorCode;
+import com.widyu.global.util.JwtUtil;
+import com.widyu.member.domain.MemberRole;
+import io.jsonwebtoken.ExpiredJwtException;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class JwtTokenProvider {
+
+    private final JwtUtil jwtUtil;
+    private final RefreshTokenRepository refreshTokenRepository;
+
+    public TokenPairResponse generateTokenPair(final Long memberId, final MemberRole memberRole) {
+        String accessToken = createAccessToken(memberId, memberRole);
+        String refreshToken = createRefreshToken(memberId);
+
+        return TokenPairResponse.of(accessToken, refreshToken);
+    }
+
+    public TemporaryTokenResponse generateTemporaryToken(final TemporaryMember temporaryMember) {
+        String temporaryToken = createTemporaryToken(temporaryMember);
+        return TemporaryTokenResponse.from(temporaryToken);
+    }
+
+    private String createAccessToken(final Long memberId, final MemberRole memberRole) {
+        return jwtUtil.generateAccessToken(memberId, memberRole);
+    }
+
+    public AccessTokenDto createAccessTokenDto(final Long memberId, final MemberRole memberRole) {
+        return jwtUtil.generateAccessTokenDto(memberId, memberRole);
+    }
+
+    private String createRefreshToken(final Long memberId) {
+        String refreshTokenValue = jwtUtil.generateRefreshToken(memberId);
+        saveRefreshTokenToRedis(memberId, refreshTokenValue, jwtUtil.getRefreshTokenExpirationTime());
+        return refreshTokenValue;
+    }
+
+    private void saveRefreshTokenToRedis(final Long memberId, final String refreshTokenDto, final Long ttl) {
+        RefreshToken refreshToken =
+                RefreshToken.builder()
+                        .memberId(memberId)
+                        .token(refreshTokenDto)
+                        .ttl(ttl)
+                        .build();
+        refreshTokenRepository.save(refreshToken);
+    }
+
+    private String createTemporaryToken(final TemporaryMember temporaryMember) {
+        return jwtUtil.generateTemporaryToken(temporaryMember.getId());
+    }
+
+    public AccessTokenDto retrieveAccessToken(final String accessTokenValue) {
+        try {
+            return jwtUtil.parseAccessToken(accessTokenValue);
+        } catch (Exception e) {
+            log.info("Access Token 파싱 실패");
+            return null;
+        }
+    }
+
+    public RefreshTokenDto retrieveRefreshToken(final String refreshTokenValue) {
+        RefreshTokenDto refreshTokenDto = parseRefreshToken(refreshTokenValue);
+        if (refreshTokenDto == null) {
+            throw new BusinessException(ErrorCode.INVALID_REFRESH_TOKEN);
+        }
+
+        Optional<RefreshToken> refreshToken = getRefreshTokenFromRedis(refreshTokenDto.memberId());
+
+        if (refreshToken.isEmpty()) {
+            throw new BusinessException(ErrorCode.INVALID_REFRESH_TOKEN);
+        }
+
+        return refreshTokenDto;
+    }
+
+    public TemporaryTokenDto retrieveTemporaryToken(final String temporaryTokenValue) {
+        try {
+            return jwtUtil.parseTemporaryToken(temporaryTokenValue);
+        } catch (ExpiredJwtException e) {
+            throw new BusinessException(ErrorCode.TEMPORARY_TOKEN_EXPIRED);
+        } catch (Exception e) {
+            log.info("Temporary Token 파싱 실패");
+            return null;
+        }
+    }
+
+    private Optional<RefreshToken> getRefreshTokenFromRedis(final Long memberId) {
+        return refreshTokenRepository.findById(memberId);
+    }
+
+    private RefreshTokenDto parseRefreshToken(final String refreshTokenValue) {
+        try {
+            return jwtUtil.parseRefreshToken(refreshTokenValue);
+        } catch (Exception e) {
+            return null;
+        }
+    }
+
+    public AccessTokenDto reissueAccessTokenIfExpired(final String accessTokenValue) {
+        // AT가 만료된 경우 AT 재발급
+        try {
+            jwtUtil.parseAccessToken(accessTokenValue);
+            return null;
+        } catch (ExpiredJwtException e) {
+            Long memberId = Long.parseLong(e.getClaims().getSubject());
+            MemberRole memberRole =
+                    MemberRole.valueOf(e.getClaims().get(TOKEN_ROLE_NAME, String.class));
+            return createAccessTokenDto(memberId, memberRole);
+        }
+    }
+}

--- a/src/main/java/com/widyu/global/security/JwtTokenProvider.java
+++ b/src/main/java/com/widyu/global/security/JwtTokenProvider.java
@@ -15,7 +15,6 @@ import com.widyu.global.error.ErrorCode;
 import com.widyu.global.util.JwtUtil;
 import com.widyu.member.domain.MemberRole;
 import io.jsonwebtoken.ExpiredJwtException;
-import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -28,103 +27,105 @@ public class JwtTokenProvider {
     private final JwtUtil jwtUtil;
     private final RefreshTokenRepository refreshTokenRepository;
 
-    public TokenPairResponse generateTokenPair(final Long memberId, final MemberRole memberRole) {
-        String accessToken = createAccessToken(memberId, memberRole);
-        String refreshToken = createRefreshToken(memberId);
+    public TokenPairResponse generateTokenPair(Long memberId, MemberRole memberRole) {
+        String accessToken = generateAccessToken(memberId, memberRole);
+        String refreshToken = generateAndSaveRefreshToken(memberId);
 
         return TokenPairResponse.of(accessToken, refreshToken);
     }
 
-    public TemporaryTokenResponse generateTemporaryToken(final TemporaryMember temporaryMember) {
-        String temporaryToken = createTemporaryToken(temporaryMember);
+    public TemporaryTokenResponse generateTemporaryToken(TemporaryMember temporaryMember) {
+        String temporaryToken = generateTemporaryTokenValue(temporaryMember);
         return TemporaryTokenResponse.from(temporaryToken);
     }
 
-    private String createAccessToken(final Long memberId, final MemberRole memberRole) {
+    public String generateAccessToken(Long memberId, MemberRole memberRole) {
         return jwtUtil.generateAccessToken(memberId, memberRole);
     }
 
-    public AccessTokenDto createAccessTokenDto(final Long memberId, final MemberRole memberRole) {
+    public AccessTokenDto generateAccessTokenDto(Long memberId, MemberRole memberRole) {
         return jwtUtil.generateAccessTokenDto(memberId, memberRole);
     }
 
-    private String createRefreshToken(final Long memberId) {
-        String refreshTokenValue = jwtUtil.generateRefreshToken(memberId);
-        saveRefreshTokenToRedis(memberId, refreshTokenValue, jwtUtil.getRefreshTokenExpirationTime());
-        return refreshTokenValue;
-    }
-
-    private void saveRefreshTokenToRedis(final Long memberId, final String refreshTokenDto, final Long ttl) {
-        RefreshToken refreshToken =
-                RefreshToken.builder()
-                        .memberId(memberId)
-                        .token(refreshTokenDto)
-                        .ttl(ttl)
-                        .build();
-        refreshTokenRepository.save(refreshToken);
-    }
-
-    private String createTemporaryToken(final TemporaryMember temporaryMember) {
-        return jwtUtil.generateTemporaryToken(temporaryMember.getId());
-    }
-
-    public AccessTokenDto retrieveAccessToken(final String accessTokenValue) {
+    public AccessTokenDto retrieveAccessToken(String accessTokenValue) {
         try {
             return jwtUtil.parseAccessToken(accessTokenValue);
         } catch (Exception e) {
-            log.info("Access Token 파싱 실패");
+            log.debug("Access Token 파싱 실패: {}", e.getMessage());
             return null;
         }
     }
 
-    public RefreshTokenDto retrieveRefreshToken(final String refreshTokenValue) {
-        RefreshTokenDto refreshTokenDto = parseRefreshToken(refreshTokenValue);
-        if (refreshTokenDto == null) {
-            throw new BusinessException(ErrorCode.INVALID_REFRESH_TOKEN);
-        }
-
-        Optional<RefreshToken> refreshToken = getRefreshTokenFromRedis(refreshTokenDto.memberId());
-
-        if (refreshToken.isEmpty()) {
-            throw new BusinessException(ErrorCode.INVALID_REFRESH_TOKEN);
-        }
-
+    public RefreshTokenDto retrieveRefreshToken(String refreshTokenValue) {
+        RefreshTokenDto refreshTokenDto = parseRefreshTokenSafely(refreshTokenValue);
+        validateRefreshTokenExists(refreshTokenDto.memberId());
         return refreshTokenDto;
     }
 
-    public TemporaryTokenDto retrieveTemporaryToken(final String temporaryTokenValue) {
+    public TemporaryTokenDto retrieveTemporaryToken(String temporaryTokenValue) {
         try {
             return jwtUtil.parseTemporaryToken(temporaryTokenValue);
         } catch (ExpiredJwtException e) {
             throw new BusinessException(ErrorCode.TEMPORARY_TOKEN_EXPIRED);
         } catch (Exception e) {
-            log.info("Temporary Token 파싱 실패");
+            log.debug("Temporary Token 파싱 실패: {}", e.getMessage());
             return null;
         }
     }
 
-    private Optional<RefreshToken> getRefreshTokenFromRedis(final Long memberId) {
-        return refreshTokenRepository.findById(memberId);
-    }
-
-    private RefreshTokenDto parseRefreshToken(final String refreshTokenValue) {
-        try {
-            return jwtUtil.parseRefreshToken(refreshTokenValue);
-        } catch (Exception e) {
-            return null;
-        }
-    }
-
-    public AccessTokenDto reissueAccessTokenIfExpired(final String accessTokenValue) {
-        // AT가 만료된 경우 AT 재발급
+    public AccessTokenDto reissueAccessTokenIfExpired(String accessTokenValue) {
         try {
             jwtUtil.parseAccessToken(accessTokenValue);
-            return null;
+            return null; // 토큰이 유효하면 재발급 불필요
         } catch (ExpiredJwtException e) {
-            Long memberId = Long.parseLong(e.getClaims().getSubject());
-            MemberRole memberRole =
-                    MemberRole.valueOf(e.getClaims().get(TOKEN_ROLE_NAME, String.class));
-            return createAccessTokenDto(memberId, memberRole);
+            return reissueAccessTokenFromExpired(e);
         }
+    }
+
+    private String generateAndSaveRefreshToken(Long memberId) {
+        String refreshTokenValue = jwtUtil.generateRefreshToken(memberId);
+        saveRefreshTokenToStorage(memberId, refreshTokenValue);
+        return refreshTokenValue;
+    }
+
+    private void saveRefreshTokenToStorage(Long memberId, String refreshTokenValue) {
+        RefreshToken refreshToken = RefreshToken.builder()
+                .memberId(memberId)
+                .token(refreshTokenValue)
+                .ttl(jwtUtil.getRefreshTokenExpirationTime())
+                .build();
+
+        refreshTokenRepository.save(refreshToken);
+    }
+
+    private String generateTemporaryTokenValue(TemporaryMember temporaryMember) {
+        return jwtUtil.generateTemporaryToken(temporaryMember.getId());
+    }
+
+    private RefreshTokenDto parseRefreshTokenSafely(String refreshTokenValue) {
+        try {
+            RefreshTokenDto refreshTokenDto = jwtUtil.parseRefreshToken(refreshTokenValue);
+            if (refreshTokenDto == null) {
+                throw new BusinessException(ErrorCode.INVALID_REFRESH_TOKEN);
+            }
+            return refreshTokenDto;
+        } catch (Exception e) {
+            throw new BusinessException(ErrorCode.INVALID_REFRESH_TOKEN);
+        }
+    }
+
+    private void validateRefreshTokenExists(Long memberId) {
+        if (refreshTokenRepository.findById(memberId).isEmpty()) {
+            throw new BusinessException(ErrorCode.INVALID_REFRESH_TOKEN);
+        }
+    }
+
+    private AccessTokenDto reissueAccessTokenFromExpired(ExpiredJwtException expiredException) {
+        Long memberId = Long.parseLong(expiredException.getClaims().getSubject());
+        MemberRole memberRole = MemberRole.valueOf(
+                expiredException.getClaims().get(TOKEN_ROLE_NAME, String.class)
+        );
+
+        return generateAccessTokenDto(memberId, memberRole);
     }
 }

--- a/src/main/java/com/widyu/global/security/PrincipalDetails.java
+++ b/src/main/java/com/widyu/global/security/PrincipalDetails.java
@@ -1,0 +1,51 @@
+package com.widyu.global.security;
+
+import com.widyu.member.domain.MemberRole;
+import java.util.Collection;
+import java.util.Collections;
+import lombok.AllArgsConstructor;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+
+@AllArgsConstructor
+public class PrincipalDetails implements UserDetails {
+
+    private final Long memberId;
+    private final MemberRole role;
+
+    @Override
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+        return Collections.singleton(new SimpleGrantedAuthority(role.getValue()));
+    }
+
+    @Override
+    public String getPassword() {
+        return null;
+    }
+
+    @Override
+    public String getUsername() {
+        return memberId.toString();
+    }
+
+    @Override
+    public boolean isAccountNonExpired() {
+        return true;
+    }
+
+    @Override
+    public boolean isAccountNonLocked() {
+        return true;
+    }
+
+    @Override
+    public boolean isCredentialsNonExpired() {
+        return true;
+    }
+
+    @Override
+    public boolean isEnabled() {
+        return true;
+    }
+}

--- a/src/main/java/com/widyu/global/util/JwtUtil.java
+++ b/src/main/java/com/widyu/global/util/JwtUtil.java
@@ -28,60 +28,62 @@ import org.springframework.stereotype.Component;
 public class JwtUtil {
 
     private final JwtProperties jwtProperties;
+
     private static final String TOKEN_TYPE_KEY_NAME = "type";
+    private static final String HEADER_TYP = "typ";
+    private static final String HEADER_ALG = "alg";
+    private static final String HEADER_REG_DATE = "regDate";
+    private static final String JWT_TYPE = "JWT";
+    private static final String HS256_ALG = "HS256";
 
-    public String generateAccessToken(final Long memberId, final MemberRole memberRole) {
-        Date issuedAt = new Date();
-        Date expiredAt =
-                new Date(issuedAt.getTime() + jwtProperties.accessTokenExpirationMilliTime());
-
-        return buildAccessToken(memberId, memberRole, issuedAt, expiredAt);
+    public String generateAccessToken(Long memberId, MemberRole memberRole) {
+        TokenTimeInfo timeInfo = createTokenTimeInfo(jwtProperties.accessTokenExpirationMilliTime());
+        return buildJwtToken(
+                TokenType.ACCESS,
+                memberId.toString(),
+                Map.of(TOKEN_ROLE_NAME, memberRole.name()),
+                timeInfo,
+                getAccessTokenKey()
+        );
     }
 
-    public AccessTokenDto generateAccessTokenDto(final Long memberId, final MemberRole memberRole) {
-        Date issuedAt = new Date();
-        Date expiredAt =
-                new Date(issuedAt.getTime() + jwtProperties.accessTokenExpirationMilliTime());
-        String tokenValue = buildAccessToken(memberId, memberRole, issuedAt, expiredAt);
-
+    public AccessTokenDto generateAccessTokenDto(Long memberId, MemberRole memberRole) {
+        String tokenValue = generateAccessToken(memberId, memberRole);
         return AccessTokenDto.of(memberId, memberRole, tokenValue);
     }
 
-    public String generateRefreshToken(final Long memberId) {
-        Date issuedAt = new Date();
-        Date expiredAt = new Date(issuedAt.getTime() + jwtProperties.refreshTokenExpirationMilliTime());
-        return buildRefreshToken(memberId, issuedAt, expiredAt);
+    public String generateRefreshToken(Long memberId) {
+        TokenTimeInfo timeInfo = createTokenTimeInfo(jwtProperties.refreshTokenExpirationMilliTime());
+        return buildJwtToken(
+                TokenType.REFRESH,
+                memberId.toString(),
+                Map.of(),
+                timeInfo,
+                getRefreshTokenKey()
+        );
     }
 
-    public String generateTemporaryToken(final String temporaryMemberId) {
-        Date issuedAt = new Date();
-        Date expiredAt = new Date(issuedAt.getTime() + jwtProperties.temporaryTokenExpirationTime());
-
-        return Jwts.builder()
-                .setHeader(createTokenHeader(TokenType.TEMPORARY))
-                .setSubject(temporaryMemberId)
-                .claim(TOKEN_ROLE_NAME, MemberRole.TEMPORARY)
-                .setIssuedAt(issuedAt)
-                .setExpiration(expiredAt)
-                .signWith(getTemporaryTokenKey())
-                .compact();
+    public String generateTemporaryToken(String temporaryMemberId) {
+        TokenTimeInfo timeInfo = createTokenTimeInfo(jwtProperties.temporaryTokenExpirationTime());
+        return buildJwtToken(
+                TokenType.TEMPORARY,
+                temporaryMemberId,
+                Map.of(TOKEN_ROLE_NAME, MemberRole.TEMPORARY),
+                timeInfo,
+                getTemporaryTokenKey()
+        );
     }
 
-    public static String extractTemporaryTokenFromHeader(HttpServletRequest request) {
-        return Optional.ofNullable(request.getHeader(HttpHeaders.AUTHORIZATION))
-                .filter(header -> header.startsWith(TOKEN_PREFIX))
-                .map(header -> header.replace(TOKEN_PREFIX, ""))
-                .orElse(null);
-    }
-
-    public AccessTokenDto parseAccessToken(final String token) throws ExpiredJwtException {
+    public AccessTokenDto parseAccessToken(String token) throws ExpiredJwtException {
         try {
-            Jws<Claims> claims = getClaims(token, getAccessTokenKey());
+            Jws<Claims> claims = parseTokenClaims(token, getAccessTokenKey());
+            Claims body = claims.getBody();
 
             return new AccessTokenDto(
-                    Long.parseLong(claims.getBody().getSubject()),
-                    MemberRole.valueOf(claims.getBody().get("role", String.class)),
-                    token);
+                    Long.parseLong(body.getSubject()),
+                    MemberRole.valueOf(body.get(TOKEN_ROLE_NAME, String.class)),
+                    token
+            );
         } catch (ExpiredJwtException e) {
             throw e;
         } catch (Exception e) {
@@ -89,13 +91,14 @@ public class JwtUtil {
         }
     }
 
-    public RefreshTokenDto parseRefreshToken(final String token) throws ExpiredJwtException {
+    public RefreshTokenDto parseRefreshToken(String token) throws ExpiredJwtException {
         try {
-            Jws<Claims> claims = getClaims(token, getRefreshTokenKey());
+            Jws<Claims> claims = parseTokenClaims(token, getRefreshTokenKey());
+            Claims body = claims.getBody();
 
             return new RefreshTokenDto(
-                    Long.parseLong(claims.getBody().getSubject()),
-                    MemberRole.valueOf(claims.getBody().get("role", String.class)),
+                    Long.parseLong(body.getSubject()),
+                    MemberRole.valueOf(body.get(TOKEN_ROLE_NAME, String.class)),
                     token,
                     jwtProperties.refreshTokenExpirationTime()
             );
@@ -106,13 +109,14 @@ public class JwtUtil {
         }
     }
 
-    public TemporaryTokenDto parseTemporaryToken(final String token) throws ExpiredJwtException {
+    public TemporaryTokenDto parseTemporaryToken(String token) throws ExpiredJwtException {
         try {
-            Jws<Claims> claims = getClaims(token, getTemporaryTokenKey());
+            Jws<Claims> claims = parseTokenClaims(token, getTemporaryTokenKey());
+            Claims body = claims.getBody();
 
             return new TemporaryTokenDto(
-                    claims.getBody().getSubject(),
-                    MemberRole.valueOf(claims.getBody().get("role", String.class)),
+                    body.getSubject(),
+                    MemberRole.valueOf(body.get(TOKEN_ROLE_NAME, String.class)),
                     token,
                     jwtProperties.temporaryTokenExpirationTime()
             );
@@ -123,62 +127,68 @@ public class JwtUtil {
         }
     }
 
+    public static String extractTemporaryTokenFromHeader(HttpServletRequest request) {
+        return extractTokenFromAuthorizationHeader(request);
+    }
+
+    public static String extractTokenFromAuthorizationHeader(HttpServletRequest request) {
+        return Optional.ofNullable(request.getHeader(HttpHeaders.AUTHORIZATION))
+                .filter(header -> header.startsWith(TOKEN_PREFIX))
+                .map(header -> header.replace(TOKEN_PREFIX, ""))
+                .orElse(null);
+    }
+
     public long getRefreshTokenExpirationTime() {
         return jwtProperties.refreshTokenExpirationTime();
     }
 
-    private Key getRefreshTokenKey() {
-        return Keys.hmacShaKeyFor(jwtProperties.refreshTokenSecret().getBytes());
+    private String buildJwtToken(TokenType tokenType, String subject,
+                                 Map<String, Object> claims, TokenTimeInfo timeInfo, Key signingKey) {
+        var builder = Jwts.builder()
+                .setHeader(createTokenHeader(tokenType))
+                .setSubject(subject)
+                .setIssuedAt(timeInfo.issuedAt())
+                .setExpiration(timeInfo.expiredAt())
+                .signWith(signingKey);
+
+        claims.forEach(builder::claim);
+
+        return builder.compact();
     }
 
-    private Key getAccessTokenKey() {
-        return Keys.hmacShaKeyFor(jwtProperties.accessTokenSecret().getBytes());
+    private TokenTimeInfo createTokenTimeInfo(long expirationMillis) {
+        Date issuedAt = new Date();
+        Date expiredAt = new Date(issuedAt.getTime() + expirationMillis);
+        return new TokenTimeInfo(issuedAt, expiredAt);
     }
 
-    private Key getTemporaryTokenKey() {
-        return Keys.hmacShaKeyFor(jwtProperties.temporaryTokenSecret().getBytes());
+    private Map<String, Object> createTokenHeader(TokenType tokenType) {
+        return Map.of(
+                HEADER_TYP, JWT_TYPE,
+                HEADER_ALG, HS256_ALG,
+                HEADER_REG_DATE, System.currentTimeMillis(),
+                TOKEN_TYPE_KEY_NAME, tokenType.getValue()
+        );
     }
 
-    private Jws<Claims> getClaims(final String token, final Key key) {
+    private Jws<Claims> parseTokenClaims(String token, Key key) {
         return Jwts.parserBuilder()
                 .setSigningKey(key)
                 .build()
                 .parseClaimsJws(token);
     }
 
-    private String buildAccessToken(final Long memberId, final MemberRole memberRole, final Date issuedAt,
-                                    final Date expiredAt) {
-        return Jwts.builder()
-                .setHeader(
-                        createTokenHeader(TokenType.ACCESS))
-                .setSubject(memberId.toString())
-                .claim(TOKEN_ROLE_NAME, memberRole.name())
-                .setIssuedAt(issuedAt)
-                .setExpiration(expiredAt)
-                .signWith(getAccessTokenKey())
-                .compact();
+    private Key getAccessTokenKey() {
+        return Keys.hmacShaKeyFor(jwtProperties.accessTokenSecret().getBytes());
     }
 
-    private String buildRefreshToken(final Long memberId, final Date issuedAt, final Date expiredAt) {
-        return Jwts.builder()
-                .setHeader(createTokenHeader(TokenType.REFRESH))
-                .setSubject(memberId.toString())
-                .setIssuedAt(issuedAt)
-                .setExpiration(expiredAt)
-                .signWith(getRefreshTokenKey())
-                .compact();
+    private Key getRefreshTokenKey() {
+        return Keys.hmacShaKeyFor(jwtProperties.refreshTokenSecret().getBytes());
     }
 
-    private Map<String, Object> createTokenHeader(final TokenType tokenType) {
-        return Map.of(
-                "typ",
-                "JWT",
-                "alg",
-                "HS256",
-                "regDate",
-                System.currentTimeMillis(),
-                TOKEN_TYPE_KEY_NAME,
-                tokenType.getValue()
-        );
+    private Key getTemporaryTokenKey() {
+        return Keys.hmacShaKeyFor(jwtProperties.temporaryTokenSecret().getBytes());
     }
+
+    private record TokenTimeInfo(Date issuedAt, Date expiredAt) {}
 }

--- a/src/main/java/com/widyu/global/util/JwtUtil.java
+++ b/src/main/java/com/widyu/global/util/JwtUtil.java
@@ -1,0 +1,184 @@
+package com.widyu.global.util;
+
+import static com.widyu.global.constant.SecurityConstant.TOKEN_PREFIX;
+import static com.widyu.global.constant.SecurityConstant.TOKEN_ROLE_NAME;
+
+import com.widyu.auth.domain.TokenType;
+import com.widyu.auth.dto.AccessTokenDto;
+import com.widyu.auth.dto.RefreshTokenDto;
+import com.widyu.auth.dto.TemporaryTokenDto;
+import com.widyu.global.properties.JwtProperties;
+import com.widyu.member.domain.MemberRole;
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.ExpiredJwtException;
+import io.jsonwebtoken.Jws;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.security.Keys;
+import jakarta.servlet.http.HttpServletRequest;
+import java.security.Key;
+import java.util.Date;
+import java.util.Map;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpHeaders;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class JwtUtil {
+
+    private final JwtProperties jwtProperties;
+    private static final String TOKEN_TYPE_KEY_NAME = "type";
+
+    public String generateAccessToken(final Long memberId, final MemberRole memberRole) {
+        Date issuedAt = new Date();
+        Date expiredAt =
+                new Date(issuedAt.getTime() + jwtProperties.accessTokenExpirationMilliTime());
+
+        return buildAccessToken(memberId, memberRole, issuedAt, expiredAt);
+    }
+
+    public AccessTokenDto generateAccessTokenDto(final Long memberId, final MemberRole memberRole) {
+        Date issuedAt = new Date();
+        Date expiredAt =
+                new Date(issuedAt.getTime() + jwtProperties.accessTokenExpirationMilliTime());
+        String tokenValue = buildAccessToken(memberId, memberRole, issuedAt, expiredAt);
+
+        return AccessTokenDto.of(memberId, memberRole, tokenValue);
+    }
+
+    public String generateRefreshToken(final Long memberId) {
+        Date issuedAt = new Date();
+        Date expiredAt = new Date(issuedAt.getTime() + jwtProperties.refreshTokenExpirationMilliTime());
+        return buildRefreshToken(memberId, issuedAt, expiredAt);
+    }
+
+    public String generateTemporaryToken(final String temporaryMemberId) {
+        Date issuedAt = new Date();
+        Date expiredAt = new Date(issuedAt.getTime() + jwtProperties.temporaryTokenExpirationTime());
+
+        return Jwts.builder()
+                .setHeader(createTokenHeader(TokenType.TEMPORARY))
+                .setSubject(temporaryMemberId)
+                .claim(TOKEN_ROLE_NAME, MemberRole.TEMPORARY)
+                .setIssuedAt(issuedAt)
+                .setExpiration(expiredAt)
+                .signWith(getTemporaryTokenKey())
+                .compact();
+    }
+
+    public static String extractTemporaryTokenFromHeader(HttpServletRequest request) {
+        return Optional.ofNullable(request.getHeader(HttpHeaders.AUTHORIZATION))
+                .filter(header -> header.startsWith(TOKEN_PREFIX))
+                .map(header -> header.replace(TOKEN_PREFIX, ""))
+                .orElse(null);
+    }
+
+    public AccessTokenDto parseAccessToken(final String token) throws ExpiredJwtException {
+        try {
+            Jws<Claims> claims = getClaims(token, getAccessTokenKey());
+
+            return new AccessTokenDto(
+                    Long.parseLong(claims.getBody().getSubject()),
+                    MemberRole.valueOf(claims.getBody().get("role", String.class)),
+                    token);
+        } catch (ExpiredJwtException e) {
+            throw e;
+        } catch (Exception e) {
+            return null;
+        }
+    }
+
+    public RefreshTokenDto parseRefreshToken(final String token) throws ExpiredJwtException {
+        try {
+            Jws<Claims> claims = getClaims(token, getRefreshTokenKey());
+
+            return new RefreshTokenDto(
+                    Long.parseLong(claims.getBody().getSubject()),
+                    MemberRole.valueOf(claims.getBody().get("role", String.class)),
+                    token,
+                    jwtProperties.refreshTokenExpirationTime()
+            );
+        } catch (ExpiredJwtException e) {
+            throw e;
+        } catch (Exception e) {
+            return null;
+        }
+    }
+
+    public TemporaryTokenDto parseTemporaryToken(final String token) throws ExpiredJwtException {
+        try {
+            Jws<Claims> claims = getClaims(token, getTemporaryTokenKey());
+
+            return new TemporaryTokenDto(
+                    claims.getBody().getSubject(),
+                    MemberRole.valueOf(claims.getBody().get("role", String.class)),
+                    token,
+                    jwtProperties.temporaryTokenExpirationTime()
+            );
+        } catch (ExpiredJwtException e) {
+            throw e;
+        } catch (Exception e) {
+            return null;
+        }
+    }
+
+    public long getRefreshTokenExpirationTime() {
+        return jwtProperties.refreshTokenExpirationTime();
+    }
+
+    private Key getRefreshTokenKey() {
+        return Keys.hmacShaKeyFor(jwtProperties.refreshTokenSecret().getBytes());
+    }
+
+    private Key getAccessTokenKey() {
+        return Keys.hmacShaKeyFor(jwtProperties.accessTokenSecret().getBytes());
+    }
+
+    private Key getTemporaryTokenKey() {
+        return Keys.hmacShaKeyFor(jwtProperties.temporaryTokenSecret().getBytes());
+    }
+
+    private Jws<Claims> getClaims(final String token, final Key key) {
+        return Jwts.parserBuilder()
+                .setSigningKey(key)
+                .build()
+                .parseClaimsJws(token);
+    }
+
+    private String buildAccessToken(final Long memberId, final MemberRole memberRole, final Date issuedAt,
+                                    final Date expiredAt) {
+        return Jwts.builder()
+                .setHeader(
+                        createTokenHeader(TokenType.ACCESS))
+                .setSubject(memberId.toString())
+                .claim(TOKEN_ROLE_NAME, memberRole.name())
+                .setIssuedAt(issuedAt)
+                .setExpiration(expiredAt)
+                .signWith(getAccessTokenKey())
+                .compact();
+    }
+
+    private String buildRefreshToken(final Long memberId, final Date issuedAt, final Date expiredAt) {
+        return Jwts.builder()
+                .setHeader(createTokenHeader(TokenType.REFRESH))
+                .setSubject(memberId.toString())
+                .setIssuedAt(issuedAt)
+                .setExpiration(expiredAt)
+                .signWith(getRefreshTokenKey())
+                .compact();
+    }
+
+    private Map<String, Object> createTokenHeader(final TokenType tokenType) {
+        return Map.of(
+                "typ",
+                "JWT",
+                "alg",
+                "HS256",
+                "regDate",
+                System.currentTimeMillis(),
+                TOKEN_TYPE_KEY_NAME,
+                tokenType.getValue()
+        );
+    }
+}

--- a/src/main/java/com/widyu/member/domain/AuthProvider.java
+++ b/src/main/java/com/widyu/member/domain/AuthProvider.java
@@ -1,0 +1,15 @@
+package com.widyu.member.domain;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum AuthProvider {
+    LOCAL("local"),
+    KAKAO("kakao"),
+    NAVER("naver"),
+    APPLE("apple");
+
+    private final String value;
+}

--- a/src/main/java/com/widyu/member/domain/LocalAccount.java
+++ b/src/main/java/com/widyu/member/domain/LocalAccount.java
@@ -10,6 +10,8 @@ import jakarta.persistence.JoinColumn;
 import jakarta.persistence.OneToOne;
 import jakarta.persistence.Table;
 import jakarta.persistence.UniqueConstraint;
+import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -17,9 +19,9 @@ import lombok.NoArgsConstructor;
 @Getter
 @NoArgsConstructor
 @Table(uniqueConstraints = {
-                @UniqueConstraint(name="uk_local_member", columnNames="member_id"),
-                @UniqueConstraint(name="uk_local_email", columnNames="email")
-        }
+        @UniqueConstraint(name = "uk_local_member", columnNames = "member_id"),
+        @UniqueConstraint(name = "uk_local_email", columnNames = "email")
+}
 )
 public class LocalAccount {
 
@@ -37,4 +39,20 @@ public class LocalAccount {
 
     @Column(name = "is_first")
     private boolean isFirst;
+
+    @Builder(access = AccessLevel.PRIVATE)
+    private LocalAccount(final Member member, final String email, final String passwordHash) {
+        this.member = member;
+        this.email = email;
+        this.passwordHash = passwordHash;
+        this.isFirst = true;
+    }
+
+    public static LocalAccount createLocalAccount(final Member member, final String email, final String passwordHash) {
+        return LocalAccount.builder()
+                .member(member)
+                .email(email)
+                .passwordHash(passwordHash)
+                .build();
+    }
 }

--- a/src/main/java/com/widyu/member/domain/LocalAccount.java
+++ b/src/main/java/com/widyu/member/domain/LocalAccount.java
@@ -1,0 +1,40 @@
+package com.widyu.member.domain;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.OneToOne;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor
+@Table(uniqueConstraints = {
+                @UniqueConstraint(name="uk_local_member", columnNames="member_id"),
+                @UniqueConstraint(name="uk_local_email", columnNames="email")
+        }
+)
+public class LocalAccount {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id", nullable = false)
+    private Member member;
+
+    private String email;
+
+    private String passwordHash;
+
+    @Column(name = "is_first")
+    private boolean isFirst;
+}

--- a/src/main/java/com/widyu/member/domain/Member.java
+++ b/src/main/java/com/widyu/member/domain/Member.java
@@ -50,8 +50,7 @@ public class Member extends BaseTimeEntity {
     private Status status;
 
     @Builder(access = AccessLevel.PRIVATE)
-
-    public Member(MemberRole role, MemberType type, String name, String phone, LocalAccount localAccount,
+    private Member(MemberRole role, MemberType type, String name, String phone, LocalAccount localAccount,
                   List<SocialAccount> socialAccounts, Status status) {
         this.role = role;
         this.type = type;

--- a/src/main/java/com/widyu/member/domain/Member.java
+++ b/src/main/java/com/widyu/member/domain/Member.java
@@ -10,7 +10,6 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.OneToMany;
-import jakarta.persistence.OneToOne;
 import java.util.ArrayList;
 import java.util.List;
 import lombok.AccessLevel;
@@ -18,7 +17,6 @@ import lombok.Builder;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-
 
 @Entity
 @Getter
@@ -38,10 +36,7 @@ public class Member extends BaseTimeEntity {
 
     private String name;
 
-    private String phone;
-
-    @OneToOne(mappedBy = "member", cascade = CascadeType.ALL, orphanRemoval = true)
-    private LocalAccount localAccount;
+    private String phoneNumber;
 
     @OneToMany(mappedBy = "member", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<SocialAccount> socialAccounts = new ArrayList<>();
@@ -50,26 +45,22 @@ public class Member extends BaseTimeEntity {
     private Status status;
 
     @Builder(access = AccessLevel.PRIVATE)
-    private Member(MemberRole role, MemberType type, String name, String phone, LocalAccount localAccount,
-                  List<SocialAccount> socialAccounts, Status status) {
+    private Member(final MemberRole role, final MemberType type, final String name, final String phoneNumber,
+                   final List<SocialAccount> socialAccounts, final Status status) {
         this.role = role;
         this.type = type;
         this.name = name;
-        this.phone = phone;
-        this.localAccount = localAccount;
+        this.phoneNumber = phoneNumber;
         this.socialAccounts = socialAccounts;
         this.status = status;
     }
 
-    public static Member createMember(MemberRole role, MemberType type, String name, String phone,
-                                      LocalAccount localAccount, List<SocialAccount> socialAccounts) {
+    public static Member createMember(final MemberType type, final String name, final String phoneNumber) {
         return Member.builder()
-                .role(role)
+                .role(MemberRole.USER)
                 .type(type)
                 .name(name)
-                .phone(phone)
-                .localAccount(localAccount)
-                .socialAccounts(socialAccounts)
+                .phoneNumber(phoneNumber)
                 .status(Status.ACTIVE)
                 .build();
     }

--- a/src/main/java/com/widyu/member/domain/Member.java
+++ b/src/main/java/com/widyu/member/domain/Member.java
@@ -1,0 +1,77 @@
+package com.widyu.member.domain;
+
+import com.widyu.global.domain.BaseTimeEntity;
+import com.widyu.global.domain.Status;
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.OneToMany;
+import jakarta.persistence.OneToOne;
+import java.util.ArrayList;
+import java.util.List;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+
+@Entity
+@Getter
+@EqualsAndHashCode(callSuper = false, of = "id")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Member extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Enumerated(EnumType.STRING)
+    private MemberRole role;
+
+    @Enumerated(EnumType.STRING)
+    private MemberType type;
+
+    private String name;
+
+    private String phone;
+
+    @OneToOne(mappedBy = "member", cascade = CascadeType.ALL, orphanRemoval = true)
+    private LocalAccount localAccount;
+
+    @OneToMany(mappedBy = "member", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<SocialAccount> socialAccounts = new ArrayList<>();
+
+    @Enumerated(EnumType.STRING)
+    private Status status;
+
+    @Builder(access = AccessLevel.PRIVATE)
+
+    public Member(MemberRole role, MemberType type, String name, String phone, LocalAccount localAccount,
+                  List<SocialAccount> socialAccounts, Status status) {
+        this.role = role;
+        this.type = type;
+        this.name = name;
+        this.phone = phone;
+        this.localAccount = localAccount;
+        this.socialAccounts = socialAccounts;
+        this.status = status;
+    }
+
+    public static Member createMember(MemberRole role, MemberType type, String name, String phone,
+                                      LocalAccount localAccount, List<SocialAccount> socialAccounts) {
+        return Member.builder()
+                .role(role)
+                .type(type)
+                .name(name)
+                .phone(phone)
+                .localAccount(localAccount)
+                .socialAccounts(socialAccounts)
+                .status(Status.ACTIVE)
+                .build();
+    }
+}

--- a/src/main/java/com/widyu/member/domain/MemberRole.java
+++ b/src/main/java/com/widyu/member/domain/MemberRole.java
@@ -8,7 +8,7 @@ import lombok.Getter;
 public enum MemberRole {
     ADMIN("ROLE_ADMIN"),
     USER("ROLE_USER"),
-    TEMPORARY("ROLE_TEMPORARY")
+    TEMPORARY("ROLE_TEMPORARY"),
     ;
 
     private final String value;

--- a/src/main/java/com/widyu/member/domain/MemberRole.java
+++ b/src/main/java/com/widyu/member/domain/MemberRole.java
@@ -1,0 +1,15 @@
+package com.widyu.member.domain;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum MemberRole {
+    ADMIN("ROLE_ADMIN"),
+    USER("ROLE_USER"),
+    TEMPORARY("ROLE_TEMPORARY")
+    ;
+
+    private final String value;
+}

--- a/src/main/java/com/widyu/member/domain/MemberType.java
+++ b/src/main/java/com/widyu/member/domain/MemberType.java
@@ -1,0 +1,11 @@
+package com.widyu.member.domain;
+
+import lombok.Getter;
+
+@Getter
+public enum MemberType {
+    PARENT,
+    GUARDIAN,
+    ;
+}
+

--- a/src/main/java/com/widyu/member/domain/SocialAccount.java
+++ b/src/main/java/com/widyu/member/domain/SocialAccount.java
@@ -1,0 +1,44 @@
+package com.widyu.member.domain;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(
+        uniqueConstraints = @UniqueConstraint(name="uk_provider_user", columnNames={"provider","providerUserId"})
+)
+public class SocialAccount {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private String email;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id", nullable = false)
+    private Member member;
+
+    @Enumerated(EnumType.STRING)
+    private AuthProvider provider;
+
+    private String providerUserId;
+
+    @Column(name = "is_first")
+    private boolean isFirst;
+}
+

--- a/src/main/java/com/widyu/member/domain/SocialAccount.java
+++ b/src/main/java/com/widyu/member/domain/SocialAccount.java
@@ -20,7 +20,7 @@ import lombok.NoArgsConstructor;
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Table(
-        uniqueConstraints = @UniqueConstraint(name="uk_provider_user", columnNames={"provider","providerUserId"})
+        uniqueConstraints = @UniqueConstraint(name = "uk_provider_user", columnNames = {"provider", "providerUserId"})
 )
 public class SocialAccount {
     @Id

--- a/src/main/java/com/widyu/member/domain/SocialRefreshToken.java
+++ b/src/main/java/com/widyu/member/domain/SocialRefreshToken.java
@@ -1,0 +1,41 @@
+package com.widyu.member.domain;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.OneToOne;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class SocialRefreshToken {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private String token;
+
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "social_account_id", nullable = false)
+    private SocialAccount socialAccount;
+
+    @Builder(access = AccessLevel.PRIVATE)
+    private SocialRefreshToken(String token, SocialAccount socialAccount) {
+        this.token = token;
+        this.socialAccount = socialAccount;
+    }
+
+    public static SocialRefreshToken createSocialRefreshToken(String token, SocialAccount socialAccount) {
+        return SocialRefreshToken.builder()
+                .token(token)
+                .socialAccount(socialAccount)
+                .build();
+    }
+}

--- a/src/main/java/com/widyu/member/repository/LocalAccountRepository.java
+++ b/src/main/java/com/widyu/member/repository/LocalAccountRepository.java
@@ -1,0 +1,10 @@
+package com.widyu.member.repository;
+
+import com.widyu.member.domain.LocalAccount;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface LocalAccountRepository extends JpaRepository<LocalAccount, Long> {
+    boolean existsByEmail(String email);
+}

--- a/src/main/java/com/widyu/member/repository/MemberRepository.java
+++ b/src/main/java/com/widyu/member/repository/MemberRepository.java
@@ -1,0 +1,9 @@
+package com.widyu.member.repository;
+
+import com.widyu.member.domain.Member;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface MemberRepository extends JpaRepository<Member, Long> {
+}

--- a/src/main/resources/application-coolsms.yml
+++ b/src/main/resources/application-coolsms.yml
@@ -1,0 +1,8 @@
+coolsms:
+  api-key: ${COOLSMS_API_KEY}
+  api-secret: ${COOLSMS_API_SECRET}
+  api-url: "https://api.solapi.com"
+  from-phone-number: ${COOLSMS_PHONE}
+  verification-code-length: 6
+  verification-code-ttl: 300
+  message-template: "[인증번호 : {code}] 위듀 계정 가입을 위한 인증번호입니다."

--- a/src/main/resources/application-redis.yml
+++ b/src/main/resources/application-redis.yml
@@ -1,0 +1,9 @@
+spring:
+  config:
+    activate:
+      on-profile: "redis"
+  data:
+    redis:
+      host: ${REDIS_HOST:localhost}
+      port: ${REDIS_PORT:6379}
+      password: ${REDIS_PASSWORD:}

--- a/src/main/resources/application-security.yml
+++ b/src/main/resources/application-security.yml
@@ -1,0 +1,8 @@
+jwt:
+  access-token-secret: ${JWT_ACCESS_TOKEN_SECRET}
+  access-token-expiration-time: ${JWT_ACCESS_TOKEN_EXPIRATION_TIME}
+  refresh-token-secret: ${JWT_REFRESH_TOKEN_SECRET}
+  refresh-token-expiration-time: ${JWT_REFRESH_TOKEN_EXPIRATION_TIME}
+  temporary-token-secret: ${JWT_TEMPORARY_TOKEN_SECRET}
+  temporary-token-expiration-time: ${JWT_TEMPORARY_TOKEN_EXPIRATION_TIME}
+

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -6,6 +6,11 @@ spring:
       local: "local, datasource, fcm"
       dev: "dev, datasource, fcm"
 
+    include:
+      - security
+      - coolsms
+      - redis
+
 swagger:
   version: ${SWAGGER_VERSION:0.0.1}
   url: ${SWAGGER_URL:http://localhost:8080}


### PR DESCRIPTION
## #️⃣연관된 이슈


- close: #12

## 🪄작업 내용
회원가입은 ① SMS 발송 → ② SMS 인증 및 임시토큰 발급 → ③ 실제 회원가입의 3단계로 진행되며, 각 단계에서 VerificationCode → TemporaryMember → Member/LocalAccount 순으로 데이터가 이동합니다.
AuthService가 전체 흐름을 관리하고, 세부 로직은 SmsService, VerificationService, TemporaryTokenService, SignupService가 담당합니다.



## 💖리뷰 요청사항
>특별히 봐주셨으면 하는 부분, 나 좀 잘했다 하는 부분! 기타 당부의 말씀 등 자유롭게 작성해주세요.

-
