### PR TITLE
Feature(#21): fcm 고도화

### DIFF
--- a/src/main/java/com/widyu/fcm/api/FcmController.java
+++ b/src/main/java/com/widyu/fcm/api/FcmController.java
@@ -3,24 +3,14 @@ package com.widyu.fcm.api;
 import com.widyu.fcm.api.dto.FcmSendDto;
 import com.widyu.fcm.application.FcmService;
 import com.widyu.global.response.ApiResponseTemplate;
-import java.io.IOException;
+import com.widyu.global.util.MemberUtil;
+import com.widyu.member.domain.Member;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.http.HttpStatus;
-import org.springframework.http.ResponseEntity;
-import org.springframework.validation.annotation.Validated;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
-/**
- * FCM 관리하는 Controller
- *
- * @author : lee
- * @fileName : FcmController
- * @since : 2/21/24
- */
+import java.io.IOException;
 
 @Slf4j
 @RestController
@@ -32,10 +22,10 @@ public class FcmController {
 
     @PostMapping("/send")
     public ApiResponseTemplate<Integer> pushMessage(
-            @RequestBody @Validated FcmSendDto fcmSendDto
+            @RequestBody @Valid FcmSendDto fcmSendDto
     ) throws IOException {
+        log.debug("[+] 로그인 유저에게 푸시 메시지를 전송합니다.");
 
-        log.debug("[+] 푸시 메시지를 전송합니다.");
         int result = fcmService.sendMessageTo(fcmSendDto);
 
         return ApiResponseTemplate.ok()

--- a/src/main/java/com/widyu/fcm/api/FcmController.java
+++ b/src/main/java/com/widyu/fcm/api/FcmController.java
@@ -2,6 +2,7 @@ package com.widyu.fcm.api;
 
 import com.widyu.fcm.api.dto.FcmSendDto;
 import com.widyu.fcm.application.FcmService;
+import com.widyu.global.response.ApiResponseTemplate;
 import java.io.IOException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -30,13 +31,16 @@ public class FcmController {
     private final FcmService fcmService;
 
     @PostMapping("/send")
-    public ResponseEntity<Integer> pushMessage(
-            @RequestBody @Validated FcmSendDto fcmSendDto) throws IOException {
+    public ApiResponseTemplate<Integer> pushMessage(
+            @RequestBody @Validated FcmSendDto fcmSendDto
+    ) throws IOException {
 
         log.debug("[+] 푸시 메시지를 전송합니다.");
         int result = fcmService.sendMessageTo(fcmSendDto);
 
-        return ResponseEntity.ok(result);
+        return ApiResponseTemplate.ok()
+                .code("FCM_2001")
+                .message("푸시 메시지 전송 성공")
+                .body(result);
     }
-
 }

--- a/src/main/java/com/widyu/fcm/api/MemberFcmTokenController.java
+++ b/src/main/java/com/widyu/fcm/api/MemberFcmTokenController.java
@@ -1,0 +1,49 @@
+package com.widyu.fcm.api;
+
+import com.widyu.fcm.api.dto.request.FcmTokenLoginRequest;
+import com.widyu.fcm.api.dto.request.FcmTokenLogoutRequest;
+import com.widyu.fcm.application.MemberFcmTokenService;
+import com.widyu.global.response.ApiResponseTemplate;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.web.bind.annotation.*;
+
+/**
+ * 로그인/로그아웃 시 FCM 토큰 처리 컨트롤러
+ */
+@Slf4j
+@RestController
+@RequestMapping("/api/v1/fcm/token")
+@RequiredArgsConstructor
+public class MemberFcmTokenController {
+
+    private final MemberFcmTokenService memberFcmTokenService;
+
+    @PostMapping("/login")
+    public ApiResponseTemplate<Void> saveFcmToken(
+            @RequestBody FcmTokenLoginRequest fcmTokenLoginRequest
+    ) {
+        memberFcmTokenService.saveOrActivateFcmToken(
+                fcmTokenLoginRequest.token(),
+                fcmTokenLoginRequest.deviceInfo()
+        );
+
+        return ApiResponseTemplate.ok()
+                .code("FCM_2002")
+                .message("로그인 시 FCM 토큰 처리 완료")
+                .build();
+    }
+
+    @PostMapping("/logout")
+    public ApiResponseTemplate<Void> deactivateFcmToken(
+            @RequestBody FcmTokenLogoutRequest fcmTokenLogoutRequest
+    ) {
+        memberFcmTokenService.deactivateFcmToken(fcmTokenLogoutRequest.token());
+
+        return ApiResponseTemplate.ok()
+                .code("FCM_2003")
+                .message("로그아웃 시 FCM 토큰 비활성화 완료")
+                .build();
+    }
+}

--- a/src/main/java/com/widyu/fcm/api/dto/FcmSendDto.java
+++ b/src/main/java/com/widyu/fcm/api/dto/FcmSendDto.java
@@ -4,7 +4,6 @@ import lombok.Builder;
 
 @Builder
 public record FcmSendDto(
-        String token,
         String title,
         String body
 ) {

--- a/src/main/java/com/widyu/fcm/api/dto/request/FcmTokenLoginRequest.java
+++ b/src/main/java/com/widyu/fcm/api/dto/request/FcmTokenLoginRequest.java
@@ -1,0 +1,7 @@
+package com.widyu.fcm.api.dto.request;
+
+public record FcmTokenLoginRequest(
+        String token,
+        String deviceInfo
+) {
+}

--- a/src/main/java/com/widyu/fcm/api/dto/request/FcmTokenLogoutRequest.java
+++ b/src/main/java/com/widyu/fcm/api/dto/request/FcmTokenLogoutRequest.java
@@ -1,0 +1,6 @@
+package com.widyu.fcm.api.dto.request;
+
+public record FcmTokenLogoutRequest(
+        String token
+) {
+}

--- a/src/main/java/com/widyu/fcm/application/FcmService.java
+++ b/src/main/java/com/widyu/fcm/application/FcmService.java
@@ -1,12 +1,10 @@
 package com.widyu.fcm.application;
 
 import com.widyu.fcm.api.dto.FcmSendDto;
+import com.widyu.member.domain.Member;
+
 import java.io.IOException;
-import org.springframework.stereotype.Service;
 
-@Service
 public interface FcmService {
-
     int sendMessageTo(FcmSendDto fcmSendDto) throws IOException;
-
 }

--- a/src/main/java/com/widyu/fcm/application/FcmServiceImpl.java
+++ b/src/main/java/com/widyu/fcm/application/FcmServiceImpl.java
@@ -5,6 +5,9 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.auth.oauth2.GoogleCredentials;
 import com.widyu.fcm.api.dto.FcmMessageDto;
 import com.widyu.fcm.api.dto.FcmSendDto;
+import com.widyu.fcm.domain.FcmNotification;
+import com.widyu.fcm.domain.repository.FcmNotificationRepository;
+import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.core.io.ClassPathResource;
@@ -19,10 +22,13 @@ import java.util.List;
 
 @Slf4j
 @Service
+@RequiredArgsConstructor
 public class FcmServiceImpl implements FcmService {
 
     @Value("${firebase.config-path}")
     private String firebaseConfigPath;
+
+    private final FcmNotificationRepository notificationRepository;
 
     @Override
     public int sendMessageTo(FcmSendDto fcmSendDto) throws IOException {
@@ -45,6 +51,13 @@ public class FcmServiceImpl implements FcmService {
                 restTemplate.exchange(API_URL, HttpMethod.POST, entity, String.class);
 
         log.info("[FCM Response] status: {}, body: {}", response.getStatusCode(), response.getBody());
+
+        notificationRepository.save(FcmNotification.builder()
+                .title(fcmSendDto.title())
+                .body(fcmSendDto.body())
+                .token(fcmSendDto.token())
+                .isRead(false)
+                .build());
 
         return response.getStatusCode() == HttpStatus.OK ? 1 : 0;
     }

--- a/src/main/java/com/widyu/fcm/application/MemberFcmTokenService.java
+++ b/src/main/java/com/widyu/fcm/application/MemberFcmTokenService.java
@@ -1,0 +1,56 @@
+package com.widyu.fcm.application;
+
+import com.widyu.fcm.domain.MemberFcmToken;
+import com.widyu.fcm.domain.repository.MemberFcmTokenRepository;
+import com.widyu.global.util.MemberUtil;
+import com.widyu.member.domain.Member;
+import java.time.LocalDateTime;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class MemberFcmTokenService {
+
+    private final MemberFcmTokenRepository memberFcmTokenRepository;
+    private final MemberUtil memberUtil;
+
+    // 로그인 시 FCM 토큰 저장 (중복 저장 방지)
+    @Transactional
+    public void saveOrActivateFcmToken(String fcmToken, String deviceInfo) {
+        Member currentMember = memberUtil.getCurrentMember();
+
+        Optional<MemberFcmToken> tokenOpt = memberFcmTokenRepository.findByToken(fcmToken);
+
+        if (tokenOpt.isPresent()) {
+            MemberFcmToken existingToken = tokenOpt.get();
+
+            if (!existingToken.getMember().equals(currentMember)) {
+                existingToken.deactivate();
+            } else {
+                // 같은 유저가 다시 로그인하면 토큰 활성화
+                existingToken.activate();
+            }
+
+        } else {
+            MemberFcmToken newToken = MemberFcmToken.builder()
+                    .member(currentMember)
+                    .token(fcmToken)
+                    .deviceInfo(deviceInfo)
+                    .registeredAt(LocalDateTime.now())
+                    .active(true)
+                    .build();
+            memberFcmTokenRepository.save(newToken);
+        }
+    }
+
+    // 로그아웃 시 FCM 토큰 삭제
+    @Transactional
+    public void deactivateFcmToken(String fcmToken) {
+        memberFcmTokenRepository.findByToken(fcmToken)
+                .ifPresent(MemberFcmToken::deactivate);
+    }
+}

--- a/src/main/java/com/widyu/fcm/domain/FcmNotification.java
+++ b/src/main/java/com/widyu/fcm/domain/FcmNotification.java
@@ -1,0 +1,36 @@
+package com.widyu.fcm.domain;
+
+import com.widyu.global.domain.BaseTimeEntity;
+import com.widyu.member.domain.Member;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class FcmNotification extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private String title;
+    private String body;
+    private String token;
+    private boolean isRead;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id", nullable = false)
+    private Member member;
+}

--- a/src/main/java/com/widyu/fcm/domain/FcmNotification.java
+++ b/src/main/java/com/widyu/fcm/domain/FcmNotification.java
@@ -27,10 +27,9 @@ public class FcmNotification extends BaseTimeEntity {
 
     private String title;
     private String body;
-    private String token;
     private boolean isRead;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "member_id", nullable = false)
-    private Member member;
+    @JoinColumn(name = "memberFcmToken_id", nullable = false)
+    private MemberFcmToken memberFcmToken;
 }

--- a/src/main/java/com/widyu/fcm/domain/MemberFcmToken.java
+++ b/src/main/java/com/widyu/fcm/domain/MemberFcmToken.java
@@ -1,0 +1,61 @@
+package com.widyu.fcm.domain;
+
+import com.widyu.member.domain.Member;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import java.time.LocalDateTime;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class MemberFcmToken {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false, unique = true, length = 255)
+    private String token;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id", nullable = false)
+    private Member member;
+
+    @Column(nullable = false)
+    private boolean active; // 현재 유효한 토큰인지 여부 (예: 로그아웃 시 false)
+
+    private String deviceInfo; // 선택: 기기 정보 (e.g., Android, iOS 등)
+
+    private LocalDateTime registeredAt;
+
+    private LocalDateTime expiredAt;
+
+    public void deactivate() {
+        this.active = false;
+        this.expiredAt = LocalDateTime.now();
+    }
+
+    public void activate() {
+        this.active = true;
+        this.expiredAt = null;
+    }
+
+    public void updateToken(String fcmToken, LocalDateTime now) {
+        this.token = fcmToken;
+        this.registeredAt = now;
+        this.active = true;
+        this.expiredAt = null;
+    }
+}

--- a/src/main/java/com/widyu/fcm/domain/repository/FcmNotificationRepository.java
+++ b/src/main/java/com/widyu/fcm/domain/repository/FcmNotificationRepository.java
@@ -1,10 +1,8 @@
 package com.widyu.fcm.domain.repository;
 
 import com.widyu.fcm.domain.FcmNotification;
-import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface FcmNotificationRepository extends JpaRepository<FcmNotification, Long> {
-    List<FcmNotification> findByTokenOrderByCreatedAtDesc(String token);
 }
 

--- a/src/main/java/com/widyu/fcm/domain/repository/FcmNotificationRepository.java
+++ b/src/main/java/com/widyu/fcm/domain/repository/FcmNotificationRepository.java
@@ -1,0 +1,10 @@
+package com.widyu.fcm.domain.repository;
+
+import com.widyu.fcm.domain.FcmNotification;
+import java.util.List;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface FcmNotificationRepository extends JpaRepository<FcmNotification, Long> {
+    List<FcmNotification> findByTokenOrderByCreatedAtDesc(String token);
+}
+

--- a/src/main/java/com/widyu/fcm/domain/repository/MemberFcmTokenRepository.java
+++ b/src/main/java/com/widyu/fcm/domain/repository/MemberFcmTokenRepository.java
@@ -1,0 +1,14 @@
+package com.widyu.fcm.domain.repository;
+
+import com.widyu.fcm.domain.FcmNotification;
+import com.widyu.fcm.domain.MemberFcmToken;
+import java.util.List;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface MemberFcmTokenRepository extends JpaRepository<MemberFcmToken, Long> {
+    boolean existsByToken(String fcmToken);
+
+    Optional<MemberFcmToken> findByToken(String fcmToken);
+}
+

--- a/src/main/java/com/widyu/fcm/domain/repository/MemberFcmTokenRepository.java
+++ b/src/main/java/com/widyu/fcm/domain/repository/MemberFcmTokenRepository.java
@@ -2,13 +2,14 @@ package com.widyu.fcm.domain.repository;
 
 import com.widyu.fcm.domain.FcmNotification;
 import com.widyu.fcm.domain.MemberFcmToken;
+import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface MemberFcmTokenRepository extends JpaRepository<MemberFcmToken, Long> {
-    boolean existsByToken(String fcmToken);
-
     Optional<MemberFcmToken> findByToken(String fcmToken);
+
+    List<MemberFcmToken> findAllByMemberIdAndActiveTrue(Long id);
 }
 

--- a/src/main/java/com/widyu/member/domain/Member.java
+++ b/src/main/java/com/widyu/member/domain/Member.java
@@ -1,5 +1,6 @@
 package com.widyu.member.domain;
 
+import com.widyu.fcm.domain.MemberFcmToken;
 import com.widyu.global.domain.BaseTimeEntity;
 import com.widyu.global.domain.Status;
 import jakarta.persistence.CascadeType;
@@ -40,6 +41,9 @@ public class Member extends BaseTimeEntity {
 
     @OneToMany(mappedBy = "member", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<SocialAccount> socialAccounts = new ArrayList<>();
+
+    @OneToMany(mappedBy = "member", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<MemberFcmToken> memberFcmTokens = new ArrayList<>();
 
     @Enumerated(EnumType.STRING)
     private Status status;


### PR DESCRIPTION
## #️⃣연관된 이슈
> #21 

- close: #[issue number]

## 🪄작업 내용
>fcm 발송 메세지 형식 일반화하기

> fcmToken 저장 테이블 구조 생성

> 로그인/로그아웃시 fcmToken 저장/삭제 로직 설계

> 토큰 삭제 - Provider가 Notification Server로 푸시 요청을 했을 때, 토큰이 만료되어 에러 메시지가 오는 경우, 핸들링하 여 그 토큰을 삭제한다.

> 푸시 알림을 보낼 때는 유저의 정보를 받아와서 토큰을 매핑시켜서 보낸다.

