### PR TITLE
Refactor/#239

### DIFF
--- a/backend/widyu-api/src/main/java/com/widyu/mypage/application/GuardianMyPageService.java
+++ b/backend/widyu-api/src/main/java/com/widyu/mypage/application/GuardianMyPageService.java
@@ -100,12 +100,17 @@ public class GuardianMyPageService {
         MyPageProfileService.updateMemberProfileImage(s3Service, seniorProfile.getMember(), image);
     }
 
-    public FamilyMemberListResponse getFamilyMembers(Long seniorId) {
+    public FamilyMemberListResponse getFamilyMembers() {
         Member guardian = MyPageProfileService.getCurrentMember(memberUtil);
-        SeniorProfile seniorProfile = getSeniorProfileWithAccessCheck(seniorId, guardian.getId());
+        List<FamilyConnection> guardianConnections = familyConnectionRepository
+                .findAllByGuardianIdWithSeniorAndMember(guardian.getId());
+        if (guardianConnections.isEmpty()) {
+            throw new BusinessException(ErrorCode.MEMBER_NOT_FOUND, "연결된 가족이 없습니다.");
+        }
+        Long seniorProfileId = guardianConnections.get(0).getSenior().getId();
 
         List<FamilyConnection> connections = familyConnectionRepository
-                .findAllBySeniorIdWithGuardian(seniorProfile.getId());
+                .findAllBySeniorIdWithGuardian(seniorProfileId);
 
         return FamilyMemberListResponse.of(connections, guardian.getId());
     }

--- a/backend/widyu-api/src/main/java/com/widyu/mypage/application/GuardianMyPageService.java
+++ b/backend/widyu-api/src/main/java/com/widyu/mypage/application/GuardianMyPageService.java
@@ -9,6 +9,7 @@ import com.widyu.member.Member;
 import com.widyu.member.SeniorProfile;
 import com.widyu.member.repository.FamilyConnectionRepository;
 import com.widyu.member.repository.SeniorProfileRepository;
+import com.widyu.mypage.dto.request.UpdateInviteCodeRequest;
 import com.widyu.mypage.dto.request.UpdateNameRequest;
 import com.widyu.mypage.dto.request.UpdateSeniorAddressRequest;
 import com.widyu.mypage.dto.request.UpdatePhoneRequest;
@@ -107,6 +108,17 @@ public class GuardianMyPageService {
         SeniorProfile seniorProfile = getSeniorProfileWithAccessCheck(seniorId, guardian.getId());
         assertIsLeader(seniorProfile.getId(), guardian.getId());
         MyPageProfileService.updateMemberProfileImage(s3Service, seniorProfile.getMember(), image);
+    }
+
+    @Transactional
+    public void updateSeniorInviteCode(Long seniorId, UpdateInviteCodeRequest request) {
+        Member guardian = MyPageProfileService.getCurrentMember(memberUtil);
+        SeniorProfile seniorProfile = getSeniorProfileWithAccessCheck(seniorId, guardian.getId());
+        assertIsLeader(seniorProfile.getId(), guardian.getId());
+        if (seniorProfileRepository.existsByInviteCode(request.inviteCode())) {
+            throw new BusinessException(ErrorCode.BAD_REQUEST, "이미 사용 중인 초대코드입니다.");
+        }
+        seniorProfile.updateInviteCode(request.inviteCode());
     }
 
     public FamilyMemberListResponse getFamilyMembers() {

--- a/backend/widyu-api/src/main/java/com/widyu/mypage/application/GuardianMyPageService.java
+++ b/backend/widyu-api/src/main/java/com/widyu/mypage/application/GuardianMyPageService.java
@@ -94,9 +94,18 @@ public class GuardianMyPageService {
     }
 
     @Transactional
+    public void updateSeniorName(Long seniorId, UpdateNameRequest request) {
+        Member guardian = MyPageProfileService.getCurrentMember(memberUtil);
+        SeniorProfile seniorProfile = getSeniorProfileWithAccessCheck(seniorId, guardian.getId());
+        assertIsLeader(seniorProfile.getId(), guardian.getId());
+        seniorProfile.getMember().updateName(request.name());
+    }
+
+    @Transactional
     public void updateSeniorProfileImage(Long seniorId, MultipartFile image) {
         Member guardian = MyPageProfileService.getCurrentMember(memberUtil);
         SeniorProfile seniorProfile = getSeniorProfileWithAccessCheck(seniorId, guardian.getId());
+        assertIsLeader(seniorProfile.getId(), guardian.getId());
         MyPageProfileService.updateMemberProfileImage(s3Service, seniorProfile.getMember(), image);
     }
 
@@ -156,6 +165,12 @@ public class GuardianMyPageService {
                 .orElseThrow(() -> new BusinessException(ErrorCode.MEMBER_NOT_FOUND, "가족 구성원을 찾을 수 없습니다."));
 
         familyConnectionRepository.delete(connection);
+    }
+
+    private void assertIsLeader(Long seniorProfileId, Long guardianId) {
+        if (!familyConnectionRepository.existsBySeniorIdAndGuardianIdAndIsLeaderTrue(seniorProfileId, guardianId)) {
+            throw new BusinessException(ErrorCode.FORBIDDEN, "방장만 수정할 수 있습니다.");
+        }
     }
 
     private SeniorProfile getSeniorProfileWithAccessCheck(Long seniorMemberId, Long guardianId) {

--- a/backend/widyu-api/src/main/java/com/widyu/mypage/application/GuardianMyPageService.java
+++ b/backend/widyu-api/src/main/java/com/widyu/mypage/application/GuardianMyPageService.java
@@ -84,6 +84,7 @@ public class GuardianMyPageService {
     public void updateSeniorPhone(Long seniorId, UpdatePhoneRequest request) {
         Member guardian = MyPageProfileService.getCurrentMember(memberUtil);
         SeniorProfile seniorProfile = getSeniorProfileWithAccessCheck(seniorId, guardian.getId());
+        assertIsLeader(seniorProfile.getId(), guardian.getId());
         seniorProfile.getMember().updatePhoneNumber(request.phoneNumber());
     }
 
@@ -91,6 +92,7 @@ public class GuardianMyPageService {
     public void updateSeniorAddress(Long seniorId, UpdateSeniorAddressRequest request) {
         Member guardian = MyPageProfileService.getCurrentMember(memberUtil);
         SeniorProfile seniorProfile = getSeniorProfileWithAccessCheck(seniorId, guardian.getId());
+        assertIsLeader(seniorProfile.getId(), guardian.getId());
         seniorProfile.updateAddress(request.address(), request.detailAddress());
     }
 

--- a/backend/widyu-api/src/main/java/com/widyu/mypage/controller/GuardianMyPageController.java
+++ b/backend/widyu-api/src/main/java/com/widyu/mypage/controller/GuardianMyPageController.java
@@ -100,6 +100,17 @@ public class GuardianMyPageController implements GuardianMyPageDocs {
     }
 
     @Override
+    @PatchMapping("/seniors/{seniorId}/name")
+    public ApiResponseTemplate<Void> updateSeniorName(@PathVariable Long seniorId,
+                                                       @RequestBody @Valid UpdateNameRequest request) {
+        guardianMyPageService.updateSeniorName(seniorId, request);
+        return ApiResponseTemplate.ok()
+                .code("MYPAGE_2023")
+                .message("시니어 이름 수정 성공")
+                .build();
+    }
+
+    @Override
     @PatchMapping("/seniors/{seniorId}/phone")
     public ApiResponseTemplate<Void> updateSeniorPhone(@PathVariable Long seniorId,
                                                         @RequestBody @Valid UpdatePhoneRequest request) {

--- a/backend/widyu-api/src/main/java/com/widyu/mypage/controller/GuardianMyPageController.java
+++ b/backend/widyu-api/src/main/java/com/widyu/mypage/controller/GuardianMyPageController.java
@@ -133,12 +133,12 @@ public class GuardianMyPageController implements GuardianMyPageDocs {
     }
 
     @Override
-    @GetMapping("/family/{seniorId}/members")
-    public ApiResponseTemplate<FamilyMemberListResponse> getFamilyMembers(@PathVariable Long seniorId) {
+    @GetMapping("/family/members")
+    public ApiResponseTemplate<FamilyMemberListResponse> getFamilyMembers() {
         return ApiResponseTemplate.ok()
                 .code("MYPAGE_2019")
                 .message("가족 멤버 목록 조회 성공")
-                .body(guardianMyPageService.getFamilyMembers(seniorId));
+                .body(guardianMyPageService.getFamilyMembers());
     }
 
     @Override

--- a/backend/widyu-api/src/main/java/com/widyu/mypage/controller/GuardianMyPageController.java
+++ b/backend/widyu-api/src/main/java/com/widyu/mypage/controller/GuardianMyPageController.java
@@ -4,6 +4,7 @@ import com.widyu.global.response.ApiResponseTemplate;
 import com.widyu.mypage.application.GuardianMyPageService;
 import com.widyu.mypage.controller.docs.GuardianMyPageDocs;
 import com.widyu.mypage.dto.request.ProfileImageUploadRequest;
+import com.widyu.mypage.dto.request.UpdateInviteCodeRequest;
 import com.widyu.mypage.dto.request.UpdateNameRequest;
 import com.widyu.mypage.dto.request.UpdatePhoneRequest;
 import com.widyu.mypage.dto.request.UpdateSeniorAddressRequest;
@@ -140,6 +141,17 @@ public class GuardianMyPageController implements GuardianMyPageDocs {
         return ApiResponseTemplate.ok()
                 .code("MYPAGE_2018")
                 .message("시니어 프로필 이미지 수정 성공")
+                .build();
+    }
+
+    @Override
+    @PatchMapping("/seniors/{seniorId}/invite-code")
+    public ApiResponseTemplate<Void> updateSeniorInviteCode(@PathVariable Long seniorId,
+                                                             @RequestBody @Valid UpdateInviteCodeRequest request) {
+        guardianMyPageService.updateSeniorInviteCode(seniorId, request);
+        return ApiResponseTemplate.ok()
+                .code("MYPAGE_2024")
+                .message("시니어 초대코드 수정 성공")
                 .build();
     }
 

--- a/backend/widyu-api/src/main/java/com/widyu/mypage/controller/docs/GuardianMyPageDocs.java
+++ b/backend/widyu-api/src/main/java/com/widyu/mypage/controller/docs/GuardianMyPageDocs.java
@@ -2,6 +2,7 @@ package com.widyu.mypage.controller.docs;
 
 import com.widyu.global.response.ApiResponseTemplate;
 import com.widyu.mypage.dto.request.ProfileImageUploadRequest;
+import com.widyu.mypage.dto.request.UpdateInviteCodeRequest;
 import com.widyu.mypage.dto.request.UpdateNameRequest;
 import com.widyu.mypage.dto.request.UpdatePhoneRequest;
 import com.widyu.mypage.dto.request.UpdateSeniorAddressRequest;
@@ -84,6 +85,16 @@ public interface GuardianMyPageDocs {
     ApiResponseTemplate<Void> updateSeniorProfileImage(
             @Parameter(description = "시니어 회원 ID", required = true, example = "1") Long seniorId,
             ProfileImageUploadRequest request);
+
+    @Operation(summary = "시니어 초대코드 수정", description = "방장만 호출 가능. 시니어 로그인에 사용되는 7자리 초대코드를 수정합니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "수정 성공"),
+            @ApiResponse(responseCode = "400", description = "이미 사용 중인 초대코드"),
+            @ApiResponse(responseCode = "403", description = "방장만 수정 가능")
+    })
+    ApiResponseTemplate<Void> updateSeniorInviteCode(
+            @Parameter(description = "시니어 회원 ID", required = true, example = "1") Long seniorId,
+            UpdateInviteCodeRequest request);
 
     @Operation(summary = "가족 멤버 목록 조회", description = "현재 로그인한 보호자가 속한 가족의 멤버 목록과 방장 여부를 조회합니다.")
     @ApiResponses({

--- a/backend/widyu-api/src/main/java/com/widyu/mypage/controller/docs/GuardianMyPageDocs.java
+++ b/backend/widyu-api/src/main/java/com/widyu/mypage/controller/docs/GuardianMyPageDocs.java
@@ -55,6 +55,15 @@ public interface GuardianMyPageDocs {
     })
     ApiResponseTemplate<FamilyCodeResponse> getFamilyCode();
 
+    @Operation(summary = "시니어 이름 수정", description = "방장만 호출 가능. 시니어의 이름을 수정합니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "수정 성공"),
+            @ApiResponse(responseCode = "403", description = "방장만 수정 가능")
+    })
+    ApiResponseTemplate<Void> updateSeniorName(
+            @Parameter(description = "시니어 회원 ID", required = true, example = "1") Long seniorId,
+            UpdateNameRequest request);
+
     @Operation(summary = "시니어 전화번호 수정")
     @ApiResponses({@ApiResponse(responseCode = "200", description = "수정 성공")})
     ApiResponseTemplate<Void> updateSeniorPhone(
@@ -67,8 +76,11 @@ public interface GuardianMyPageDocs {
             @Parameter(description = "시니어 회원 ID", required = true, example = "1") Long seniorId,
             UpdateSeniorAddressRequest request);
 
-    @Operation(summary = "시니어 프로필 이미지 수정")
-    @ApiResponses({@ApiResponse(responseCode = "200", description = "수정 성공")})
+    @Operation(summary = "시니어 프로필 이미지 수정", description = "방장만 호출 가능.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "수정 성공"),
+            @ApiResponse(responseCode = "403", description = "방장만 수정 가능")
+    })
     ApiResponseTemplate<Void> updateSeniorProfileImage(
             @Parameter(description = "시니어 회원 ID", required = true, example = "1") Long seniorId,
             ProfileImageUploadRequest request);

--- a/backend/widyu-api/src/main/java/com/widyu/mypage/controller/docs/GuardianMyPageDocs.java
+++ b/backend/widyu-api/src/main/java/com/widyu/mypage/controller/docs/GuardianMyPageDocs.java
@@ -65,14 +65,20 @@ public interface GuardianMyPageDocs {
             @Parameter(description = "시니어 회원 ID", required = true, example = "1") Long seniorId,
             UpdateNameRequest request);
 
-    @Operation(summary = "시니어 전화번호 수정")
-    @ApiResponses({@ApiResponse(responseCode = "200", description = "수정 성공")})
+    @Operation(summary = "시니어 전화번호 수정", description = "방장만 호출 가능.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "수정 성공"),
+            @ApiResponse(responseCode = "403", description = "방장만 수정 가능")
+    })
     ApiResponseTemplate<Void> updateSeniorPhone(
             @Parameter(description = "시니어 회원 ID", required = true, example = "1") Long seniorId,
             UpdatePhoneRequest request);
 
-    @Operation(summary = "시니어 주소 수정")
-    @ApiResponses({@ApiResponse(responseCode = "200", description = "수정 성공")})
+    @Operation(summary = "시니어 주소 수정", description = "방장만 호출 가능.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "수정 성공"),
+            @ApiResponse(responseCode = "403", description = "방장만 수정 가능")
+    })
     ApiResponseTemplate<Void> updateSeniorAddress(
             @Parameter(description = "시니어 회원 ID", required = true, example = "1") Long seniorId,
             UpdateSeniorAddressRequest request);

--- a/backend/widyu-api/src/main/java/com/widyu/mypage/controller/docs/GuardianMyPageDocs.java
+++ b/backend/widyu-api/src/main/java/com/widyu/mypage/controller/docs/GuardianMyPageDocs.java
@@ -73,10 +73,12 @@ public interface GuardianMyPageDocs {
             @Parameter(description = "시니어 회원 ID", required = true, example = "1") Long seniorId,
             ProfileImageUploadRequest request);
 
-    @Operation(summary = "가족 멤버 목록 조회", description = "특정 시니어 가족의 보호자 목록과 방장 여부를 조회합니다.")
-    @ApiResponses({@ApiResponse(responseCode = "200", description = "조회 성공")})
-    ApiResponseTemplate<FamilyMemberListResponse> getFamilyMembers(
-            @Parameter(description = "시니어 회원 ID", required = true, example = "1") Long seniorId);
+    @Operation(summary = "가족 멤버 목록 조회", description = "현재 로그인한 보호자가 속한 가족의 멤버 목록과 방장 여부를 조회합니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "조회 성공"),
+            @ApiResponse(responseCode = "404", description = "연결된 가족 없음")
+    })
+    ApiResponseTemplate<FamilyMemberListResponse> getFamilyMembers();
 
     @Operation(summary = "방장 변경", description = "방장만 호출 가능. 다른 보호자를 방장으로 변경합니다.")
     @ApiResponses({

--- a/backend/widyu-api/src/main/java/com/widyu/mypage/dto/request/UpdateInviteCodeRequest.java
+++ b/backend/widyu-api/src/main/java/com/widyu/mypage/dto/request/UpdateInviteCodeRequest.java
@@ -1,0 +1,12 @@
+package com.widyu.mypage.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
+
+public record UpdateInviteCodeRequest(
+        @NotBlank(message = "초대코드는 필수입니다.")
+        @Size(min = 7, max = 7, message = "초대코드는 7자리여야 합니다.")
+        @Pattern(regexp = "^[A-Za-z0-9]{7}$", message = "초대코드는 영문자와 숫자로만 구성되어야 합니다.")
+        String inviteCode
+) {}

--- a/backend/widyu-api/src/test/java/com/widyu/mypage/application/GuardianMyPageServiceTest.java
+++ b/backend/widyu-api/src/test/java/com/widyu/mypage/application/GuardianMyPageServiceTest.java
@@ -19,6 +19,7 @@ import com.widyu.member.SeniorProfile;
 import com.widyu.member.SocialAccount;
 import com.widyu.member.repository.FamilyConnectionRepository;
 import com.widyu.member.repository.SeniorProfileRepository;
+import com.widyu.mypage.dto.request.UpdateInviteCodeRequest;
 import com.widyu.mypage.dto.request.UpdateNameRequest;
 import com.widyu.mypage.dto.request.UpdatePhoneRequest;
 import com.widyu.mypage.dto.request.UpdateSeniorAddressRequest;
@@ -325,10 +326,54 @@ class GuardianMyPageServiceTest {
         verify(seniorMember).updatePhoneNumber("01099998888");
     }
 
+    // ======================== 시니어 이름 수정 ========================
+
+    @Test
+    @DisplayName("방장이 시니어 이름을 수정하면 시니어 회원 엔티티의 이름이 변경된다")
+    void 시니어_이름_수정() {
+        // given
+        Member guardian = mock(Member.class);
+        SeniorProfile seniorProfile = mock(SeniorProfile.class);
+        Member seniorMember = mock(Member.class);
+
+        given(memberUtil.getCurrentMember()).willReturn(guardian);
+        given(guardian.getId()).willReturn(1L);
+        given(seniorProfileRepository.findByMemberId(10L)).willReturn(Optional.of(seniorProfile));
+        given(seniorProfile.getId()).willReturn(100L);
+        given(familyConnectionRepository.existsBySeniorIdAndGuardianId(100L, 1L)).willReturn(true);
+        given(familyConnectionRepository.existsBySeniorIdAndGuardianIdAndIsLeaderTrue(100L, 1L)).willReturn(true);
+        given(seniorProfile.getMember()).willReturn(seniorMember);
+
+        // when
+        guardianMyPageService.updateSeniorName(10L, new UpdateNameRequest("오일남"));
+
+        // then
+        verify(seniorMember).updateName("오일남");
+    }
+
+    @Test
+    @DisplayName("방장이 아닌 보호자가 시니어 이름을 수정하려 하면 예외가 발생한다")
+    void 시니어_이름_수정_방장이_아닌_경우() {
+        // given
+        Member guardian = mock(Member.class);
+        SeniorProfile seniorProfile = mock(SeniorProfile.class);
+
+        given(memberUtil.getCurrentMember()).willReturn(guardian);
+        given(guardian.getId()).willReturn(1L);
+        given(seniorProfileRepository.findByMemberId(10L)).willReturn(Optional.of(seniorProfile));
+        given(seniorProfile.getId()).willReturn(100L);
+        given(familyConnectionRepository.existsBySeniorIdAndGuardianId(100L, 1L)).willReturn(true);
+        given(familyConnectionRepository.existsBySeniorIdAndGuardianIdAndIsLeaderTrue(100L, 1L)).willReturn(false);
+
+        // when & then
+        assertThatThrownBy(() -> guardianMyPageService.updateSeniorName(10L, new UpdateNameRequest("오일남")))
+                .isInstanceOf(BusinessException.class);
+    }
+
     // ======================== 시니어 프로필 이미지 수정 ========================
 
     @Test
-    @DisplayName("시니어 기존 프로필 이미지가 있을 때 새 이미지로 교체하면 기존 이미지가 S3에서 삭제된다")
+    @DisplayName("방장이 시니어 기존 프로필 이미지가 있을 때 새 이미지로 교체하면 기존 이미지가 S3에서 삭제된다")
     void 시니어_프로필_이미지_수정_기존이미지_삭제() {
         // given
         Member guardian = mock(Member.class);
@@ -340,6 +385,7 @@ class GuardianMyPageServiceTest {
         given(seniorProfileRepository.findByMemberId(10L)).willReturn(Optional.of(seniorProfile));
         given(seniorProfile.getId()).willReturn(100L);
         given(familyConnectionRepository.existsBySeniorIdAndGuardianId(100L, 1L)).willReturn(true);
+        given(familyConnectionRepository.existsBySeniorIdAndGuardianIdAndIsLeaderTrue(100L, 1L)).willReturn(true);
         given(seniorProfile.getMember()).willReturn(seniorMember);
         given(seniorMember.getProfileImage()).willReturn("https://s3.old-senior.png");
         given(s3Service.generateFilePath(anyString(), anyString())).willReturn("profile/new.png");
@@ -356,7 +402,7 @@ class GuardianMyPageServiceTest {
     }
 
     @Test
-    @DisplayName("시니어 기존 프로필 이미지가 없을 때 새 이미지를 등록하면 S3 삭제 없이 업로드만 진행된다")
+    @DisplayName("방장이 시니어 기존 프로필 이미지가 없을 때 새 이미지를 등록하면 S3 삭제 없이 업로드만 진행된다")
     void 시니어_프로필_이미지_수정_기존이미지_없음() {
         // given
         Member guardian = mock(Member.class);
@@ -368,6 +414,7 @@ class GuardianMyPageServiceTest {
         given(seniorProfileRepository.findByMemberId(10L)).willReturn(Optional.of(seniorProfile));
         given(seniorProfile.getId()).willReturn(100L);
         given(familyConnectionRepository.existsBySeniorIdAndGuardianId(100L, 1L)).willReturn(true);
+        given(familyConnectionRepository.existsBySeniorIdAndGuardianIdAndIsLeaderTrue(100L, 1L)).willReturn(true);
         given(seniorProfile.getMember()).willReturn(seniorMember);
         given(seniorMember.getProfileImage()).willReturn(null);
         given(s3Service.generateFilePath(anyString(), anyString())).willReturn("profile/new.png");
@@ -381,6 +428,27 @@ class GuardianMyPageServiceTest {
         // then
         verify(s3Service, never()).deleteFile(anyString());
         verify(seniorMember).updateProfileImage("https://s3.new-senior.png");
+    }
+
+    @Test
+    @DisplayName("방장이 아닌 보호자가 시니어 프로필 이미지를 수정하려 하면 예외가 발생한다")
+    void 시니어_프로필_이미지_수정_방장이_아닌_경우() {
+        // given
+        Member guardian = mock(Member.class);
+        SeniorProfile seniorProfile = mock(SeniorProfile.class);
+
+        given(memberUtil.getCurrentMember()).willReturn(guardian);
+        given(guardian.getId()).willReturn(1L);
+        given(seniorProfileRepository.findByMemberId(10L)).willReturn(Optional.of(seniorProfile));
+        given(seniorProfile.getId()).willReturn(100L);
+        given(familyConnectionRepository.existsBySeniorIdAndGuardianId(100L, 1L)).willReturn(true);
+        given(familyConnectionRepository.existsBySeniorIdAndGuardianIdAndIsLeaderTrue(100L, 1L)).willReturn(false);
+
+        MockMultipartFile image = new MockMultipartFile("image", "new.png", "image/png", new byte[]{1});
+
+        // when & then
+        assertThatThrownBy(() -> guardianMyPageService.updateSeniorProfileImage(10L, image))
+                .isInstanceOf(BusinessException.class);
     }
 
     // ======================== 시니어 주소 수정 ========================
@@ -412,6 +480,7 @@ class GuardianMyPageServiceTest {
     void 가족_멤버_목록_조회_방장인_경우() {
         // given
         Member guardian = mock(Member.class);
+        FamilyConnection guardianConnection = mock(FamilyConnection.class);
         SeniorProfile seniorProfile = mock(SeniorProfile.class);
         FamilyConnection leaderConnection = mock(FamilyConnection.class);
         FamilyConnection memberConnection = mock(FamilyConnection.class);
@@ -420,9 +489,10 @@ class GuardianMyPageServiceTest {
 
         given(memberUtil.getCurrentMember()).willReturn(guardian);
         given(guardian.getId()).willReturn(1L);
-        given(seniorProfileRepository.findByMemberId(10L)).willReturn(Optional.of(seniorProfile));
+        given(familyConnectionRepository.findAllByGuardianIdWithSeniorAndMember(1L))
+                .willReturn(List.of(guardianConnection));
+        given(guardianConnection.getSenior()).willReturn(seniorProfile);
         given(seniorProfile.getId()).willReturn(100L);
-        given(familyConnectionRepository.existsBySeniorIdAndGuardianId(100L, 1L)).willReturn(true);
         given(familyConnectionRepository.findAllBySeniorIdWithGuardian(100L))
                 .willReturn(List.of(leaderConnection, memberConnection));
 
@@ -437,7 +507,7 @@ class GuardianMyPageServiceTest {
         given(memberConnection.isLeader()).willReturn(false);
 
         // when
-        FamilyMemberListResponse response = guardianMyPageService.getFamilyMembers(10L);
+        FamilyMemberListResponse response = guardianMyPageService.getFamilyMembers();
 
         // then
         assertThat(response.isCurrentUserLeader()).isTrue();
@@ -449,6 +519,7 @@ class GuardianMyPageServiceTest {
     void 가족_멤버_목록_조회_방장이_아닌_경우() {
         // given
         Member guardian = mock(Member.class);
+        FamilyConnection guardianConnection = mock(FamilyConnection.class);
         SeniorProfile seniorProfile = mock(SeniorProfile.class);
         FamilyConnection leaderConnection = mock(FamilyConnection.class);
         FamilyConnection memberConnection = mock(FamilyConnection.class);
@@ -457,9 +528,10 @@ class GuardianMyPageServiceTest {
 
         given(memberUtil.getCurrentMember()).willReturn(guardian);
         given(guardian.getId()).willReturn(2L);
-        given(seniorProfileRepository.findByMemberId(10L)).willReturn(Optional.of(seniorProfile));
+        given(familyConnectionRepository.findAllByGuardianIdWithSeniorAndMember(2L))
+                .willReturn(List.of(guardianConnection));
+        given(guardianConnection.getSenior()).willReturn(seniorProfile);
         given(seniorProfile.getId()).willReturn(100L);
-        given(familyConnectionRepository.existsBySeniorIdAndGuardianId(100L, 2L)).willReturn(true);
         given(familyConnectionRepository.findAllBySeniorIdWithGuardian(100L))
                 .willReturn(List.of(leaderConnection, memberConnection));
 
@@ -474,13 +546,29 @@ class GuardianMyPageServiceTest {
         given(memberConnection.isLeader()).willReturn(false);
 
         // when
-        FamilyMemberListResponse response = guardianMyPageService.getFamilyMembers(10L);
+        FamilyMemberListResponse response = guardianMyPageService.getFamilyMembers();
 
         // then
         assertThat(response.isCurrentUserLeader()).isFalse();
         assertThat(response.members()).hasSize(2);
         assertThat(response.members().get(0).name()).isEqualTo("한채희");
         assertThat(response.members().get(1).name()).isEqualTo("한토마");
+    }
+
+    @Test
+    @DisplayName("가족에 연결되지 않은 상태에서 가족 멤버 목록을 조회하면 예외가 발생한다")
+    void 가족_멤버_목록_조회_가족연결_없음() {
+        // given
+        Member guardian = mock(Member.class);
+
+        given(memberUtil.getCurrentMember()).willReturn(guardian);
+        given(guardian.getId()).willReturn(1L);
+        given(familyConnectionRepository.findAllByGuardianIdWithSeniorAndMember(1L))
+                .willReturn(List.of());
+
+        // when & then
+        assertThatThrownBy(() -> guardianMyPageService.getFamilyMembers())
+                .isInstanceOf(BusinessException.class);
     }
 
     // ======================== 방장 변경 ========================
@@ -605,5 +693,68 @@ class GuardianMyPageServiceTest {
 
         // then
         verify(familyConnectionRepository).delete(targetConnection);
+    }
+
+    // ======================== 시니어 초대코드 수정 ========================
+
+    @Test
+    @DisplayName("방장이 중복되지 않는 초대코드로 수정하면 시니어 프로필의 초대코드가 변경된다")
+    void 시니어_초대코드_수정() {
+        // given
+        Member guardian = mock(Member.class);
+        SeniorProfile seniorProfile = mock(SeniorProfile.class);
+
+        given(memberUtil.getCurrentMember()).willReturn(guardian);
+        given(guardian.getId()).willReturn(1L);
+        given(seniorProfileRepository.findByMemberId(10L)).willReturn(Optional.of(seniorProfile));
+        given(seniorProfile.getId()).willReturn(100L);
+        given(familyConnectionRepository.existsBySeniorIdAndGuardianId(100L, 1L)).willReturn(true);
+        given(familyConnectionRepository.existsBySeniorIdAndGuardianIdAndIsLeaderTrue(100L, 1L)).willReturn(true);
+        given(seniorProfileRepository.existsByInviteCode("ABC1234")).willReturn(false);
+
+        // when
+        guardianMyPageService.updateSeniorInviteCode(10L, new UpdateInviteCodeRequest("ABC1234"));
+
+        // then
+        verify(seniorProfile).updateInviteCode("ABC1234");
+    }
+
+    @Test
+    @DisplayName("방장이 아닌 보호자가 초대코드를 수정하려 하면 예외가 발생한다")
+    void 시니어_초대코드_수정_방장이_아닌_경우() {
+        // given
+        Member guardian = mock(Member.class);
+        SeniorProfile seniorProfile = mock(SeniorProfile.class);
+
+        given(memberUtil.getCurrentMember()).willReturn(guardian);
+        given(guardian.getId()).willReturn(1L);
+        given(seniorProfileRepository.findByMemberId(10L)).willReturn(Optional.of(seniorProfile));
+        given(seniorProfile.getId()).willReturn(100L);
+        given(familyConnectionRepository.existsBySeniorIdAndGuardianId(100L, 1L)).willReturn(true);
+        given(familyConnectionRepository.existsBySeniorIdAndGuardianIdAndIsLeaderTrue(100L, 1L)).willReturn(false);
+
+        // when & then
+        assertThatThrownBy(() -> guardianMyPageService.updateSeniorInviteCode(10L, new UpdateInviteCodeRequest("ABC1234")))
+                .isInstanceOf(BusinessException.class);
+    }
+
+    @Test
+    @DisplayName("이미 사용 중인 초대코드로 수정하려 하면 예외가 발생한다")
+    void 시니어_초대코드_수정_중복_코드() {
+        // given
+        Member guardian = mock(Member.class);
+        SeniorProfile seniorProfile = mock(SeniorProfile.class);
+
+        given(memberUtil.getCurrentMember()).willReturn(guardian);
+        given(guardian.getId()).willReturn(1L);
+        given(seniorProfileRepository.findByMemberId(10L)).willReturn(Optional.of(seniorProfile));
+        given(seniorProfile.getId()).willReturn(100L);
+        given(familyConnectionRepository.existsBySeniorIdAndGuardianId(100L, 1L)).willReturn(true);
+        given(familyConnectionRepository.existsBySeniorIdAndGuardianIdAndIsLeaderTrue(100L, 1L)).willReturn(true);
+        given(seniorProfileRepository.existsByInviteCode("ABC1234")).willReturn(true);
+
+        // when & then
+        assertThatThrownBy(() -> guardianMyPageService.updateSeniorInviteCode(10L, new UpdateInviteCodeRequest("ABC1234")))
+                .isInstanceOf(BusinessException.class);
     }
 }

--- a/backend/widyu-api/src/test/java/com/widyu/mypage/application/GuardianMyPageServiceTest.java
+++ b/backend/widyu-api/src/test/java/com/widyu/mypage/application/GuardianMyPageServiceTest.java
@@ -317,6 +317,7 @@ class GuardianMyPageServiceTest {
         given(seniorProfileRepository.findByMemberId(10L)).willReturn(Optional.of(seniorProfile));
         given(seniorProfile.getId()).willReturn(100L);
         given(familyConnectionRepository.existsBySeniorIdAndGuardianId(100L, 1L)).willReturn(true);
+        given(familyConnectionRepository.existsBySeniorIdAndGuardianIdAndIsLeaderTrue(100L, 1L)).willReturn(true);
         given(seniorProfile.getMember()).willReturn(seniorMember);
 
         // when
@@ -465,6 +466,7 @@ class GuardianMyPageServiceTest {
         given(seniorProfileRepository.findByMemberId(10L)).willReturn(Optional.of(seniorProfile));
         given(seniorProfile.getId()).willReturn(100L);
         given(familyConnectionRepository.existsBySeniorIdAndGuardianId(100L, 1L)).willReturn(true);
+        given(familyConnectionRepository.existsBySeniorIdAndGuardianIdAndIsLeaderTrue(100L, 1L)).willReturn(true);
 
         // when
         guardianMyPageService.updateSeniorAddress(10L, new UpdateSeniorAddressRequest("서울시 강서구", "101호"));

--- a/backend/widyu-domain/src/main/java/com/widyu/member/SeniorProfile.java
+++ b/backend/widyu-domain/src/main/java/com/widyu/member/SeniorProfile.java
@@ -106,4 +106,8 @@ public class SeniorProfile extends BaseTimeEntity {
         this.address = address;
         this.detailAddress = detailAddress;
     }
+
+    public void updateInviteCode(String inviteCode) {
+        this.inviteCode = inviteCode;
+    }
 }


### PR DESCRIPTION
  ## #️연관된 이슈
  - close: #239

  ## 🪄작업 내용
  - 가족 멤버 목록 조회 API URL에서 `{seniorId}` 제거 (`GET /family/members`)
    - JWT의 보호자 정보로 소속 가족을 자동 조회하도록 변경                                                                                                                                                     
  - 시니어 프로필 이미지, 전화번호, 주소 수정에 방장 권한 체크 추가                                                                                                                         
  - 시니어 이름 수정 API 신규 추가 (`PATCH /seniors/{seniorId}/name`, 방장 전용)                                                                                                                               
  - 시니어 초대코드 수정 API 신규 추가 (`PATCH /seniors/{seniorId}/invite-code`, 방장 전용)                                                                                                                    
    - 7자리 영문+숫자 유효성 검사, 중복 초대코드 400 에러 처리                                                                                                                                                 
                                                                                                                                                                                                               
  ## 💖리뷰 요청사항   