### PR TITLE
 앨범 무한스크롤 조회 캘린더 무한스크롤 조회랑 통합 및 반환값 변경

### DIFF
--- a/src/main/java/com/widyu/domain/album/api/AlbumController.java
+++ b/src/main/java/com/widyu/domain/album/api/AlbumController.java
@@ -9,7 +9,7 @@ import com.widyu.domain.album.dto.response.AlbumFeedResponse;
 import com.widyu.domain.album.dto.response.AlbumUnlockResponse;
 import com.widyu.domain.album.dto.response.AlbumUploadResponse;
 import com.widyu.domain.album.dto.response.LikedAlbumsResponse;
-import com.widyu.domain.album.dto.response.MediaItem;
+import com.widyu.domain.album.dto.response.AlbumMediaResponse;
 import com.widyu.global.dto.CursorPage;
 import com.widyu.global.response.ApiResponseTemplate;
 import io.swagger.v3.oas.annotations.Operation;
@@ -53,9 +53,10 @@ public class AlbumController implements AlbumDocs {
     @Override
     @GetMapping("/feed")
     public ApiResponseTemplate<CursorPage<AlbumFeedResponse>> getAlbumFeed(
-            @RequestParam(value = "cursor", required = false) Long cursor
+            @RequestParam(value = "cursor", required = false) Long cursor,
+            @RequestParam(value = "date", required = false) String date
     ) {
-        CursorPage<AlbumFeedResponse> response = albumFacade.getAlbumFeed(cursor);
+        CursorPage<AlbumFeedResponse> response = albumFacade.getAlbumFeed(cursor, date);
         
         return ApiResponseTemplate.ok()
                 .code("ALBM_2010")
@@ -65,10 +66,10 @@ public class AlbumController implements AlbumDocs {
 
     @Override
     @GetMapping("/media")
-    public ApiResponseTemplate<CursorPage<MediaItem>> getMediaFeed(
+    public ApiResponseTemplate<CursorPage<AlbumMediaResponse>> getMediaFeed(
             @RequestParam(value = "cursor", required = false) Long cursor
     ) {
-        CursorPage<MediaItem> response = albumFacade.getMediaFeed(cursor);
+        CursorPage<AlbumMediaResponse> response = albumFacade.getMediaFeed(cursor);
         
         return ApiResponseTemplate.ok()
                 .code("ALBM_2011")

--- a/src/main/java/com/widyu/domain/album/api/docs/AlbumDocs.java
+++ b/src/main/java/com/widyu/domain/album/api/docs/AlbumDocs.java
@@ -7,7 +7,7 @@ import com.widyu.domain.album.dto.response.AlbumFeedResponse;
 import com.widyu.domain.album.dto.response.AlbumUnlockResponse;
 import com.widyu.domain.album.dto.response.AlbumUploadResponse;
 import com.widyu.domain.album.dto.response.LikedAlbumsResponse;
-import com.widyu.domain.album.dto.response.MediaItem;
+import com.widyu.domain.album.dto.response.AlbumMediaResponse;
 import com.widyu.global.dto.CursorPage;
 import com.widyu.global.response.ApiResponseTemplate;
 import io.swagger.v3.oas.annotations.Operation;
@@ -138,11 +138,16 @@ public interface AlbumDocs {
                     - 무한 스크롤 지원 (커서 기반 페이지네이션)
                     - 각 게시물의 좋아요, 댓글, 조회수 정보 포함
                     - 열람자 정보 (최대 3명까지)
-                    - 현재 사용자의 좋아요 여부 표시
+                    - 현재 사용자의 수정 가능 여부 표시
                     
                     **무한 스크롤 사용법:**
-                    1. 첫 번째 요청: lastAlbumId 없이 호출
-                    2. 다음 요청: 응답의 nextCursor를 lastAlbumId로 사용
+                    1. 첫 번째 요청: cursor 없이 호출
+                    2. 다음 요청: 응답의 nextCursor를 cursor로 사용
+                    
+                    **날짜 필터링:**
+                    - date 파라미터로 특정 날짜의 앨범만 조회 가능
+                    - 형식: yyyy-MM-dd (예: 2024-12-21)
+                    - 캘린더 탭에서 활용
                     """
     )
     @ApiResponses({
@@ -177,7 +182,7 @@ public interface AlbumDocs {
                                                       {"name": "김엄마", "profileImage": null}
                                                     ],
                                                     "createdAt": "2024-12-21T14:30:00",
-                                                    "isLikedByCurrentUser": true,
+                                                    "canEdit": true,
                                                     "videoDuration": null
                                                   }
                                                 ],
@@ -192,7 +197,9 @@ public interface AlbumDocs {
     })
     ApiResponseTemplate<CursorPage<AlbumFeedResponse>> getAlbumFeed(
             @Parameter(description = "마지막으로 조회한 앨범 ID (무한 스크롤용)", example = "123")
-            @RequestParam(value = "lastAlbumId", required = false) Long lastAlbumId
+            @RequestParam(value = "cursor", required = false) Long cursor,
+            @Parameter(description = "캘린더용 날짜 파라미터 (yyyy-MM-dd 형식)", example = "2024-12-21")
+            @RequestParam(value = "date", required = false) String date
     );
 
     @Operation(
@@ -253,7 +260,7 @@ public interface AlbumDocs {
                     )
             )
     })
-    ApiResponseTemplate<CursorPage<MediaItem>> getMediaFeed(
+    ApiResponseTemplate<CursorPage<AlbumMediaResponse>> getMediaFeed(
             @Parameter(description = "마지막으로 조회한 postId (무한 스크롤용)", example = "123")
             @RequestParam(value = "lastPostId", required = false) Long lastPostId
     );

--- a/src/main/java/com/widyu/domain/album/application/AlbumFacade.java
+++ b/src/main/java/com/widyu/domain/album/application/AlbumFacade.java
@@ -7,7 +7,7 @@ import com.widyu.domain.album.dto.response.AlbumFeedResponse;
 import com.widyu.domain.album.dto.response.AlbumUnlockResponse;
 import com.widyu.domain.album.dto.response.AlbumUploadResponse;
 import com.widyu.domain.album.dto.response.LikedAlbumsResponse;
-import com.widyu.domain.album.dto.response.MediaItem;
+import com.widyu.domain.album.dto.response.AlbumMediaResponse;
 import com.widyu.global.dto.CursorPage;
 
 /**
@@ -24,12 +24,12 @@ public interface AlbumFacade {
     /**
      * 앨범 피드 조회 (무한 스크롤)
      */
-    CursorPage<AlbumFeedResponse> getAlbumFeed(Long lastAlbumId);
+    CursorPage<AlbumFeedResponse> getAlbumFeed(Long lastAlbumId, String date);
     
     /**
      * 미디어 피드 조회 (무한 스크롤)
      */
-    CursorPage<MediaItem> getMediaFeed(Long lastPostId);
+    CursorPage<AlbumMediaResponse> getMediaFeed(Long lastPostId);
     
     /**
      * 앨범 상세 조회

--- a/src/main/java/com/widyu/domain/album/application/AlbumFacadeImpl.java
+++ b/src/main/java/com/widyu/domain/album/application/AlbumFacadeImpl.java
@@ -8,7 +8,7 @@ import com.widyu.domain.album.dto.response.AlbumFeedResponse;
 import com.widyu.domain.album.dto.response.AlbumUnlockResponse;
 import com.widyu.domain.album.dto.response.AlbumUploadResponse;
 import com.widyu.domain.album.dto.response.LikedAlbumsResponse;
-import com.widyu.domain.album.dto.response.MediaItem;
+import com.widyu.domain.album.dto.response.AlbumMediaResponse;
 import com.widyu.global.dto.CursorPage;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -38,13 +38,13 @@ public class AlbumFacadeImpl implements AlbumFacade {
     }
 
     @Override
-    public CursorPage<AlbumFeedResponse> getAlbumFeed(Long lastAlbumId) {
-        AlbumFeedRequest request = AlbumFeedRequest.from(lastAlbumId);
+    public CursorPage<AlbumFeedResponse> getAlbumFeed(Long lastAlbumId, String date) {
+        AlbumFeedRequest request = AlbumFeedRequest.from(lastAlbumId, date);
         return albumFeedService.getAlbumFeed(request);
     }
     
     @Override
-    public CursorPage<MediaItem> getMediaFeed(Long lastPostId) {
+    public CursorPage<AlbumMediaResponse> getMediaFeed(Long lastPostId) {
         return albumFeedService.getMediaFeed(lastPostId);
     }
 

--- a/src/main/java/com/widyu/domain/album/application/AlbumFeedService.java
+++ b/src/main/java/com/widyu/domain/album/application/AlbumFeedService.java
@@ -2,7 +2,7 @@ package com.widyu.domain.album.application;
 
 import com.widyu.domain.album.dto.request.AlbumFeedRequest;
 import com.widyu.domain.album.dto.response.AlbumFeedResponse;
-import com.widyu.domain.album.dto.response.MediaItem;
+import com.widyu.domain.album.dto.response.AlbumMediaResponse;
 import com.widyu.domain.album.entity.Album;
 import com.widyu.domain.album.repository.AlbumLikeRepository;
 import com.widyu.domain.album.repository.AlbumRepository;
@@ -10,13 +10,12 @@ import com.widyu.domain.album.repository.AlbumViewRepository;
 import com.widyu.domain.member.entity.Member;
 import com.widyu.global.dto.CursorPage;
 import com.widyu.global.util.MemberUtil;
+import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -45,7 +44,7 @@ public class AlbumFeedService {
 
         // 1) 앨범 ID 커서 페이지 조회 (size+1 로 hasNext 판단)
         Pageable pageable = pagePlusOne(ALBUM_FEED_SIZE);
-        Slice<Long> idSlice = findAlbumIdSlice(request.hasCursor() ? request.lastAlbumId() : null, pageable);
+        Slice<Long> idSlice = findAlbumIdSlice(request.hasCursor() ? request.lastAlbumId() : null, request.hasDate() ? LocalDate.parse(request.date()) : null, pageable);
 
         // 2) 상세 조회 (ID 순서 보존)
         List<Long> albumIds = idSlice.getContent();
@@ -65,39 +64,45 @@ public class AlbumFeedService {
     }
 
     @Transactional(readOnly = true)
-    public CursorPage<MediaItem> getMediaFeed(Long lastPostId) {
+    public CursorPage<AlbumMediaResponse> getMediaFeed(Long lastPostId) {
         Pageable pageable = pagePlusOne(MEDIA_FEED_SIZE);
 
         // 1) 앨범 ID 커서 페이지
-        Slice<Long> idSlice = findAlbumIdSlice(lastPostId, pageable);
+        Slice<Long> idSlice = findAlbumIdSlice(lastPostId, null, pageable);
 
         // 2) 상세 조회 (ID 순서 보존)
         List<Long> albumIds = idSlice.getContent();
         List<Album> albums = findAlbumsOrderedByIds(albumIds);
 
         // 3) 앨범 -> 미디어 평탄화
-        List<MediaItem> mediaItems = new ArrayList<>();
+        List<AlbumMediaResponse> albumMediaResponses = new ArrayList<>();
         for (Album album : albums) {
-            mediaItems.addAll(MediaItem.fromAlbum(album));
+            albumMediaResponses.addAll(AlbumMediaResponse.fromAlbum(album));
         }
 
         // 4) 커서는 마지막 미디어의 postId(=albumId)
         boolean hasNext = idSlice.hasNext();
-        String nextCursor = mediaItems.isEmpty()
+        String nextCursor = albumMediaResponses.isEmpty()
                 ? null
-                : String.valueOf(mediaItems.getLast().postId());
+                : String.valueOf(albumMediaResponses.getLast().postId());
 
-        return new CursorPage<>(mediaItems, nextCursor, hasNext);
+        return new CursorPage<>(albumMediaResponses, nextCursor, hasNext);
     }
 
     private Pageable pagePlusOne(int size) {
         return PageRequest.of(0, size + 1);
     }
 
-    private Slice<Long> findAlbumIdSlice(Long lastPostId, Pageable pageable) {
-        return (lastPostId != null)
-                ? albumRepository.findAlbumIdsAfterPostId(lastPostId, pageable)
-                : albumRepository.findLatestAlbumIds(pageable);
+    private Slice<Long> findAlbumIdSlice(Long lastPostId, LocalDate date, Pageable pageable) {
+        if (date != null) {
+            return (lastPostId != null)
+                    ? albumRepository.findAlbumIdsAfterPostIdByDate(lastPostId, date, pageable)
+                    : albumRepository.findLatestAlbumIdsByDate(date, pageable);
+        } else {
+            return (lastPostId != null)
+                    ? albumRepository.findAlbumIdsAfterPostId(lastPostId, pageable)
+                    : albumRepository.findLatestAlbumIds(pageable);
+        }
     }
 
     private List<Album> findAlbumsOrderedByIds(List<Long> albumIds) {
@@ -127,7 +132,7 @@ public class AlbumFeedService {
                 .map(Album::getId)
                 .collect(Collectors.toList());
 
-        Set<Long> likedAlbumIds = new HashSet<>(albumLikeRepository.findLikedAlbumIds(currentMember, albumIds));
+        // canEdit: 현재 사용자가 작성한 앨범인지 확인
 
         Map<Long, List<AlbumFeedResponse.ViewerInfo>> viewersMap = albumViewRepository
                 .findTop3ViewersForAlbums(albumIds).stream()
@@ -145,10 +150,10 @@ public class AlbumFeedService {
         // 순서대로 응답 생성
         List<AlbumFeedResponse> result = new ArrayList<>(albums.size());
         for (Album album : albums) {
-            boolean isLiked = likedAlbumIds.contains(album.getId());
+            boolean canEdit = album.getMember().getId().equals(currentMember.getId());
             List<AlbumFeedResponse.ViewerInfo> viewers =
                     viewersMap.getOrDefault(album.getId(), List.of());
-            result.add(AlbumFeedResponse.from(album, isLiked, viewers));
+            result.add(AlbumFeedResponse.from(album, canEdit, viewers));
         }
         return result;
     }

--- a/src/main/java/com/widyu/domain/album/dto/request/AlbumFeedRequest.java
+++ b/src/main/java/com/widyu/domain/album/dto/request/AlbumFeedRequest.java
@@ -1,13 +1,18 @@
 package com.widyu.domain.album.dto.request;
 
 public record AlbumFeedRequest(
-        Long lastAlbumId
+        Long lastAlbumId,
+        String date
 ) {
     public boolean hasCursor() {
         return lastAlbumId != null;
     }
 
-    public static AlbumFeedRequest from(Long lastAlbumId) {
-        return new AlbumFeedRequest(lastAlbumId);
+    public static AlbumFeedRequest from(Long lastAlbumId, String date) {
+        return new AlbumFeedRequest(lastAlbumId, date);
+    }
+    
+    public boolean hasDate() {
+        return date != null && !date.trim().isEmpty();
     }
 }

--- a/src/main/java/com/widyu/domain/album/dto/response/AlbumFeedResponse.java
+++ b/src/main/java/com/widyu/domain/album/dto/response/AlbumFeedResponse.java
@@ -21,7 +21,7 @@ public record AlbumFeedResponse(
         Integer viewCount,
         List<ViewerInfo> viewers,
         LocalDateTime createdAt,
-        Boolean isLikedByCurrentUser,
+        Boolean canEdit,
         String videoDuration // 동영상인 경우만
 ) {
     public record ViewerInfo(
@@ -29,7 +29,7 @@ public record AlbumFeedResponse(
             String profileImage
     ) {}
 
-    public static AlbumFeedResponse from(Album album, Boolean isLikedByCurrentUser, List<ViewerInfo> viewers) {
+    public static AlbumFeedResponse from(Album album, Boolean canEdit, List<ViewerInfo> viewers) {
         return new AlbumFeedResponse(
                 album.getId(),
                 album.getMember().getName(),
@@ -46,7 +46,7 @@ public record AlbumFeedResponse(
                 album.getViewCount(),
                 viewers,
                 album.getCreatedAt(),
-                isLikedByCurrentUser,
+                canEdit,
                 null // TODO: 비디오 지속시간 구현 시 추가
         );
     }

--- a/src/main/java/com/widyu/domain/album/dto/response/AlbumMediaResponse.java
+++ b/src/main/java/com/widyu/domain/album/dto/response/AlbumMediaResponse.java
@@ -5,7 +5,7 @@ import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 
-public record MediaItem(
+public record AlbumMediaResponse(
         Long id,
         Long postId,
         String type,
@@ -14,8 +14,8 @@ public record MediaItem(
         LocalDateTime createdAt
 ) {
 
-    public static List<MediaItem> fromAlbum(Album album) {
-        List<MediaItem> mediaItems = new ArrayList<>();
+    public static List<AlbumMediaResponse> fromAlbum(Album album) {
+        List<AlbumMediaResponse> albumMediaResponses = new ArrayList<>();
         List<String> mediaUrls = album.getMediaUrls();
         List<String> thumbnailUrls = album.getThumbnailUrls();
         List<Integer> durations = album.getDurations();
@@ -31,7 +31,7 @@ public record MediaItem(
                 duration = null;
             }
             
-            mediaItems.add(new MediaItem(
+            albumMediaResponses.add(new AlbumMediaResponse(
                     generateMediaId(album.getId(), i), // 앨범ID + 인덱스로 고유 ID 생성
                     album.getId(),
                     isImageUrl(mediaUrl) ? "image" : "video",
@@ -41,7 +41,7 @@ public record MediaItem(
             ));
         }
         
-        return mediaItems;
+        return albumMediaResponses;
     }
     
     private static Long generateMediaId(Long albumId, int index) {

--- a/src/main/java/com/widyu/domain/album/repository/AlbumRepository.java
+++ b/src/main/java/com/widyu/domain/album/repository/AlbumRepository.java
@@ -3,6 +3,7 @@ package com.widyu.domain.album.repository;
 import com.widyu.domain.album.entity.Album;
 import com.widyu.domain.member.entity.Member;
 import com.widyu.global.domain.Status;
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
@@ -35,4 +36,14 @@ public interface AlbumRepository extends JpaRepository<Album, Long> {
     Optional<LocalDateTime> findLastUploadDateByMember(@Param("member") Member member, @Param("status") Status status);
 
     long countByMemberId(Long id);
+    
+    @Query("SELECT a.id FROM Album a WHERE a.status = 'ACTIVE' AND DATE(a.createdAt) = :date ORDER BY a.createdAt DESC, a.id DESC")
+    org.springframework.data.domain.Slice<Long> findLatestAlbumIdsByDate(@Param("date") LocalDate date, Pageable pageable);
+    
+    @Query("SELECT a.id FROM Album a WHERE a.status = 'ACTIVE' AND DATE(a.createdAt) = :date AND a.id < :lastPostId ORDER BY a.id DESC")
+    org.springframework.data.domain.Slice<Long> findAlbumIdsAfterPostIdByDate(
+            @Param("lastPostId") Long lastPostId,
+            @Param("date") LocalDate date,
+            Pageable pageable
+    );
 }


### PR DESCRIPTION
## #️⃣연관된 이슈
>PR과 연관된 이슈 번호를 작성해주세요. ex) #이슈 번호, #이슈 번호

- close: #108

## 🪄작업 내용
>앨범 무한스크롤 조회 캘린더 무한스크롤 조회가 반환값이 같아 통합합니다.
- 앨범 무한스크롤 조회 반환값 변경
-캘린더 무한스크롤 조회 api 삭제는 추후 진행


## 💖리뷰 요청사항
>특별히 봐주셨으면 하는 부분, 나 좀 잘했다 하는 부분! 기타 당부의 말씀 등 자유롭게 작성해주세요.

-
