### PR TITLE
ffmpeg 경로 변경

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -75,6 +75,10 @@ services:
       SWAGGER_VERSION: ${SWAGGER_VERSION}
       SWAGGER_URL: ${SWAGGER_URL}
 
+      # FFmpeg (공통)
+      FFMPEG_PATH: ${FFMPEG_PATH}
+      FFPROBE_PATH: ${FFPROBE_PATH}
+
       # AI Server (공통)
       AI_SERVER_URL: ${AI_SERVER_URL:-http://widyu-ai:5000}
 


### PR DESCRIPTION
## 연관된 이슈                                                                                                                                                                                             
                                                                                                                                                                                                               
  - close: #232                                                                                                                                                                                                
                                                                                                                                                                                                               
  ## 🪄작업 내용
                                                                                                                                                                                                               
  - EC2 Docker 컨테이너에서 FFmpeg 경로 불일치로 앱 기동 실패하는 버그 수정                                                                                                                                    
  - `docker-compose.yml` 공통 설정에 `FFMPEG_PATH`, `FFPROBE_PATH` 환경변수 추가
  - EC2 `.env`에 `/usr/bin/ffmpeg`, `/usr/bin/ffprobe` 설정하면 적용됨                                                                                                                                         
                                                                                                                                                                                                               
  ## 💖리뷰 요청사항                                                                                                                                                                                           
                                                                                                                                                                                                               
  - Alpine Linux 컨테이너 기준 FFmpeg 경로 `/usr/bin/ffmpeg`로 `.env`에 설정 필요   