### PR TITLE
가족 멤버 삭제 API에서 시니어 탈퇴 지원 추가

### DIFF
--- a/backend/widyu-api/src/main/java/com/widyu/member/repository/PointHistoryRepository.java
+++ b/backend/widyu-api/src/main/java/com/widyu/member/repository/PointHistoryRepository.java
@@ -7,4 +7,6 @@ import org.springframework.data.jpa.repository.JpaRepository;
 public interface PointHistoryRepository extends JpaRepository<PointHistory, Long> {
 
     List<PointHistory> findAllBySeniorProfileIdOrderByCreatedAtDesc(Long seniorProfileId);
+
+    void deleteBySeniorProfileId(Long seniorProfileId);
 }

--- a/backend/widyu-api/src/main/java/com/widyu/mypage/application/GuardianMyPageService.java
+++ b/backend/widyu-api/src/main/java/com/widyu/mypage/application/GuardianMyPageService.java
@@ -7,8 +7,11 @@ import com.widyu.global.util.MemberUtil;
 import com.widyu.member.Family;
 import com.widyu.member.FamilyMembership;
 import com.widyu.member.Member;
+import com.widyu.member.MemberType;
 import com.widyu.member.SeniorProfile;
 import com.widyu.member.repository.FamilyMembershipRepository;
+import com.widyu.member.repository.MemberRepository;
+import com.widyu.member.repository.PointHistoryRepository;
 import com.widyu.member.repository.SeniorProfileRepository;
 import com.widyu.mypage.dto.request.UpdateInviteCodeRequest;
 import com.widyu.mypage.dto.request.UpdateNameRequest;
@@ -37,6 +40,8 @@ public class GuardianMyPageService {
     private final S3Service s3Service;
     private final FamilyMembershipRepository familyMembershipRepository;
     private final SeniorProfileRepository seniorProfileRepository;
+    private final MemberRepository memberRepository;
+    private final PointHistoryRepository pointHistoryRepository;
 
     public GuardianInfoResponse getGuardianInfo() {
         Member member = MyPageProfileService.getCurrentMember(memberUtil);
@@ -167,11 +172,33 @@ public class GuardianMyPageService {
             throw new BusinessException(ErrorCode.BAD_REQUEST, "본인을 삭제할 수 없습니다.");
         }
 
+        Member target = memberRepository.findById(targetMemberId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.MEMBER_NOT_FOUND));
+
+        if (target.getType() == MemberType.SENIOR) {
+            deleteSeniorFromFamily(targetMemberId, myMembership.getFamily().getId());
+        } else {
+            deleteGuardianFromFamily(targetMemberId, myMembership.getFamily().getId());
+        }
+    }
+
+    private void deleteGuardianFromFamily(Long targetMemberId, Long familyId) {
         FamilyMembership membership = familyMembershipRepository
-                .findByFamilyIdAndGuardianId(myMembership.getFamily().getId(), targetMemberId)
+                .findByFamilyIdAndGuardianId(familyId, targetMemberId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.MEMBER_NOT_FOUND, "가족 구성원을 찾을 수 없습니다."));
+        familyMembershipRepository.delete(membership);
+    }
+
+    private void deleteSeniorFromFamily(Long targetMemberId, Long familyId) {
+        SeniorProfile seniorProfile = seniorProfileRepository.findByMemberId(targetMemberId)
                 .orElseThrow(() -> new BusinessException(ErrorCode.MEMBER_NOT_FOUND, "가족 구성원을 찾을 수 없습니다."));
 
-        familyMembershipRepository.delete(membership);
+        if (!seniorProfile.getFamily().getId().equals(familyId)) {
+            throw new BusinessException(ErrorCode.FORBIDDEN, "해당 시니어에 접근 권한이 없습니다.");
+        }
+
+        pointHistoryRepository.deleteBySeniorProfileId(seniorProfile.getId());
+        seniorProfileRepository.delete(seniorProfile);
     }
 
     private void assertIsLeader(SeniorProfile seniorProfile, Long guardianId) {

--- a/backend/widyu-api/src/test/java/com/widyu/mypage/application/GuardianMyPageServiceTest.java
+++ b/backend/widyu-api/src/test/java/com/widyu/mypage/application/GuardianMyPageServiceTest.java
@@ -16,9 +16,12 @@ import com.widyu.member.Family;
 import com.widyu.member.FamilyMembership;
 import com.widyu.member.LocalAccount;
 import com.widyu.member.Member;
+import com.widyu.member.MemberType;
 import com.widyu.member.SeniorProfile;
 import com.widyu.member.SocialAccount;
 import com.widyu.member.repository.FamilyMembershipRepository;
+import com.widyu.member.repository.MemberRepository;
+import com.widyu.member.repository.PointHistoryRepository;
 import com.widyu.member.repository.SeniorProfileRepository;
 import com.widyu.mypage.dto.request.UpdateInviteCodeRequest;
 import com.widyu.mypage.dto.request.UpdateNameRequest;
@@ -47,6 +50,8 @@ class GuardianMyPageServiceTest {
     @Mock private S3Service s3Service;
     @Mock private FamilyMembershipRepository familyMembershipRepository;
     @Mock private SeniorProfileRepository seniorProfileRepository;
+    @Mock private MemberRepository memberRepository;
+    @Mock private PointHistoryRepository pointHistoryRepository;
 
     @InjectMocks
     private GuardianMyPageService guardianMyPageService;
@@ -700,6 +705,7 @@ class GuardianMyPageServiceTest {
         Member guardian = mock(Member.class);
         FamilyMembership myMembership = mock(FamilyMembership.class);
         Family family = mock(Family.class);
+        Member targetMember = mock(Member.class);
         FamilyMembership targetMembership = mock(FamilyMembership.class);
 
         given(memberUtil.getCurrentMember()).willReturn(guardian);
@@ -708,6 +714,8 @@ class GuardianMyPageServiceTest {
         given(myMembership.isLeader()).willReturn(true);
         given(myMembership.getFamily()).willReturn(family);
         given(family.getId()).willReturn(10L);
+        given(memberRepository.findById(2L)).willReturn(Optional.of(targetMember));
+        given(targetMember.getType()).willReturn(MemberType.GUARDIAN);
         given(familyMembershipRepository.findByFamilyIdAndGuardianId(10L, 2L))
                 .willReturn(Optional.of(targetMembership));
 


### PR DESCRIPTION
  
  - close: #259
  
  ## 🪄작업 내용
  
  - 가족 멤버 삭제 API(`DELETE /api/v1/mypage/guardian/family/members/{memberId}`)에서 시니어 탈퇴 지원 추가
    - 기존: 보호자(`FamilyMembership`) 삭제만 가능
    - 변경: 대상 회원의 `MemberType`에 따라 분기 처리
      - 보호자 → `FamilyMembership` 삭제 (계정 유지, 기존 동작 유지)
      - 시니어 → `PointHistory` 삭제 후 `SeniorProfile` 삭제 (계정 유지, 가족 프로필만 제거)
    - `SeniorProfile.family_id`가 `NOT NULL` 제약이 있어 null 처리 대신 삭제 방식 채택 
    - `PointHistoryRepository`에 `deleteBySeniorProfileId` 추가 (FK 제약 선처리)
    
  ## 💖리뷰 요청사항