### PR TITLE
가족 메시지 전송 기능 추가

### DIFF
--- a/backend/widyu-api/src/main/java/com/widyu/fcm/dto/response/FcmCategoryResponse.java
+++ b/backend/widyu-api/src/main/java/com/widyu/fcm/dto/response/FcmCategoryResponse.java
@@ -27,6 +27,7 @@ public class FcmCategoryResponse {
             case HEALTH_SCHEDULE -> "방문 일정";
             case WALK -> "만보계";
             case MEDICINE_SCHEDULE -> "복약 알림";
+            case HEART_MESSAGE -> "가족 메시지";
             case SAFE_ZONE -> "안전구역";
         };
     }

--- a/backend/widyu-api/src/main/java/com/widyu/heart/application/HeartMessageService.java
+++ b/backend/widyu-api/src/main/java/com/widyu/heart/application/HeartMessageService.java
@@ -1,0 +1,66 @@
+package com.widyu.heart.application;
+
+import com.widyu.fcm.FcmCategory;
+import com.widyu.fcm.application.FcmService;
+import com.widyu.fcm.dto.FcmSendDto;
+import com.widyu.global.error.BusinessException;
+import com.widyu.global.error.ErrorCode;
+import com.widyu.global.util.MemberUtil;
+import com.widyu.heart.dto.request.HeartMessageRequest;
+import com.widyu.member.Member;
+import com.widyu.member.MemberType;
+import com.widyu.member.repository.FamilyConnectionRepository;
+import com.widyu.member.repository.MemberRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class HeartMessageService {
+
+    private final MemberUtil memberUtil;
+    private final MemberRepository memberRepository;
+    private final FamilyConnectionRepository familyConnectionRepository;
+    private final FcmService fcmService;
+
+    @Transactional
+    public void sendHeartMessage(HeartMessageRequest request) {
+        Member sender = memberUtil.getCurrentMember();
+        Member receiver = memberRepository.findById(request.receiverId())
+                .orElseThrow(() -> new BusinessException(ErrorCode.MEMBER_NOT_FOUND));
+
+        validateFamilyConnection(sender, receiver);
+
+        String title = sender.getName() + "님이 메시지를 보냈어요.";
+
+        FcmSendDto fcmSendDto = FcmSendDto.builder()
+                .title(title)
+                .content(request.message())
+                .fcmCategory(FcmCategory.HEART_MESSAGE)
+                .scheme("")
+                .image(sender.getProfileImage())
+                .build();
+
+        fcmService.sendMessageToUser(receiver.getId(), fcmSendDto);
+        log.info("하트 메시지 전송 완료: senderId={}, receiverId={}", sender.getId(), receiver.getId());
+    }
+
+    private void validateFamilyConnection(Member sender, Member receiver) {
+        if (sender.getType() == MemberType.GUARDIAN && receiver.getType() == MemberType.SENIOR) {
+            Long seniorProfileId = receiver.getSeniorProfile().getId();
+            if (!familyConnectionRepository.existsBySeniorIdAndGuardianId(seniorProfileId, sender.getId())) {
+                throw new BusinessException(ErrorCode.FORBIDDEN);
+            }
+        } else if (sender.getType() == MemberType.SENIOR && receiver.getType() == MemberType.GUARDIAN) {
+            Long seniorProfileId = sender.getSeniorProfile().getId();
+            if (!familyConnectionRepository.existsBySeniorIdAndGuardianId(seniorProfileId, receiver.getId())) {
+                throw new BusinessException(ErrorCode.FORBIDDEN);
+            }
+        } else {
+            throw new BusinessException(ErrorCode.FORBIDDEN);
+        }
+    }
+}

--- a/backend/widyu-api/src/main/java/com/widyu/heart/controller/HeartRateController.java
+++ b/backend/widyu-api/src/main/java/com/widyu/heart/controller/HeartRateController.java
@@ -3,8 +3,10 @@ package com.widyu.heart.controller;
 import com.widyu.global.annotation.ValidateFamilyAccess;
 import com.widyu.global.response.ApiResponseTemplate;
 import com.widyu.global.util.SecurityUtil;
+import com.widyu.heart.application.HeartMessageService;
 import com.widyu.heart.application.HeartRateService;
 import com.widyu.heart.controller.docs.HeartRateDocs;
+import com.widyu.heart.dto.request.HeartMessageRequest;
 import com.widyu.heart.dto.request.HeartRateSendRequest;
 import com.widyu.heart.dto.response.HeartRateStatusResponse;
 import jakarta.validation.Valid;
@@ -24,6 +26,7 @@ import org.springframework.web.bind.annotation.RestController;
 public class HeartRateController implements HeartRateDocs {
 
     private final HeartRateService heartRateService;
+    private final HeartMessageService heartMessageService;
     private final SecurityUtil securityUtil;
 
     @Override
@@ -50,6 +53,18 @@ public class HeartRateController implements HeartRateDocs {
         return ApiResponseTemplate.ok()
                 .code("HEART_2002")
                 .message("심박수 전송 완료")
+                .build();
+    }
+
+    @Override
+    @PostMapping("/message")
+    public ApiResponseTemplate<Void> sendHeartMessage(
+            @Valid @RequestBody HeartMessageRequest request
+    ) {
+        heartMessageService.sendHeartMessage(request);
+        return ApiResponseTemplate.ok()
+                .code("HEART_2003")
+                .message("메시지 전송 완료")
                 .build();
     }
 }

--- a/backend/widyu-api/src/main/java/com/widyu/heart/controller/docs/HeartRateDocs.java
+++ b/backend/widyu-api/src/main/java/com/widyu/heart/controller/docs/HeartRateDocs.java
@@ -1,6 +1,7 @@
 package com.widyu.heart.controller.docs;
 
 import com.widyu.global.response.ApiResponseTemplate;
+import com.widyu.heart.dto.request.HeartMessageRequest;
 import com.widyu.heart.dto.request.HeartRateSendRequest;
 import com.widyu.heart.dto.response.HeartRateStatusResponse;
 import io.swagger.v3.oas.annotations.Operation;
@@ -222,4 +223,107 @@ public interface HeartRateDocs {
             )
     )
     ApiResponseTemplate<Void> sendHeartRates(HeartRateSendRequest request);
+
+    @Operation(
+            summary = "가족 메시지 전송",
+            description = """
+                    같은 가족에게 50자 이내의 메시지를 FCM 알림으로 전송합니다.
+                    알림은 수신자의 알림 내역에 저장됩니다.
+
+                    **접근 권한**:
+                    - 보호자 → 부모님, 부모님 → 보호자 방향 모두 가능
+                    - 반드시 가족 연결이 되어 있어야 합니다.
+                    """
+    )
+    @io.swagger.v3.oas.annotations.parameters.RequestBody(
+            description = "메시지 전송 요청",
+            required = true,
+            content = @Content(
+                    schema = @Schema(implementation = HeartMessageRequest.class),
+                    examples = @ExampleObject(
+                            name = "메시지 전송 예시",
+                            value = """
+                                    {
+                                      "receiverId": 1001,
+                                      "message": "오늘 건강은 좀 어때요?"
+                                    }
+                                    """
+                    )
+            )
+    )
+    @ApiResponse(
+            responseCode = "200",
+            description = "전송 성공",
+            content = @Content(
+                    schema = @Schema(implementation = ApiResponseTemplate.class),
+                    examples = @ExampleObject(
+                            value = """
+                                    {
+                                      "code": "HEART_2003",
+                                      "message": "메시지 전송 완료",
+                                      "data": null
+                                    }
+                                    """
+                    )
+            )
+    )
+    @ApiResponse(
+            responseCode = "400",
+            description = "잘못된 요청",
+            content = @Content(
+                    examples = {
+                            @ExampleObject(
+                                    name = "메시지 초과",
+                                    value = """
+                                            {
+                                              "code": "REQ_4000",
+                                              "message": "메시지는 50자 이내로 입력해주세요.",
+                                              "data": null
+                                            }
+                                            """
+                            ),
+                            @ExampleObject(
+                                    name = "필수값 누락",
+                                    value = """
+                                            {
+                                              "code": "REQ_4000",
+                                              "message": "받는 사람 ID는 필수입니다.",
+                                              "data": null
+                                            }
+                                            """
+                            )
+                    }
+            )
+    )
+    @ApiResponse(
+            responseCode = "403",
+            description = "가족 관계 없음",
+            content = @Content(
+                    examples = @ExampleObject(
+                            value = """
+                                    {
+                                      "code": "AUTH_4030",
+                                      "message": "접근 권한이 없습니다.",
+                                      "data": null
+                                    }
+                                    """
+                    )
+            )
+    )
+    @ApiResponse(
+            responseCode = "404",
+            description = "회원 없음",
+            content = @Content(
+                    examples = @ExampleObject(
+                            value = """
+                                    {
+                                      "code": "MEMBER_4041",
+                                      "message": "회원을 찾을 수 없습니다.",
+                                      "data": null
+                                    }
+                                    """
+                    )
+            )
+    )
+    ApiResponseTemplate<Void> sendHeartMessage(HeartMessageRequest request);
 }

--- a/backend/widyu-api/src/main/java/com/widyu/heart/dto/request/HeartMessageRequest.java
+++ b/backend/widyu-api/src/main/java/com/widyu/heart/dto/request/HeartMessageRequest.java
@@ -1,0 +1,16 @@
+package com.widyu.heart.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+
+public record HeartMessageRequest(
+
+        @NotNull(message = "받는 사람 ID는 필수입니다.")
+        Long receiverId,
+
+        @NotBlank(message = "메시지 내용은 필수입니다.")
+        @Size(max = 50, message = "메시지는 50자 이내로 입력해주세요.")
+        String message
+) {
+}

--- a/backend/widyu-domain/src/main/java/com/widyu/fcm/FcmCategory.java
+++ b/backend/widyu-domain/src/main/java/com/widyu/fcm/FcmCategory.java
@@ -6,5 +6,6 @@ public enum FcmCategory {
     TARGET,
     HEALTH_SCHEDULE,
     WALK,
-    MEDICINE_SCHEDULE
+    MEDICINE_SCHEDULE,
+    HEART_MESSAGE
 }

--- a/backend/widyu-domain/src/main/java/com/widyu/fcm/FcmCategory.java
+++ b/backend/widyu-domain/src/main/java/com/widyu/fcm/FcmCategory.java
@@ -7,5 +7,6 @@ public enum FcmCategory {
     HEALTH_SCHEDULE,
     WALK,
     MEDICINE_SCHEDULE,
-    HEART_MESSAGE
+    HEART_MESSAGE,
+    SAFE_ZONE
 }


### PR DESCRIPTION


## #️⃣연관된 이슈
>PR과 연관된 이슈 번호를 작성해주세요. ex) #이슈 번호, #이슈 번호

- close: #205

## 🪄작업 내용
- HeartMessageService: 가족 간 FCM 메시지 전송 로직 구현 (보호자↔부모님 양방향)
- HeartMessageRequest: 수신자 ID 및 50자 이내 메시지 유효성 검증 DTO 추가
- HeartRateController: POST /message 엔드포인트 추가
- HeartRateDocs: Swagger 문서 추가
- FcmCategory: HEART_MESSAGE 카테고리 추가

## 💖리뷰 요청사항
>특별히 봐주셨으면 하는 부분, 나 좀 잘했다 하는 부분! 기타 당부의 말씀 등 자유롭게 작성해주세요.

-
