### PR TITLE
인증 도메인 에러 코드 구체화 및 민감 정보 노출 제거

### DIFF
--- a/backend/widyu-api/src/main/java/com/widyu/auth/application/TemporaryTokenService.java
+++ b/backend/widyu-api/src/main/java/com/widyu/auth/application/TemporaryTokenService.java
@@ -36,7 +36,7 @@ public class TemporaryTokenService {
 
     public TemporaryMember loadTemporaryMemberOrThrow(String temporaryMemberId) {
         return temporaryMemberRepository.findById(temporaryMemberId)
-                .orElseThrow(() -> new BusinessException(ErrorCode.MEMBER_NOT_FOUND));
+                .orElseThrow(() -> new BusinessException(ErrorCode.TEMPORARY_MEMBER_NOT_FOUND));
     }
 
     public void deleteTemporaryMember(String temporaryMemberId) {

--- a/backend/widyu-api/src/main/java/com/widyu/auth/application/VerificationCodeService.java
+++ b/backend/widyu-api/src/main/java/com/widyu/auth/application/VerificationCodeService.java
@@ -37,8 +37,7 @@ public class VerificationCodeService {
     private boolean verifyCode(final String phoneNumber, final String inputCode) {
         return verificationCodeRepository.findById(phoneNumber)
                 .map(verification -> verification.getCode().equals(inputCode))
-                .orElseThrow(() ->
-                        new BusinessException(ErrorCode.SMS_VERIFICATION_CODE_NOT_FOUND, "인증 코드가 존재하지 않습니다."));
+                .orElseThrow(() -> new BusinessException(ErrorCode.SMS_VERIFICATION_CODE_NOT_FOUND));
     }
 
     private TemporaryMember createTemporaryMember(String phoneNumber) {

--- a/backend/widyu-api/src/main/java/com/widyu/auth/application/guardian/oauth/strategy/SocialLoginStrategyFactory.java
+++ b/backend/widyu-api/src/main/java/com/widyu/auth/application/guardian/oauth/strategy/SocialLoginStrategyFactory.java
@@ -31,7 +31,7 @@ public class SocialLoginStrategyFactory {
         SocialLoginStrategy strategy = strategies.get(provider);
         if (strategy == null) {
             log.error("지원하지 않는 OAuth 제공자입니다: {}", provider);
-            throw new BusinessException(ErrorCode.UNSUPPORTED_OAUTH_PROVIDER, provider.name());
+            throw new BusinessException(ErrorCode.UNSUPPORTED_OAUTH_PROVIDER);
         }
         return strategy;
     }

--- a/backend/widyu-api/src/main/java/com/widyu/auth/application/guardian/oauth/strategy/apple/AppleJwtUtils.java
+++ b/backend/widyu-api/src/main/java/com/widyu/auth/application/guardian/oauth/strategy/apple/AppleJwtUtils.java
@@ -76,7 +76,8 @@ public class AppleJwtUtils {
             
             return keyFactory.generatePrivate(keySpec);
         } catch (NoSuchAlgorithmException | InvalidKeySpecException e) {
-            throw new BusinessException(ErrorCode.APPLE_PRIVATE_KEY_PARSING_FAILED, e.getMessage());
+            log.error("Apple 개인 키 파싱 실패", e);
+            throw new BusinessException(ErrorCode.APPLE_PRIVATE_KEY_PARSING_FAILED);
         }
     }
 }

--- a/backend/widyu-api/src/main/java/com/widyu/auth/application/senior/SeniorAuthService.java
+++ b/backend/widyu-api/src/main/java/com/widyu/auth/application/senior/SeniorAuthService.java
@@ -20,9 +20,11 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class SeniorAuthService {
@@ -62,7 +64,7 @@ public class SeniorAuthService {
 
     private void validateRequestsNotEmpty(List<SeniorSignUpRequest> requests) {
         if (requests == null || requests.isEmpty()) {
-            throw new BusinessException(ErrorCode.BAD_REQUEST, ": 요청 리스트가 비어 있습니다.");
+            throw new BusinessException(ErrorCode.SENIOR_SIGNUP_REQUEST_EMPTY);
         }
     }
 
@@ -107,7 +109,7 @@ public class SeniorAuthService {
                 return code;
             }
         }
-        throw new BusinessException(ErrorCode.INTERNAL_SERVER_ERROR, "가족코드 생성에 실패했습니다.");
+        throw new BusinessException(ErrorCode.FAMILY_CODE_GENERATION_FAILED);
     }
 
     private String generateCode() {
@@ -145,7 +147,10 @@ public class SeniorAuthService {
 
     private SeniorProfile findByInviteCodeAndPhoneNumber(String inviteCode, String phoneNumber) {
         return seniorProfileRepository.findByInviteCodeAndMemberPhoneNumber(inviteCode, phoneNumber)
-                .orElseThrow(() -> new BusinessException(ErrorCode.INVITE_CODE_NOT_FOUND, inviteCode));
+                .orElseThrow(() -> {
+                    log.warn("초대코드로 시니어 프로필을 찾을 수 없습니다. inviteCode: {}", inviteCode);
+                    return new BusinessException(ErrorCode.INVITE_CODE_NOT_FOUND);
+                });
     }
 
     private TokenPairResponse generateTokenPairForMember(Member member) {

--- a/backend/widyu-api/src/test/java/com/widyu/auth/application/TemporaryTokenServiceTest.java
+++ b/backend/widyu-api/src/test/java/com/widyu/auth/application/TemporaryTokenServiceTest.java
@@ -121,7 +121,7 @@ class TemporaryTokenServiceTest {
         // when & then
         assertThatThrownBy(() -> temporaryTokenService.loadTemporaryMemberOrThrow("non-existing-id"))
                 .isInstanceOf(BusinessException.class)
-                .hasFieldOrPropertyWithValue("errorCode", ErrorCode.MEMBER_NOT_FOUND);
+                .hasFieldOrPropertyWithValue("errorCode", ErrorCode.TEMPORARY_MEMBER_NOT_FOUND);
     }
 
     @Test

--- a/backend/widyu-api/src/test/java/com/widyu/auth/application/VerificationCodeServiceTest.java
+++ b/backend/widyu-api/src/test/java/com/widyu/auth/application/VerificationCodeServiceTest.java
@@ -119,7 +119,8 @@ class VerificationCodeServiceTest {
 
         // when
         assertThatThrownBy(() -> verificationCodeService.verifyAndIssueTemporaryToken(phone, "000000"))
-                .isInstanceOf(BusinessException.class);
+                .isInstanceOf(BusinessException.class)
+                .hasFieldOrPropertyWithValue("errorCode", ErrorCode.SMS_VERIFICATION_CODE_MISMATCH);
 
         // then
         verify(temporaryMemberRepository, never()).save(any());

--- a/backend/widyu-api/src/test/java/com/widyu/auth/application/guardian/oauth/strategy/SocialLoginStrategyFactoryTest.java
+++ b/backend/widyu-api/src/test/java/com/widyu/auth/application/guardian/oauth/strategy/SocialLoginStrategyFactoryTest.java
@@ -6,6 +6,7 @@ import static org.mockito.BDDMockito.given;
 
 import com.widyu.auth.OAuthProvider;
 import com.widyu.global.error.BusinessException;
+import com.widyu.global.error.ErrorCode;
 import java.util.List;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -114,7 +115,8 @@ class SocialLoginStrategyFactoryTest {
 
         // when & then
         assertThatThrownBy(() -> factory.getStrategy("github"))
-                .isInstanceOf(BusinessException.class);
+                .isInstanceOf(BusinessException.class)
+                .hasFieldOrPropertyWithValue("errorCode", ErrorCode.UNSUPPORTED_OAUTH_PROVIDER);
     }
 
     @Test

--- a/backend/widyu-api/src/test/java/com/widyu/auth/application/senior/SeniorAuthServiceTest.java
+++ b/backend/widyu-api/src/test/java/com/widyu/auth/application/senior/SeniorAuthServiceTest.java
@@ -84,7 +84,7 @@ class SeniorAuthServiceTest {
         // when & then
         assertThatThrownBy(() -> seniorAuthService.seniorSignUpBulk(List.of()))
                 .isInstanceOf(BusinessException.class)
-                .hasFieldOrPropertyWithValue("errorCode", ErrorCode.BAD_REQUEST);
+                .hasFieldOrPropertyWithValue("errorCode", ErrorCode.SENIOR_SIGNUP_REQUEST_EMPTY);
     }
 
     @Test
@@ -97,7 +97,7 @@ class SeniorAuthServiceTest {
         // when & then
         assertThatThrownBy(() -> seniorAuthService.seniorSignUpBulk(null))
                 .isInstanceOf(BusinessException.class)
-                .hasFieldOrPropertyWithValue("errorCode", ErrorCode.BAD_REQUEST);
+                .hasFieldOrPropertyWithValue("errorCode", ErrorCode.SENIOR_SIGNUP_REQUEST_EMPTY);
     }
 
     @Test
@@ -137,6 +137,25 @@ class SeniorAuthServiceTest {
                 new SeniorSignInRequest("0000000", "01011112222")))
                 .isInstanceOf(BusinessException.class)
                 .hasFieldOrPropertyWithValue("errorCode", ErrorCode.INVITE_CODE_NOT_FOUND);
+    }
+
+    @Test
+    @DisplayName("가족 코드 생성 최대 시도 초과 시 BusinessException을 던진다")
+    void 가족코드_생성_최대_시도_초과_시_예외가_발생한다() {
+        // given
+        Member guardian = Member.createMember(MemberType.GUARDIAN, "보호자", "01099999999");
+        given(memberUtil.getCurrentMember()).willReturn(guardian);
+        given(memberRepository.saveAll(anyList())).willAnswer(inv -> inv.getArgument(0));
+        given(seniorProfileRepository.existsByFamilyCode(anyString())).willReturn(true);
+
+        List<SeniorSignUpRequest> requests = List.of(
+                new SeniorSignUpRequest("부모님", "01011112222", "서울", "101호", "1234567")
+        );
+
+        // when & then
+        assertThatThrownBy(() -> seniorAuthService.seniorSignUpBulk(requests))
+                .isInstanceOf(BusinessException.class)
+                .hasFieldOrPropertyWithValue("errorCode", ErrorCode.FAMILY_CODE_GENERATION_FAILED);
     }
 
     @Test

--- a/backend/widyu-domain/src/main/java/com/widyu/global/error/ErrorCode.java
+++ b/backend/widyu-domain/src/main/java/com/widyu/global/error/ErrorCode.java
@@ -33,6 +33,8 @@ public enum ErrorCode {
     INVITE_CODE_NOT_FOUND(HttpStatus.NOT_FOUND, "PARENT_4040", "초대코드를 찾을 수 없습니다."),
     INVITE_CODE_DUPLICATED_IN_REQUEST(HttpStatus.BAD_REQUEST, "PARENT_4002", "요청 내 중복된 초대코드가 있습니다."),
     ALREADY_CONNECTED_TO_FAMILY(HttpStatus.BAD_REQUEST, "PARENT_4003", "이미 해당 가족에 연결되어 있습니다."),
+    SENIOR_SIGNUP_REQUEST_EMPTY(HttpStatus.BAD_REQUEST, "PARENT_4004", "시니어 등록 요청 목록이 비어 있습니다."),
+    FAMILY_CODE_GENERATION_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "PARENT_5001", "가족 코드 생성에 실패했습니다."),
 
     // 문자 인증
     SMS_VERIFICATION_CODE_NOT_FOUND(HttpStatus.NOT_FOUND, "SMS_4040", "문자 인증 코드가 존재하지 않습니다."),
@@ -64,6 +66,7 @@ public enum ErrorCode {
     // 회원 관련
     MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, "MEMBER_4041", "회원을 찾을 수 없습니다."),
     SENIOR_PROFILE_NOT_FOUND(HttpStatus.NOT_FOUND, "MEMBER_4042", "시니어 프로필을 찾을 수 없습니다."),
+    TEMPORARY_MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, "AUTH_4041", "임시 회원을 찾을 수 없습니다."),
 
     // fcm 관련
     FCM_TOKEN_NOT_FOUND(HttpStatus.NOT_FOUND, "FCM_4040", "FCM 토큰이 존재하지 않습니다."),


### PR DESCRIPTION
## #️⃣연관된 이슈
>PR과 연관된 이슈 번호를 작성해주세요. ex) #이슈 번호, #이슈 번호

- close: #247

## 🪄작업 내용
>해당 이슈 그리고 이번 PR에서 작업한 내용들을 작성해주세요.
>뷰 작업 내용이 포함되었을 경우 사진 혹은 동영상 파일 첨부를 부탁드립니다!

- TEMPORARY_MEMBER_NOT_FOUND, SENIOR_SIGNUP_REQUEST_EMPTY, FAMILY_CODE_GENERATION_FAILED 에러 코드 신규 추가
  - 기존에 MEMBER_NOT_FOUND, BAD_REQUEST, INTERNAL_SERVER_ERROR 등 범용 에러 코드를 사용하던 인증 로직에 도메인 전용 에러 코드 적용
  - BusinessException 두 번째 인자로 하드코딩 메시지 또는 민감값(inviteCode, provider.name(), e.getMessage())을 직접 전달하던 패턴 제거
  - 민감 정보는 log.warn / log.error로 이동 (응답 바디에 노출되지 않도록)


## 💖리뷰 요청사항
>특별히 봐주셨으면 하는 부분, 나 좀 잘했다 하는 부분! 기타 당부의 말씀 등 자유롭게 작성해주세요.

-
