### PR TITLE
심박수 그래프 API 및 보호자 실시간 브로드캐스트 구현

### DIFF
--- a/backend/widyu-api/src/main/java/com/widyu/global/security/PrincipalDetails.java
+++ b/backend/widyu-api/src/main/java/com/widyu/global/security/PrincipalDetails.java
@@ -14,6 +14,10 @@ public class PrincipalDetails implements UserDetails {
     private final Long memberId;
     private final MemberRole role;
 
+    public Long getMemberId() {
+        return memberId;
+    }
+
     @Override
     public Collection<? extends GrantedAuthority> getAuthorities() {
         return Collections.singleton(new SimpleGrantedAuthority(role.getValue()));

--- a/backend/widyu-api/src/main/java/com/widyu/global/websocket/JwtChannelInterceptor.java
+++ b/backend/widyu-api/src/main/java/com/widyu/global/websocket/JwtChannelInterceptor.java
@@ -35,7 +35,7 @@ public class JwtChannelInterceptor implements ChannelInterceptor {
                 String token = authHeader.replace(TOKEN_PREFIX, "");
                 AccessTokenDto accessTokenDto = jwtTokenProvider.retrieveAccessToken(token);
 
-                if (accessTokenDto != null) {
+                if (accessTokenDto != null && accessTokenDto.memberId() != null) {
                     PrincipalDetails principal = new PrincipalDetails(
                             accessTokenDto.memberId(),
                             accessTokenDto.memberRole()

--- a/backend/widyu-api/src/main/java/com/widyu/heart/application/HeartRateService.java
+++ b/backend/widyu-api/src/main/java/com/widyu/heart/application/HeartRateService.java
@@ -1,16 +1,31 @@
 package com.widyu.heart.application;
 
+import com.widyu.global.error.BusinessException;
+import com.widyu.global.error.ErrorCode;
+import com.widyu.heart.HeartRateEmergency;
+import com.widyu.heart.HeartRateEvent;
 import com.widyu.heart.HeartRateResult;
 import com.widyu.heart.HeartRateStatus;
 import com.widyu.heart.dto.request.HeartRateMeasurement;
 import com.widyu.heart.dto.request.HeartRateSendRequest;
+import com.widyu.heart.dto.response.EmergencyEventResponse;
+import com.widyu.heart.dto.response.EmergencyHistoryResponse;
+import com.widyu.heart.dto.response.HeartGraphCurrentResponse;
+import com.widyu.heart.dto.response.HeartGraphPageResponse;
+import com.widyu.heart.dto.response.HeartGraphResponse;
+import com.widyu.heart.dto.response.HeartRateEventResponse;
 import com.widyu.heart.dto.response.HeartRateStatusResponse;
+import com.widyu.heart.repository.HeartRateEmergencyRepository;
+import com.widyu.heart.repository.HeartRateEventRepository;
 import com.widyu.heart.repository.HeartRateResultRepository;
+import com.widyu.member.Member;
+import com.widyu.member.repository.MemberRepository;
 import java.util.Comparator;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Slf4j
 @Service
@@ -19,7 +34,11 @@ public class HeartRateService {
 
     private final HeartRateAnomalyDetector heartRateAnomalyDetector;
     private final HeartRateResultRepository heartRateResultRepository;
+    private final HeartRateEventRepository heartRateEventRepository;
+    private final HeartRateEmergencyRepository heartRateEmergencyRepository;
+    private final MemberRepository memberRepository;
 
+    @Transactional
     public HeartRateStatusResponse processHeartRates(Long memberId, HeartRateSendRequest request) {
         List<Integer> heartRateValues = request.heartRates().stream()
                 .map(HeartRateMeasurement::heartRate)
@@ -27,7 +46,7 @@ public class HeartRateService {
 
         boolean isAbnormal = heartRateAnomalyDetector.detectAnomaly(heartRateValues);
 
-        HeartRateStatus status = isAbnormal ? HeartRateStatus.ANOMALY : HeartRateStatus.NORMAL;
+        HeartRateStatus status = resolveStatus(isAbnormal);
 
         HeartRateMeasurement latestMeasurement = request.heartRates().stream()
                 .max(Comparator.comparing(HeartRateMeasurement::measuredAt))
@@ -39,8 +58,21 @@ public class HeartRateService {
                 latestMeasurement.heartRate(),
                 latestMeasurement.measuredAt()
         );
-
         heartRateResultRepository.save(result);
+
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.MEMBER_NOT_FOUND));
+
+        List<HeartRateEvent> events = request.heartRates().stream()
+                .map(m -> HeartRateEvent.of(member, m.heartRate(), m.measuredAt(), status))
+                .toList();
+        heartRateEventRepository.saveAll(events);
+
+        if (isAbnormal) {
+            Integer peakHeartRate = heartRateValues.stream().max(Integer::compareTo).orElse(latestMeasurement.heartRate());
+            HeartRateEmergency emergency = HeartRateEmergency.of(member, peakHeartRate, latestMeasurement.measuredAt(), request.location());
+            heartRateEmergencyRepository.save(emergency);
+        }
 
         log.info("심박수 분석 완료: memberId={}, status={}, heartRate={}, measuredAt={}",
                 memberId, status, latestMeasurement.heartRate(), latestMeasurement.measuredAt());
@@ -52,5 +84,84 @@ public class HeartRateService {
         return heartRateResultRepository.findByMemberId(memberId)
                 .map(HeartRateStatusResponse::from)
                 .orElse(HeartRateStatusResponse.unknown(memberId));
+    }
+
+    @Transactional(readOnly = true)
+    public HeartGraphPageResponse getHeartGraph(Long memberId) {
+        HeartRateResult latest = heartRateResultRepository.findByMemberId(memberId).orElse(null);
+
+        List<HeartRateEvent> allEvents = heartRateEventRepository.findByMemberIdOrderByMeasuredAtAsc(memberId);
+        Integer maxHeartRate = heartRateEventRepository.findMaxHeartRateByMemberId(memberId).orElse(null);
+        Integer minHeartRate = heartRateEventRepository.findMinHeartRateByMemberId(memberId).orElse(null);
+
+        HeartGraphCurrentResponse current = buildCurrentForInitial(latest, maxHeartRate, minHeartRate);
+
+        HeartRateEmergency firstEmergency = heartRateEmergencyRepository.findFirstByMemberIdOrderByMeasuredAtAsc(memberId).orElse(null);
+        HeartRateEventResponse firstEmergencyResponse = null;
+        if (firstEmergency != null) {
+            firstEmergencyResponse = new HeartRateEventResponse(firstEmergency.getHeartRate(), firstEmergency.getMeasuredAt());
+        }
+
+        List<HeartRateEventResponse> eventResponses = allEvents.stream()
+                .map(HeartRateEventResponse::from)
+                .toList();
+
+        HeartGraphResponse heartGraph = HeartGraphResponse.forInitial(current, firstEmergencyResponse, eventResponses);
+
+        return HeartGraphPageResponse.of(heartGraph, buildEmergencyHistory(memberId));
+    }
+
+    @Transactional(readOnly = true)
+    public HeartGraphPageResponse getHeartGraphRefresh(Long memberId) {
+        HeartRateResult latest = heartRateResultRepository.findByMemberId(memberId).orElse(null);
+
+        Integer maxHeartRate = heartRateEventRepository.findMaxHeartRateByMemberId(memberId).orElse(null);
+        Integer minHeartRate = heartRateEventRepository.findMinHeartRateByMemberId(memberId).orElse(null);
+
+        HeartGraphCurrentResponse current = buildCurrentForRefresh(latest, maxHeartRate, minHeartRate);
+
+        List<HeartRateEventResponse> recentEvents = heartRateEventRepository
+                .findTop5ByMemberIdOrderByMeasuredAtDesc(memberId)
+                .stream()
+                .sorted(Comparator.comparing(HeartRateEvent::getMeasuredAt))
+                .map(HeartRateEventResponse::from)
+                .toList();
+
+        HeartGraphResponse heartGraph = HeartGraphResponse.forRefresh(current, recentEvents);
+
+        return HeartGraphPageResponse.of(heartGraph, buildEmergencyHistory(memberId));
+    }
+
+    private HeartGraphCurrentResponse buildCurrentForInitial(HeartRateResult latest, Integer maxHeartRate, Integer minHeartRate) {
+        if (latest == null) {
+            return HeartGraphCurrentResponse.forInitial(null, null, maxHeartRate, minHeartRate, HeartRateStatus.UNKNOWN);
+        }
+        return HeartGraphCurrentResponse.forInitial(
+                latest.getHeartRate(), latest.getMeasuredAt(), maxHeartRate, minHeartRate, latest.getStatus());
+    }
+
+    private HeartGraphCurrentResponse buildCurrentForRefresh(HeartRateResult latest, Integer maxHeartRate, Integer minHeartRate) {
+        if (latest == null) {
+            return HeartGraphCurrentResponse.forRefresh(null, maxHeartRate, minHeartRate, HeartRateStatus.UNKNOWN);
+        }
+        return HeartGraphCurrentResponse.forRefresh(latest.getHeartRate(), maxHeartRate, minHeartRate, latest.getStatus());
+    }
+
+    private HeartRateStatus resolveStatus(boolean isAbnormal) {
+        if (isAbnormal) {
+            return HeartRateStatus.ANOMALY;
+        }
+        return HeartRateStatus.NORMAL;
+    }
+
+    private EmergencyHistoryResponse buildEmergencyHistory(Long memberId) {
+        long emergencyCount = heartRateEmergencyRepository.countByMemberId(memberId);
+        int totalDuration = heartRateEventRepository.findTotalDurationMinutesByMemberId(memberId).orElse(0);
+        List<EmergencyEventResponse> emergencyEvents = heartRateEmergencyRepository
+                .findByMemberIdOrderByMeasuredAtDesc(memberId)
+                .stream()
+                .map(EmergencyEventResponse::from)
+                .toList();
+        return new EmergencyHistoryResponse(emergencyCount, totalDuration, emergencyEvents);
     }
 }

--- a/backend/widyu-api/src/main/java/com/widyu/heart/controller/HeartRateController.java
+++ b/backend/widyu-api/src/main/java/com/widyu/heart/controller/HeartRateController.java
@@ -7,6 +7,7 @@ import com.widyu.heart.application.HeartMessageService;
 import com.widyu.heart.application.HeartRateService;
 import com.widyu.heart.controller.docs.HeartRateDocs;
 import com.widyu.heart.dto.request.HeartMessageRequest;
+import com.widyu.heart.dto.response.HeartGraphPageResponse;
 import com.widyu.heart.dto.response.HeartRateStatusResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -39,6 +40,34 @@ public class HeartRateController implements HeartRateDocs {
         return ApiResponseTemplate.ok()
                 .code("HEART_2001")
                 .message("심박수 이상치 조회 완료")
+                .body(response);
+    }
+
+    @Override
+    @GetMapping("/graph")
+    @ValidateFamilyAccess(memberIdParam = "memberId")
+    public ApiResponseTemplate<HeartGraphPageResponse> getHeartGraph(
+            @RequestParam(required = false) Long memberId
+    ) {
+        Long targetMemberId = memberId != null ? memberId : securityUtil.getCurrentMemberId();
+        HeartGraphPageResponse response = heartRateService.getHeartGraph(targetMemberId);
+        return ApiResponseTemplate.ok()
+                .code("HEART_2004")
+                .message("심박수 그래프 조회 완료")
+                .body(response);
+    }
+
+    @Override
+    @GetMapping("/graph/refresh")
+    @ValidateFamilyAccess(memberIdParam = "memberId")
+    public ApiResponseTemplate<HeartGraphPageResponse> getHeartGraphRefresh(
+            @RequestParam(required = false) Long memberId
+    ) {
+        Long targetMemberId = memberId != null ? memberId : securityUtil.getCurrentMemberId();
+        HeartGraphPageResponse response = heartRateService.getHeartGraphRefresh(targetMemberId);
+        return ApiResponseTemplate.ok()
+                .code("HEART_2005")
+                .message("심박수 그래프 갱신 완료")
                 .body(response);
     }
 

--- a/backend/widyu-api/src/main/java/com/widyu/heart/controller/HeartRateWebSocketController.java
+++ b/backend/widyu-api/src/main/java/com/widyu/heart/controller/HeartRateWebSocketController.java
@@ -5,12 +5,14 @@ import com.widyu.heart.application.HeartRateService;
 import com.widyu.heart.dto.request.HeartRateSendRequest;
 import com.widyu.heart.dto.response.HeartRateStatusResponse;
 import jakarta.validation.Valid;
+import java.util.Map;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.messaging.handler.annotation.MessageMapping;
 import org.springframework.messaging.handler.annotation.Payload;
-import org.springframework.messaging.handler.annotation.SendTo;
-import org.springframework.messaging.simp.annotation.SendToUser;
+import org.springframework.messaging.simp.SimpMessageHeaderAccessor;
+import org.springframework.messaging.simp.SimpMessageType;
+import org.springframework.messaging.simp.SimpMessagingTemplate;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.stereotype.Controller;
 
@@ -20,21 +22,50 @@ import org.springframework.stereotype.Controller;
 public class HeartRateWebSocketController {
 
     private final HeartRateService heartRateService;
+    private final SimpMessagingTemplate messagingTemplate;
 
     /**
-     * 시니어가 심박수 데이터를 전송하는 WebSocket 엔드포인트
+     * 시니어가 심박수 데이터(15개)를 전송하는 WebSocket 엔드포인트
      * 클라이언트는 /app/heart-rate/send 로 메시지 전송
-     * 분석 결과는 /queue/heart-rate/result 로 수신
+     * 분석 결과는 /topic/heart-rate/{memberId} 로 보호자에게 브로드캐스트
+     * ACK는 /user/queue/heart-rate/result 로 전송자에게 수신
      */
     @MessageMapping("/heart-rate/send")
-    @SendToUser("/queue/heart-rate/result")
-    public HeartRateStatusResponse sendHeartRates(
+    public void sendHeartRates(
             @Valid @Payload HeartRateSendRequest request,
-            @AuthenticationPrincipal PrincipalDetails principal
+            @AuthenticationPrincipal PrincipalDetails principal,
+            SimpMessageHeaderAccessor headerAccessor
     ) {
-        Long memberId = Long.parseLong(principal.getUsername());
+        String sessionId = headerAccessor.getSessionId();
+        Long memberId = resolveMemberId(principal, headerAccessor);
         log.info("심박수 데이터 수신 (WebSocket) - memberId: {}, 데이터 수: {}", memberId, request.heartRates().size());
 
-        return heartRateService.processHeartRates(memberId, request);
+        HeartRateStatusResponse response = heartRateService.processHeartRates(memberId, request);
+
+        String topic = String.format("/topic/heart-rate/%d", memberId);
+        messagingTemplate.convertAndSend(topic, response);
+
+        messagingTemplate.convertAndSendToUser(sessionId, "/queue/heart-rate/result", response, sessionHeader(sessionId));
+    }
+
+    private Long resolveMemberId(PrincipalDetails principal, SimpMessageHeaderAccessor headerAccessor) {
+        if (principal != null && principal.getMemberId() != null) {
+            return principal.getMemberId();
+        }
+
+        Map<String, Object> sessionAttributes = headerAccessor.getSessionAttributes();
+        if (sessionAttributes != null && sessionAttributes.get("memberId") instanceof Long memberId) {
+            log.debug("세션 속성에서 memberId 조회 - memberId: {}", memberId);
+            return memberId;
+        }
+
+        throw new IllegalStateException("인증 정보가 없습니다. WebSocket 연결 시 유효한 JWT 토큰이 필요합니다.");
+    }
+
+    private Map<String, Object> sessionHeader(String sessionId) {
+        SimpMessageHeaderAccessor accessor = SimpMessageHeaderAccessor.create(SimpMessageType.MESSAGE);
+        accessor.setSessionId(sessionId);
+        accessor.setLeaveMutable(true);
+        return accessor.toMap();
     }
 }

--- a/backend/widyu-api/src/main/java/com/widyu/heart/controller/docs/HeartRateDocs.java
+++ b/backend/widyu-api/src/main/java/com/widyu/heart/controller/docs/HeartRateDocs.java
@@ -2,6 +2,7 @@ package com.widyu.heart.controller.docs;
 
 import com.widyu.global.response.ApiResponseTemplate;
 import com.widyu.heart.dto.request.HeartMessageRequest;
+import com.widyu.heart.dto.response.HeartGraphPageResponse;
 import com.widyu.heart.dto.response.HeartRateStatusResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
@@ -99,6 +100,40 @@ public interface HeartRateDocs {
             )
     )
     ApiResponseTemplate<HeartRateStatusResponse> getHeartRateStatus(
+            @Parameter(description = "조회할 회원 ID (미입력 시 본인)", example = "1023")
+            Long memberId
+    );
+
+    @Operation(
+            summary = "심박수 그래프 최초 조회",
+            description = """
+                    심박수 그래프 화면 최초 진입 시 호출합니다.
+                    현재 심박수, 오늘의 최대/최소, 최초 이상치 탐지 정보, 전체 이벤트, 위급상황 히스토리를 반환합니다.
+
+                    **접근 권한**:
+                    - memberId 미입력 시: 본인 조회
+                    - memberId 입력 시: 가족 연결된 경우에만 조회 가능
+                    """
+    )
+    @ApiResponse(responseCode = "200", description = "조회 성공")
+    ApiResponseTemplate<HeartGraphPageResponse> getHeartGraph(
+            @Parameter(description = "조회할 회원 ID (미입력 시 본인)", example = "1023")
+            Long memberId
+    );
+
+    @Operation(
+            summary = "심박수 그래프 갱신",
+            description = """
+                    심박수 그래프를 갱신할 때 호출합니다.
+                    현재 심박수, 최대/최소, 최근 5개 이벤트, 위급상황 히스토리를 반환합니다.
+
+                    **접근 권한**:
+                    - memberId 미입력 시: 본인 조회
+                    - memberId 입력 시: 가족 연결된 경우에만 조회 가능
+                    """
+    )
+    @ApiResponse(responseCode = "200", description = "갱신 성공")
+    ApiResponseTemplate<HeartGraphPageResponse> getHeartGraphRefresh(
             @Parameter(description = "조회할 회원 ID (미입력 시 본인)", example = "1023")
             Long memberId
     );

--- a/backend/widyu-api/src/main/java/com/widyu/heart/dto/request/HeartRateSendRequest.java
+++ b/backend/widyu-api/src/main/java/com/widyu/heart/dto/request/HeartRateSendRequest.java
@@ -9,6 +9,8 @@ public record HeartRateSendRequest(
         @NotNull(message = "심박수 데이터는 필수입니다.")
         @Size(min = 15, max = 15, message = "심박수 데이터는 정확히 15개여야 합니다.")
         @Valid
-        List<HeartRateMeasurement> heartRates
+        List<HeartRateMeasurement> heartRates,
+
+        String location // 현재 위치 주소 (이상치 감지 시 위급상황 기록에 사용)
 ) {
 }

--- a/backend/widyu-api/src/main/java/com/widyu/heart/dto/response/EmergencyEventResponse.java
+++ b/backend/widyu-api/src/main/java/com/widyu/heart/dto/response/EmergencyEventResponse.java
@@ -1,0 +1,18 @@
+package com.widyu.heart.dto.response;
+
+import com.widyu.heart.HeartRateEmergency;
+import java.time.LocalDateTime;
+
+public record EmergencyEventResponse(
+        Integer heartRate,
+        LocalDateTime measuredAt,
+        String location
+) {
+    public static EmergencyEventResponse from(HeartRateEmergency emergency) {
+        return new EmergencyEventResponse(
+                emergency.getHeartRate(),
+                emergency.getMeasuredAt(),
+                emergency.getLocation()
+        );
+    }
+}

--- a/backend/widyu-api/src/main/java/com/widyu/heart/dto/response/EmergencyHistoryResponse.java
+++ b/backend/widyu-api/src/main/java/com/widyu/heart/dto/response/EmergencyHistoryResponse.java
@@ -1,0 +1,10 @@
+package com.widyu.heart.dto.response;
+
+import java.util.List;
+
+public record EmergencyHistoryResponse(
+        long emergencyCount,
+        int totalDuration,
+        List<EmergencyEventResponse> events
+) {
+}

--- a/backend/widyu-api/src/main/java/com/widyu/heart/dto/response/HeartGraphCurrentResponse.java
+++ b/backend/widyu-api/src/main/java/com/widyu/heart/dto/response/HeartGraphCurrentResponse.java
@@ -1,0 +1,23 @@
+package com.widyu.heart.dto.response;
+
+import com.widyu.heart.HeartRateStatus;
+import java.time.LocalDateTime;
+
+public record HeartGraphCurrentResponse(
+        Integer heartRate,
+        LocalDateTime measuredAt, // 최초 조회 시에만 포함 (갱신 시 null)
+        Integer maxHeartRate,
+        Integer minHeartRate,
+        HeartRateStatus status
+) {
+    public static HeartGraphCurrentResponse forInitial(
+            Integer heartRate, LocalDateTime measuredAt,
+            Integer maxHeartRate, Integer minHeartRate, HeartRateStatus status) {
+        return new HeartGraphCurrentResponse(heartRate, measuredAt, maxHeartRate, minHeartRate, status);
+    }
+
+    public static HeartGraphCurrentResponse forRefresh(
+            Integer heartRate, Integer maxHeartRate, Integer minHeartRate, HeartRateStatus status) {
+        return new HeartGraphCurrentResponse(heartRate, null, maxHeartRate, minHeartRate, status);
+    }
+}

--- a/backend/widyu-api/src/main/java/com/widyu/heart/dto/response/HeartGraphPageResponse.java
+++ b/backend/widyu-api/src/main/java/com/widyu/heart/dto/response/HeartGraphPageResponse.java
@@ -1,0 +1,10 @@
+package com.widyu.heart.dto.response;
+
+public record HeartGraphPageResponse(
+        HeartGraphResponse heartGraph,
+        EmergencyHistoryResponse emergencyHistory
+) {
+    public static HeartGraphPageResponse of(HeartGraphResponse heartGraph, EmergencyHistoryResponse emergencyHistory) {
+        return new HeartGraphPageResponse(heartGraph, emergencyHistory);
+    }
+}

--- a/backend/widyu-api/src/main/java/com/widyu/heart/dto/response/HeartGraphResponse.java
+++ b/backend/widyu-api/src/main/java/com/widyu/heart/dto/response/HeartGraphResponse.java
@@ -1,0 +1,22 @@
+package com.widyu.heart.dto.response;
+
+import java.util.List;
+
+public record HeartGraphResponse(
+        HeartGraphCurrentResponse current,
+        HeartRateEventResponse firstEmergency, // 최초 조회 시에만 포함 (갱신 시 null)
+        List<HeartRateEventResponse> events
+) {
+    public static HeartGraphResponse forInitial(
+            HeartGraphCurrentResponse current,
+            HeartRateEventResponse firstEmergency,
+            List<HeartRateEventResponse> events) {
+        return new HeartGraphResponse(current, firstEmergency, events);
+    }
+
+    public static HeartGraphResponse forRefresh(
+            HeartGraphCurrentResponse current,
+            List<HeartRateEventResponse> events) {
+        return new HeartGraphResponse(current, null, events);
+    }
+}

--- a/backend/widyu-api/src/main/java/com/widyu/heart/dto/response/HeartRateEventResponse.java
+++ b/backend/widyu-api/src/main/java/com/widyu/heart/dto/response/HeartRateEventResponse.java
@@ -1,0 +1,13 @@
+package com.widyu.heart.dto.response;
+
+import com.widyu.heart.HeartRateEvent;
+import java.time.LocalDateTime;
+
+public record HeartRateEventResponse(
+        Integer heartRate,
+        LocalDateTime measuredAt
+) {
+    public static HeartRateEventResponse from(HeartRateEvent event) {
+        return new HeartRateEventResponse(event.getHeartRate(), event.getMeasuredAt());
+    }
+}

--- a/backend/widyu-api/src/main/java/com/widyu/heart/repository/HeartRateEmergencyRepository.java
+++ b/backend/widyu-api/src/main/java/com/widyu/heart/repository/HeartRateEmergencyRepository.java
@@ -1,0 +1,17 @@
+package com.widyu.heart.repository;
+
+import com.widyu.heart.HeartRateEmergency;
+import java.util.List;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface HeartRateEmergencyRepository extends JpaRepository<HeartRateEmergency, Long> {
+
+    List<HeartRateEmergency> findByMemberIdOrderByMeasuredAtDesc(Long memberId);
+
+    Optional<HeartRateEmergency> findFirstByMemberIdOrderByMeasuredAtAsc(Long memberId);
+
+    long countByMemberId(Long memberId);
+}

--- a/backend/widyu-api/src/main/java/com/widyu/heart/repository/HeartRateEventRepository.java
+++ b/backend/widyu-api/src/main/java/com/widyu/heart/repository/HeartRateEventRepository.java
@@ -1,0 +1,34 @@
+package com.widyu.heart.repository;
+
+import com.widyu.heart.HeartRateEvent;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface HeartRateEventRepository extends JpaRepository<HeartRateEvent, Long> {
+
+    List<HeartRateEvent> findByMemberIdOrderByMeasuredAtAsc(Long memberId);
+
+    List<HeartRateEvent> findTop5ByMemberIdOrderByMeasuredAtDesc(Long memberId);
+
+    List<HeartRateEvent> findTop15ByMemberIdOrderByMeasuredAtDesc(Long memberId);
+
+    @Query("SELECT MAX(h.heartRate) FROM HeartRateEvent h WHERE h.member.id = :memberId")
+    Optional<Integer> findMaxHeartRateByMemberId(@Param("memberId") Long memberId);
+
+    @Query("SELECT MIN(h.heartRate) FROM HeartRateEvent h WHERE h.member.id = :memberId")
+    Optional<Integer> findMinHeartRateByMemberId(@Param("memberId") Long memberId);
+
+    @Query("SELECT TIMESTAMPDIFF(MINUTE, MIN(h.measuredAt), MAX(h.measuredAt)) FROM HeartRateEvent h WHERE h.member.id = :memberId")
+    Optional<Integer> findTotalDurationMinutesByMemberId(@Param("memberId") Long memberId);
+
+    @Modifying
+    @Query("DELETE FROM HeartRateEvent h WHERE h.measuredAt < :before")
+    int deleteByMeasuredAtBefore(@Param("before") LocalDateTime before);
+}

--- a/backend/widyu-api/src/main/java/com/widyu/heart/scheduler/HeartRateCleanupScheduler.java
+++ b/backend/widyu-api/src/main/java/com/widyu/heart/scheduler/HeartRateCleanupScheduler.java
@@ -1,0 +1,31 @@
+package com.widyu.heart.scheduler;
+
+import com.widyu.heart.repository.HeartRateEventRepository;
+import java.time.LocalDateTime;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class HeartRateCleanupScheduler {
+
+    private static final int RETENTION_DAYS = 30;
+
+    private final HeartRateEventRepository heartRateEventRepository;
+
+    /**
+     * 매일 새벽 3시 실행: 30일 이상 지난 심박수 이벤트 삭제
+     * HeartRateEmergency(위급상황 기록)는 안전 기록이므로 삭제하지 않음
+     */
+    @Scheduled(cron = "0 0 3 * * *")
+    @Transactional
+    public void deleteOldHeartRateEvents() {
+        LocalDateTime cutoff = LocalDateTime.now().minusDays(RETENTION_DAYS);
+        int deleted = heartRateEventRepository.deleteByMeasuredAtBefore(cutoff);
+        log.info("심박수 이벤트 정리 완료 - {}일 이전 데이터 {}건 삭제", RETENTION_DAYS, deleted);
+    }
+}

--- a/backend/widyu-api/src/main/java/com/widyu/location/realtime/controller/RealtimeLocationController.java
+++ b/backend/widyu-api/src/main/java/com/widyu/location/realtime/controller/RealtimeLocationController.java
@@ -5,10 +5,12 @@ import com.widyu.location.realtime.application.RealtimeLocationService;
 import com.widyu.location.realtime.dto.LocationUpdateRequest;
 import com.widyu.location.realtime.dto.LocationUpdateResponse;
 import jakarta.validation.Valid;
+import java.util.Map;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.messaging.handler.annotation.MessageMapping;
 import org.springframework.messaging.handler.annotation.Payload;
+import org.springframework.messaging.simp.SimpMessageHeaderAccessor;
 import org.springframework.messaging.simp.annotation.SendToUser;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.stereotype.Controller;
@@ -28,21 +30,28 @@ public class RealtimeLocationController {
     @SendToUser("/queue/location/ack")
     public LocationUpdateResponse updateLocation(
             @Valid @Payload LocationUpdateRequest request,
-            @AuthenticationPrincipal PrincipalDetails principal
+            @AuthenticationPrincipal PrincipalDetails principal,
+            SimpMessageHeaderAccessor headerAccessor
     ) {
+        Long authenticatedMemberId = resolveMemberId(principal, headerAccessor);
         log.info("위치 업데이트 수신 - authenticatedMemberId: {}, requestMemberId: {}, lat: {}, lng: {}",
-                 principal.getUsername(), request.memberId(),
+                 authenticatedMemberId, request.memberId(),
                  request.latitude(), request.longitude());
 
-        // 시니어 본인 확인 (선택적 보안 강화)
-        Long authenticatedMemberId = Long.parseLong(principal.getUsername());
+        return realtimeLocationService.updateAndBroadcast(request, authenticatedMemberId);
+    }
 
-        // 위치 저장 및 브로드캐스트
-        LocationUpdateResponse response = realtimeLocationService.updateAndBroadcast(
-                request, authenticatedMemberId
-        );
+    private Long resolveMemberId(PrincipalDetails principal, SimpMessageHeaderAccessor headerAccessor) {
+        if (principal != null && principal.getMemberId() != null) {
+            return principal.getMemberId();
+        }
 
-        // 시니어에게 ACK 전송 (선택사항)
-        return response;
+        Map<String, Object> sessionAttributes = headerAccessor.getSessionAttributes();
+        if (sessionAttributes != null && sessionAttributes.get("memberId") instanceof Long memberId) {
+            log.debug("세션 속성에서 memberId 조회 - memberId: {}", memberId);
+            return memberId;
+        }
+
+        throw new IllegalStateException("인증 정보가 없습니다. WebSocket 연결 시 유효한 JWT 토큰이 필요합니다.");
     }
 }

--- a/backend/widyu-domain/src/main/java/com/widyu/heart/HeartRateEmergency.java
+++ b/backend/widyu-domain/src/main/java/com/widyu/heart/HeartRateEmergency.java
@@ -1,0 +1,60 @@
+package com.widyu.heart;
+
+import com.widyu.global.entity.BaseTimeEntity;
+import com.widyu.member.Member;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import java.time.LocalDateTime;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@Table(name = "heart_rate_emergency")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class HeartRateEmergency extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "heart_rate_emergency_id")
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id", nullable = false)
+    private Member member;
+
+    @Column(name = "heart_rate", nullable = false)
+    private Integer heartRate;
+
+    @Column(name = "measured_at", nullable = false)
+    private LocalDateTime measuredAt;
+
+    @Column(name = "location", length = 500)
+    private String location;
+
+    @Builder(access = AccessLevel.PRIVATE)
+    private HeartRateEmergency(Member member, Integer heartRate, LocalDateTime measuredAt, String location) {
+        this.member = member;
+        this.heartRate = heartRate;
+        this.measuredAt = measuredAt;
+        this.location = location;
+    }
+
+    public static HeartRateEmergency of(Member member, Integer heartRate, LocalDateTime measuredAt, String location) {
+        return HeartRateEmergency.builder()
+                .member(member)
+                .heartRate(heartRate)
+                .measuredAt(measuredAt)
+                .location(location)
+                .build();
+    }
+}

--- a/backend/widyu-domain/src/main/java/com/widyu/heart/HeartRateEvent.java
+++ b/backend/widyu-domain/src/main/java/com/widyu/heart/HeartRateEvent.java
@@ -1,0 +1,63 @@
+package com.widyu.heart;
+
+import com.widyu.global.entity.BaseTimeEntity;
+import com.widyu.member.Member;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import java.time.LocalDateTime;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@Table(name = "heart_rate_event")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class HeartRateEvent extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "heart_rate_event_id")
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id", nullable = false)
+    private Member member;
+
+    @Column(name = "heart_rate", nullable = false)
+    private Integer heartRate;
+
+    @Column(name = "measured_at", nullable = false)
+    private LocalDateTime measuredAt;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "status", nullable = false)
+    private HeartRateStatus status;
+
+    @Builder(access = AccessLevel.PRIVATE)
+    private HeartRateEvent(Member member, Integer heartRate, LocalDateTime measuredAt, HeartRateStatus status) {
+        this.member = member;
+        this.heartRate = heartRate;
+        this.measuredAt = measuredAt;
+        this.status = status;
+    }
+
+    public static HeartRateEvent of(Member member, Integer heartRate, LocalDateTime measuredAt, HeartRateStatus status) {
+        return HeartRateEvent.builder()
+                .member(member)
+                .heartRate(heartRate)
+                .measuredAt(measuredAt)
+                .status(status)
+                .build();
+    }
+}

--- a/websocket-test.html
+++ b/websocket-test.html
@@ -70,7 +70,7 @@
         <button class="btn-send" onclick="seniorSendLocation()">위치 전송</button>
       </div>
 
-      <!-- 심박수 전송 -->
+      <!-- 심박수 전송 (15개) -->
       <div class="section">
         <h3>심박수 전송 <code>/app/heart-rate/send</code></h3>
         <label>심박수 데이터 (정확히 15개)</label>
@@ -118,13 +118,13 @@
         <button class="btn-disconnect" onclick="guardianDisconnect()">해제</button>
       </div>
 
-      <!-- 시니어 위치 구독 -->
+      <!-- 시니어 구독 (위치 + 심박수 동시) -->
       <div class="section">
-        <h3>시니어 위치 구독 <code>/topic/location/senior/{memberId}</code></h3>
+        <h3>시니어 구독 <code>/topic/location/senior/{id}</code> + <code>/topic/heart-rate/{id}</code></h3>
         <label>구독할 시니어 memberId</label>
         <div class="row" style="align-items:center">
           <input id="guardian-seniorId" placeholder="시니어 memberId" style="width:180px" />
-          <button class="btn-send" onclick="guardianSubscribeLocation()">구독</button>
+          <button class="btn-send" onclick="guardianSubscribe()">구독</button>
         </div>
         <div id="guardian-subscribed" style="font-size:12px; color:#808080; margin-top:4px"></div>
       </div>
@@ -141,7 +141,8 @@
   <script>
     let seniorClient   = null;
     let guardianClient = null;
-    let guardianLocationSub = null;
+    let guardianLocationSub  = null;
+    let guardianHeartRateSub = null;
 
     /* ── 공통 유틸 ── */
     function appendLog(logId, msg, type = 'info') {
@@ -168,7 +169,6 @@
         onConnect: () => {
           setBadge(badgeId, true);
           appendLog(logId, 'WebSocket 연결 성공', 'info');
-          // 공통 개인 큐 구독
           client.subscribe('/user/queue/location/ack', (msg) => {
             appendLog(logId, '위치 ACK: ' + prettyJson(msg.body), 'recv');
           });
@@ -233,20 +233,29 @@
       appendLog('guardian-log', '연결 시도 중... ' + url, 'info');
     }
     function guardianDisconnect() {
-      if (guardianClient) { guardianClient.deactivate(); guardianClient = null; guardianLocationSub = null; }
+      if (guardianClient) { guardianClient.deactivate(); guardianClient = null; guardianLocationSub = null; guardianHeartRateSub = null; }
       document.getElementById('guardian-subscribed').textContent = '';
     }
-    function guardianSubscribeLocation() {
+    function guardianSubscribe() {
       if (!guardianClient?.connected) { alert('보호자를 먼저 연결하세요.'); return; }
       const seniorId = document.getElementById('guardian-seniorId').value.trim();
       if (!seniorId) { alert('시니어 memberId를 입력하세요.'); return; }
-      if (guardianLocationSub) { guardianLocationSub.unsubscribe(); }
-      const dest = `/topic/location/senior/${seniorId}`;
-      guardianLocationSub = guardianClient.subscribe(dest, (msg) => {
-        appendLog('guardian-log', `[시니어 ${seniorId}] 위치 수신: ` + prettyJson(msg.body), 'recv');
+      if (guardianLocationSub)  { guardianLocationSub.unsubscribe(); }
+      if (guardianHeartRateSub) { guardianHeartRateSub.unsubscribe(); }
+
+      const locationDest  = `/topic/location/senior/${seniorId}`;
+      const heartRateDest = `/topic/heart-rate/${seniorId}`;
+
+      guardianLocationSub = guardianClient.subscribe(locationDest, (msg) => {
+        appendLog('guardian-log', `[위치] ` + prettyJson(msg.body), 'recv');
       });
-      document.getElementById('guardian-subscribed').textContent = '구독 중: ' + dest;
-      appendLog('guardian-log', '위치 구독 시작: ' + dest, 'info');
+      guardianHeartRateSub = guardianClient.subscribe(heartRateDest, (msg) => {
+        appendLog('guardian-log', `[심박수] ` + prettyJson(msg.body), 'recv');
+      });
+
+      document.getElementById('guardian-subscribed').textContent = `구독 중: 위치 + 심박수 (시니어 ${seniorId})`;
+      appendLog('guardian-log', `위치 구독: ${locationDest}`, 'info');
+      appendLog('guardian-log', `심박수 구독: ${heartRateDest}`, 'info');
     }
   </script>
 </body>


### PR DESCRIPTION


## #️⃣연관된 이슈
>PR과 연관된 이슈 번호를 작성해주세요. ex) #이슈 번호, #이슈 번호

- close: #209

## 🪄작업 내용
- HeartRateEvent, HeartRateEmergency JPA 엔티티 추가
- 심박수 그래프 최초 조회(GET /graph), 갱신(GET /graph/refresh) API 추가
- 심박수 전송 시 /topic/heart-rate/{memberId} 로 보호자에게 브로드캐스트
- WebSocket 인증: PrincipalDetails getMemberId() 추가, JwtChannelInterceptor null 체크
- HeartRateWebSocketController, RealtimeLocationController resolveMemberId() fallback 추가
- 심박수 이벤트 30일 보존 스케줄러 추가 (매일 새벽 3시 실행)
- websocket-test.html 보호자 위치+심박수 구독 버튼 통합


## 💖리뷰 요청사항
>특별히 봐주셨으면 하는 부분, 나 좀 잘했다 하는 부분! 기타 당부의 말씀 등 자유롭게 작성해주세요.

-
