### PR TITLE
영상 업로드 파이프라인 비동기화

### DIFF
--- a/backend/widyu-api/src/main/java/com/widyu/album/application/AlbumFacade.java
+++ b/backend/widyu-api/src/main/java/com/widyu/album/application/AlbumFacade.java
@@ -5,6 +5,7 @@ import com.widyu.album.dto.request.AlbumUploadRequest;
 import com.widyu.album.dto.response.AlbumDetailResponse;
 import com.widyu.album.dto.response.AlbumFeedResponse;
 import com.widyu.album.dto.response.AlbumUnlockResponse;
+import com.widyu.album.dto.response.AlbumUploadAcceptedResponse;
 import com.widyu.album.dto.response.AlbumUploadResponse;
 import com.widyu.album.dto.response.LikedAlbumsResponse;
 import com.widyu.album.dto.response.AlbumMediaResponse;
@@ -17,9 +18,9 @@ import com.widyu.global.dto.CursorPage;
 public interface AlbumFacade {
 
     /**
-     * 앨범 업로드
+     * 앨범 업로드 (비동기) - 즉시 albumId 반환, 미디어 처리는 백그라운드 수행
      */
-    AlbumUploadResponse uploadAlbum(AlbumUploadRequest request);
+    AlbumUploadAcceptedResponse uploadAlbum(AlbumUploadRequest request);
 
     /**
      * 앨범 피드 조회 (무한 스크롤)

--- a/backend/widyu-api/src/main/java/com/widyu/album/application/AlbumFacadeImpl.java
+++ b/backend/widyu-api/src/main/java/com/widyu/album/application/AlbumFacadeImpl.java
@@ -6,35 +6,90 @@ import com.widyu.album.dto.request.AlbumUploadRequest;
 import com.widyu.album.dto.response.AlbumDetailResponse;
 import com.widyu.album.dto.response.AlbumFeedResponse;
 import com.widyu.album.dto.response.AlbumUnlockResponse;
+import com.widyu.album.dto.response.AlbumUploadAcceptedResponse;
 import com.widyu.album.dto.response.AlbumUploadResponse;
 import com.widyu.album.dto.response.LikedAlbumsResponse;
 import com.widyu.album.dto.response.AlbumMediaResponse;
 import com.widyu.global.dto.CursorPage;
+import com.widyu.global.error.BusinessException;
+import com.widyu.global.error.ErrorCode;
+import com.widyu.global.util.MemberUtil;
+import com.widyu.member.Member;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
 
 /**
  * 앨범 도메인 파사드 구현체
- * 
- * 여러 서비스들을 조합하여 앨범 도메인의 모든 기능을 제공하는 파사드 패턴 구현
- * - AlbumUploadService: 업로드 처리
- * - AlbumFeedService: 피드 조회 처리  
- * - AlbumService: 수정/삭제 처리
  */
 @Slf4j
 @Service
 @RequiredArgsConstructor
 public class AlbumFacadeImpl implements AlbumFacade {
-    
+
     private final AlbumFeedService albumFeedService;
     private final AlbumService albumService;
     private final AlbumLikeService albumLikeService;
     private final AlbumUnlockService albumUnlockService;
+    private final AlbumFileService albumFileService;
+    private final AlbumMediaPolicy mediaPolicy;
+    private final AlbumVideoProcessingService albumVideoProcessingService;
+    private final MemberUtil memberUtil;
 
     @Override
-    public AlbumUploadResponse uploadAlbum(AlbumUploadRequest request) {
-        return albumService.uploadAlbum(request);
+    public AlbumUploadAcceptedResponse uploadAlbum(AlbumUploadRequest request) {
+        Member currentMember = memberUtil.getCurrentMember();
+        mediaPolicy.validate(request.mediaFiles());
+
+        List<String> mediaUrls = new ArrayList<>();
+        List<String> thumbnailUrls = new ArrayList<>();
+        List<Integer> durations = new ArrayList<>();
+        List<AlbumVideoProcessingService.VideoEntry> videoEntries = new ArrayList<>();
+
+        for (int i = 0; i < request.mediaFiles().size(); i++) {
+            MultipartFile file = request.mediaFiles().get(i);
+            String contentType = file.getContentType();
+
+            if (contentType == null) {
+                throw new BusinessException(ErrorCode.INVALID_FILE_TYPE);
+            }
+
+            if (contentType.startsWith("image/")) {
+                String url = albumFileService.uploadAlbumPhoto(file, currentMember.getId());
+                mediaUrls.add(url);
+                thumbnailUrls.add(null);
+                durations.add(null);
+            } else if (contentType.startsWith("video/")) {
+                try {
+                    File tempFile = albumFileService.toTempFile(file);
+                    videoEntries.add(new AlbumVideoProcessingService.VideoEntry(
+                            i, tempFile, file.getOriginalFilename(), contentType));
+                    mediaUrls.add("");
+                    thumbnailUrls.add(null);
+                    durations.add(null);
+                } catch (IOException e) {
+                    throw new BusinessException(ErrorCode.FILE_UPLOAD_FAILED);
+                }
+            } else {
+                throw new BusinessException(ErrorCode.INVALID_FILE_TYPE);
+            }
+        }
+
+        boolean hasVideos = !videoEntries.isEmpty();
+        Long albumId = albumService.saveAlbum(
+                currentMember, request.content(), mediaUrls, thumbnailUrls, durations, hasVideos);
+
+        if (hasVideos) {
+            albumVideoProcessingService.processVideosAsync(albumId, currentMember.getId(), videoEntries);
+        }
+
+        return new AlbumUploadAcceptedResponse(albumId);
     }
 
     @Override

--- a/backend/widyu-api/src/main/java/com/widyu/album/application/AlbumFileService.java
+++ b/backend/widyu-api/src/main/java/com/widyu/album/application/AlbumFileService.java
@@ -223,7 +223,7 @@ public class AlbumFileService {
         }
     }
 
-    private File toTempFile(MultipartFile file) throws IOException {
+    File toTempFile(MultipartFile file) throws IOException {
         String ext = guessExtByContentType(file.getContentType());
         Path tmp = Files.createTempFile("source_" + UUID.randomUUID(), ext.isEmpty() ? "" : "." + ext);
         Files.copy(file.getInputStream(), tmp, java.nio.file.StandardCopyOption.REPLACE_EXISTING);

--- a/backend/widyu-api/src/main/java/com/widyu/album/application/AlbumService.java
+++ b/backend/widyu-api/src/main/java/com/widyu/album/application/AlbumService.java
@@ -1,7 +1,6 @@
 package com.widyu.album.application;
 
 import com.widyu.album.dto.request.AlbumUpdateRequest;
-import com.widyu.album.dto.request.AlbumUploadRequest;
 import com.widyu.album.dto.response.AlbumDetailResponse;
 import com.widyu.album.dto.response.AlbumUploadResponse;
 import com.widyu.album.Album;
@@ -28,42 +27,25 @@ public class AlbumService {
 
     private final AlbumRepository albumRepository;
     private final AlbumCommentRepository albumCommentRepository;
-    private final AlbumFileService albumFileService;
     private final AlbumViewService albumViewService;
     private final AlbumPermissionService albumPermissionService;
     private final MemberUtil memberUtil;
-    private final AlbumMediaPolicy mediaPolicy;
     private final ApplicationEventPublisher eventPublisher;
 
     @Transactional
-    public AlbumUploadResponse uploadAlbum(AlbumUploadRequest request) {
-        // 1) 사용자
-        Member currentMember = memberUtil.getCurrentMember();
-
-        // 2) 정책 검증(개수/타입/용량)
-        mediaPolicy.validate(request.mediaFiles());
-
-        // 3) 업로드 (이미지/비디오+썸네일/길이)
-        AlbumFileService.UploadResult uploadResult =
-                albumFileService.uploadMediaFilesWithThumbnails(request.mediaFiles(), currentMember.getId());
-
-        // 4) 앨범 저장
-        Album album = Album.createAlbumWithMetadata(
-                currentMember,
-                request.content(),
-                uploadResult.mediaUrls(),
-                uploadResult.thumbnailUrls(),
-                uploadResult.durations()
-        );
+    public Long saveAlbum(Member member, String content,
+                          List<String> mediaUrls, List<String> thumbnailUrls, List<Integer> durations,
+                          boolean hasVideos) {
+        Album album = hasVideos
+                ? Album.createAlbumForProcessing(member, content, mediaUrls, thumbnailUrls, durations)
+                : Album.createAlbumWithMetadata(member, content, mediaUrls, thumbnailUrls, durations);
         Album saved = albumRepository.save(album);
 
-        // 앨범 작성 알림 이벤트 발행
-        eventPublisher.publishEvent(new AlbumCreatedEvent(
-                saved.getId(),
-                currentMember.getId()
-        ));
+        if (!hasVideos) {
+            eventPublisher.publishEvent(new AlbumCreatedEvent(saved.getId(), member.getId()));
+        }
 
-        return AlbumUploadResponse.from(saved);
+        return saved.getId();
     }
 
     @Transactional

--- a/backend/widyu-api/src/main/java/com/widyu/album/application/AlbumVideoProcessingService.java
+++ b/backend/widyu-api/src/main/java/com/widyu/album/application/AlbumVideoProcessingService.java
@@ -1,0 +1,91 @@
+package com.widyu.album.application;
+
+import com.widyu.album.Album;
+import com.widyu.album.repository.AlbumRepository;
+import com.widyu.fcm.event.album.dto.AlbumCreatedEvent;
+import com.widyu.global.error.BusinessException;
+import com.widyu.global.error.ErrorCode;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.jetbrains.annotations.NotNull;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class AlbumVideoProcessingService {
+
+    private final AlbumRepository albumRepository;
+    private final AlbumFileService albumFileService;
+    private final ApplicationEventPublisher eventPublisher;
+
+    public record VideoEntry(int index, File tempFile, String originalFileName, String contentType) {}
+
+    @Async
+    @Transactional
+    public void processVideosAsync(Long albumId, Long memberId, List<VideoEntry> videoEntries) {
+        Map<Integer, String> videoUrls = new HashMap<>();
+        Map<Integer, String> thumbnailUrls = new HashMap<>();
+        Map<Integer, Integer> durations = new HashMap<>();
+
+        try {
+            for (VideoEntry entry : videoEntries) {
+                MultipartFile videoFile = wrapFile(entry.tempFile(), entry.originalFileName(), entry.contentType());
+                AlbumFileService.VideoUploadResult result = albumFileService.uploadAlbumVideoWithThumbnail(videoFile, memberId);
+                videoUrls.put(entry.index(), result.videoUrl());
+                thumbnailUrls.put(entry.index(), result.thumbnailUrl());
+                durations.put(entry.index(), result.duration());
+            }
+
+            Album album = albumRepository.findById(albumId)
+                    .orElseThrow(() -> new BusinessException(ErrorCode.ALBUM_NOT_FOUND));
+            album.completeVideoProcessing(videoUrls, thumbnailUrls, durations);
+
+            eventPublisher.publishEvent(new AlbumCreatedEvent(albumId, memberId));
+            log.info("비디오 비동기 처리 완료: albumId={}", albumId);
+
+        } catch (Exception e) {
+            log.error("비디오 비동기 처리 실패: albumId={}, error={}", albumId, e.getMessage(), e);
+            albumRepository.findById(albumId).ifPresent(Album::delete);
+        } finally {
+            for (VideoEntry entry : videoEntries) {
+                try {
+                    Files.deleteIfExists(entry.tempFile().toPath());
+                } catch (IOException ignored) {
+                    log.warn("비디오 임시 파일 삭제 실패: path={}", entry.tempFile().getAbsolutePath());
+                }
+            }
+        }
+    }
+
+    private MultipartFile wrapFile(File file, String originalName, String contentType) {
+        final Path path = file.toPath();
+        return new MultipartFile() {
+            @NotNull
+            @Override public String getName() { return "file"; }
+            @Override public String getOriginalFilename() { return originalName; }
+            @Override public String getContentType() { return contentType; }
+            @Override public boolean isEmpty() { return file.length() == 0; }
+            @Override public long getSize() { return file.length(); }
+            @NotNull
+            @Override public byte[] getBytes() throws IOException { return Files.readAllBytes(path); }
+            @NotNull
+            @Override public InputStream getInputStream() throws IOException { return new FileInputStream(file); }
+            @Override public void transferTo(@NotNull File dest) throws IOException { Files.copy(path, dest.toPath()); }
+        };
+    }
+}

--- a/backend/widyu-api/src/main/java/com/widyu/album/controller/AlbumController.java
+++ b/backend/widyu-api/src/main/java/com/widyu/album/controller/AlbumController.java
@@ -7,6 +7,7 @@ import com.widyu.album.dto.request.AlbumUploadRequest;
 import com.widyu.album.dto.response.AlbumDetailResponse;
 import com.widyu.album.dto.response.AlbumFeedResponse;
 import com.widyu.album.dto.response.AlbumUnlockResponse;
+import com.widyu.album.dto.response.AlbumUploadAcceptedResponse;
 import com.widyu.album.dto.response.AlbumUploadResponse;
 import com.widyu.album.dto.response.LikedAlbumsResponse;
 import com.widyu.album.dto.response.AlbumMediaResponse;
@@ -14,7 +15,9 @@ import com.widyu.global.dto.CursorPage;
 import com.widyu.global.response.ApiResponseTemplate;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.ModelAttribute;
@@ -35,15 +38,16 @@ public class AlbumController implements AlbumDocs {
 
     @Override
     @PostMapping(value = "/upload", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
-    public ApiResponseTemplate<AlbumUploadResponse> uploadAlbum(
+    public ResponseEntity<ApiResponseTemplate<AlbumUploadAcceptedResponse>> uploadAlbum(
             @ModelAttribute @Valid AlbumUploadRequest request
     ) {
-        AlbumUploadResponse response = albumFacade.uploadAlbum(request);
-        
-        return ApiResponseTemplate.ok()
-                .code("ALBM_2001")
-                .message("앨범 업로드가 완료되었습니다.")
-                .body(response);
+        AlbumUploadAcceptedResponse response = albumFacade.uploadAlbum(request);
+
+        return ResponseEntity.status(HttpStatus.ACCEPTED)
+                .body(ApiResponseTemplate.ok()
+                        .code("ALBM_2001")
+                        .message("앨범 업로드 요청이 접수되었습니다.")
+                        .body(response));
     }
 
     @Override

--- a/backend/widyu-api/src/main/java/com/widyu/album/controller/docs/AlbumDocs.java
+++ b/backend/widyu-api/src/main/java/com/widyu/album/controller/docs/AlbumDocs.java
@@ -5,11 +5,13 @@ import com.widyu.album.dto.request.AlbumUploadRequest;
 import com.widyu.album.dto.response.AlbumDetailResponse;
 import com.widyu.album.dto.response.AlbumFeedResponse;
 import com.widyu.album.dto.response.AlbumUnlockResponse;
+import com.widyu.album.dto.response.AlbumUploadAcceptedResponse;
 import com.widyu.album.dto.response.AlbumUploadResponse;
 import com.widyu.album.dto.response.LikedAlbumsResponse;
 import com.widyu.album.dto.response.AlbumMediaResponse;
 import com.widyu.global.dto.CursorPage;
 import com.widyu.global.response.ApiResponseTemplate;
+import org.springframework.http.ResponseEntity;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Content;
@@ -124,7 +126,7 @@ public interface AlbumDocs {
                     )
             )
     })
-    ApiResponseTemplate<AlbumUploadResponse> uploadAlbum(@Valid AlbumUploadRequest request);
+    ResponseEntity<ApiResponseTemplate<AlbumUploadAcceptedResponse>> uploadAlbum(@Valid AlbumUploadRequest request);
 
     // ========== 앨범 피드 조회 ==========
     

--- a/backend/widyu-api/src/main/java/com/widyu/album/dto/response/AlbumUploadAcceptedResponse.java
+++ b/backend/widyu-api/src/main/java/com/widyu/album/dto/response/AlbumUploadAcceptedResponse.java
@@ -1,0 +1,4 @@
+package com.widyu.album.dto.response;
+
+public record AlbumUploadAcceptedResponse(Long albumId) {
+}

--- a/backend/widyu-api/src/main/java/com/widyu/global/infrastructure/s3/S3ServiceImpl.java
+++ b/backend/widyu-api/src/main/java/com/widyu/global/infrastructure/s3/S3ServiceImpl.java
@@ -14,7 +14,6 @@ import org.springframework.web.multipart.MultipartFile;
 import software.amazon.awssdk.core.sync.RequestBody;
 import software.amazon.awssdk.services.s3.S3Client;
 import software.amazon.awssdk.services.s3.model.DeleteObjectRequest;
-import software.amazon.awssdk.services.s3.model.ObjectCannedACL;
 import software.amazon.awssdk.services.s3.model.PutObjectRequest;
 
 @Slf4j
@@ -31,7 +30,6 @@ public class S3ServiceImpl implements S3Service {
             PutObjectRequest putObjectRequest = PutObjectRequest.builder()
                     .bucket(s3Properties.s3().bucketName())
                     .key(filePath)
-                    .acl(ObjectCannedACL.PUBLIC_READ)
                     .contentType(file.getContentType())
                     .build();
 

--- a/backend/widyu-domain/src/main/java/com/widyu/album/Album.java
+++ b/backend/widyu-domain/src/main/java/com/widyu/album/Album.java
@@ -20,6 +20,7 @@ import jakarta.persistence.OneToMany;
 import jakarta.persistence.OrderColumn;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
@@ -106,6 +107,32 @@ public class Album extends BaseTimeEntity {
                 .thumbnailUrls(thumbnailUrls)
                 .durations(durations)
                 .build();
+    }
+
+    public static Album createAlbumForProcessing(Member member, String content, List<String> mediaUrls, List<String> thumbnailUrls, List<Integer> durations) {
+        return Album.builder()
+                .member(member)
+                .content(content)
+                .mediaUrls(mediaUrls)
+                .thumbnailUrls(thumbnailUrls)
+                .durations(durations)
+                .status(Status.PROCESSING)
+                .build();
+    }
+
+    public void completeVideoProcessing(Map<Integer, String> videoUrlsByIndex,
+                                        Map<Integer, String> thumbnailUrlsByIndex,
+                                        Map<Integer, Integer> durationsByIndex) {
+        for (Map.Entry<Integer, String> entry : videoUrlsByIndex.entrySet()) {
+            this.mediaUrls.set(entry.getKey(), entry.getValue());
+        }
+        for (Map.Entry<Integer, String> entry : thumbnailUrlsByIndex.entrySet()) {
+            this.thumbnailUrls.set(entry.getKey(), entry.getValue());
+        }
+        for (Map.Entry<Integer, Integer> entry : durationsByIndex.entrySet()) {
+            this.durations.set(entry.getKey(), entry.getValue());
+        }
+        this.status = Status.ACTIVE;
     }
 
     public int getPhotoCount() {

--- a/backend/widyu-domain/src/main/java/com/widyu/global/entity/Status.java
+++ b/backend/widyu-domain/src/main/java/com/widyu/global/entity/Status.java
@@ -3,7 +3,8 @@ package com.widyu.global.entity;
 public enum Status {
     ACTIVE("활성화"),
     INACTIVE("비활성화"),
-    DELETED("삭제");
+    DELETED("삭제"),
+    PROCESSING("처리중");
 
     Status(String description) {
     }


### PR DESCRIPTION
  ## #️연관된 이슈
  - close: #226                                                                                                                                                                                                                          
               
  ## 🪄작업 내용                                                                                                                                                                                                                         
  - 사진은 즉시 S3 업로드, 영상은 @Async 백그라운드 스레드에서 FFmpeg 처리 및 S3 업로드하도록 분리
  - 영상 포함 여부에 따라 Album 저장 시 PROCESSING / ACTIVE 상태 분기                             
  - 비동기 처리 완료 시 FCM 푸시 알림 발행 (클라이언트 폴링 불필요)                                                                                                                                                                      
  - API 응답을 202 Accepted로 변경, albumId 즉시 반환              
  - Status enum에 PROCESSING 값 추가                                                                                                                                                                                                     
  - S3 업로드 시 ObjectCannedACL.PUBLIC_READ 제거 (버킷 정책 방식으로 전환)                                                                                                                                                              
                                                                                                                                                                                                                                         
  ## 💖리뷰 요청사항                                                                                                                                                                                                                     
  - 280MB 영상 기준 API 응답 시간 9.25s → 4.31s, 약 53% 단축 (로컬 환경 10회 실측)   