### PR TITLE
시니어 회원가입/프로필 조회에 생년월일 반영

### DIFF
--- a/backend/widyu-api/src/main/java/com/widyu/auth/application/senior/SeniorAuthService.java
+++ b/backend/widyu-api/src/main/java/com/widyu/auth/application/senior/SeniorAuthService.java
@@ -106,7 +106,8 @@ public class SeniorAuthService {
                     family,
                     req.address(),
                     req.detailAddress(),
-                    req.inviteCode()
+                    req.inviteCode(),
+                    req.birthDate()
             );
             profiles.add(profile);
         }

--- a/backend/widyu-api/src/main/java/com/widyu/auth/controller/docs/SeniorAuthDocs.java
+++ b/backend/widyu-api/src/main/java/com/widyu/auth/controller/docs/SeniorAuthDocs.java
@@ -17,7 +17,7 @@ public interface SeniorAuthDocs {
 
     @Operation(
             summary = "시니어 일괄 회원가입",
-            description = "보호자가 시니어를 일괄 등록합니다. 각 시니어는 초대코드를 받아 로그인할 수 있습니다."
+            description = "보호자가 시니어를 일괄 등록합니다. 각 시니어는 이름, 생년월일, 전화번호, 주소, 초대코드를 저장하고 초대코드로 로그인할 수 있습니다."
     )
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "시니어 일괄 회원가입 성공"),

--- a/backend/widyu-api/src/main/java/com/widyu/auth/dto/request/SeniorSignUpRequest.java
+++ b/backend/widyu-api/src/main/java/com/widyu/auth/dto/request/SeniorSignUpRequest.java
@@ -1,13 +1,22 @@
 package com.widyu.auth.dto.request;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Past;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Pattern;
 import jakarta.validation.constraints.Size;
+import java.time.LocalDate;
 
 public record SeniorSignUpRequest(
         @NotBlank(message = "이름은 필수입니다.")
         @Size(max = 50, message = "이름은 최대 50자입니다.")
         String name,
+
+        @NotNull(message = "생년월일은 필수입니다.")
+        @Past(message = "생년월일은 오늘 이전 날짜여야 합니다.")
+        @JsonFormat(pattern = "yyyy-MM-dd")
+        LocalDate birthDate,
 
         @NotBlank(message = "전화번호는 필수입니다.")
         @Pattern(

--- a/backend/widyu-api/src/main/java/com/widyu/global/config/DevDataInitializer.java
+++ b/backend/widyu-api/src/main/java/com/widyu/global/config/DevDataInitializer.java
@@ -156,8 +156,10 @@ public class DevDataInitializer implements CommandLineRunner {
         familyMembershipRepository.save(m1);
         familyMembershipRepository.save(FamilyMembership.createMembership(family, g2));
 
-        seniorProfileRepository.save(SeniorProfile.createSeniorProfile(s1, family, "서울시 강남구", "101호", "AAAS001"));
-        seniorProfileRepository.save(SeniorProfile.createSeniorProfile(s2, family, "서울시 강남구", "202호", "AAAS002"));
+        seniorProfileRepository.save(SeniorProfile.createSeniorProfile(
+                s1, family, "서울시 강남구", "101호", "AAAS001", LocalDate.of(1948, 3, 12)));
+        seniorProfileRepository.save(SeniorProfile.createSeniorProfile(
+                s2, family, "서울시 강남구", "202호", "AAAS002", LocalDate.of(1952, 11, 5)));
 
         return List.of(s1, s2);
     }
@@ -178,7 +180,8 @@ public class DevDataInitializer implements CommandLineRunner {
         familyMembershipRepository.save(m1);
         familyMembershipRepository.save(FamilyMembership.createMembership(family, g2));
 
-        seniorProfileRepository.save(SeniorProfile.createSeniorProfile(s1, family, "부산시 해운대구", "303호", "BBBS001"));
+        seniorProfileRepository.save(SeniorProfile.createSeniorProfile(
+                s1, family, "부산시 해운대구", "303호", "BBBS001", LocalDate.of(1945, 7, 21)));
 
         return List.of(s1);
     }

--- a/backend/widyu-api/src/main/java/com/widyu/mypage/dto/response/SeniorProfileDetailResponse.java
+++ b/backend/widyu-api/src/main/java/com/widyu/mypage/dto/response/SeniorProfileDetailResponse.java
@@ -2,10 +2,12 @@ package com.widyu.mypage.dto.response;
 
 import com.widyu.member.Member;
 import com.widyu.member.SeniorProfile;
+import java.time.LocalDate;
 
 public record SeniorProfileDetailResponse(
         String profileImage,
         String name,
+        LocalDate birthDate,
         String phoneNumber,
         String address,
         String detailAddress,
@@ -15,6 +17,7 @@ public record SeniorProfileDetailResponse(
         return new SeniorProfileDetailResponse(
                 member.getProfileImage(),
                 member.getName(),
+                seniorProfile.getBirthDate(),
                 member.getPhoneNumber(),
                 seniorProfile.getAddress(),
                 seniorProfile.getDetailAddress(),

--- a/backend/widyu-api/src/main/java/com/widyu/mypage/dto/response/SeniorProfileForGuardianResponse.java
+++ b/backend/widyu-api/src/main/java/com/widyu/mypage/dto/response/SeniorProfileForGuardianResponse.java
@@ -2,11 +2,13 @@ package com.widyu.mypage.dto.response;
 
 import com.widyu.member.Member;
 import com.widyu.member.SeniorProfile;
+import java.time.LocalDate;
 
 public record SeniorProfileForGuardianResponse(
         Long memberId,
         String profileImage,
         String name,
+        LocalDate birthDate,
         String phoneNumber,
         String address,
         String detailAddress,
@@ -17,6 +19,7 @@ public record SeniorProfileForGuardianResponse(
                 seniorMember.getId(),
                 seniorMember.getProfileImage(),
                 seniorMember.getName(),
+                seniorProfile.getBirthDate(),
                 seniorMember.getPhoneNumber(),
                 seniorProfile.getAddress(),
                 seniorProfile.getDetailAddress(),

--- a/backend/widyu-api/src/test/java/com/widyu/auth/application/senior/SeniorAuthServiceTest.java
+++ b/backend/widyu-api/src/test/java/com/widyu/auth/application/senior/SeniorAuthServiceTest.java
@@ -25,6 +25,7 @@ import com.widyu.member.repository.FamilyMembershipRepository;
 import com.widyu.member.repository.FamilyRepository;
 import com.widyu.member.repository.MemberRepository;
 import com.widyu.member.repository.SeniorProfileRepository;
+import java.time.LocalDate;
 import java.util.List;
 import java.util.Optional;
 import org.junit.jupiter.api.DisplayName;
@@ -57,8 +58,8 @@ class SeniorAuthServiceTest {
         ReflectionTestUtils.setField(guardian, "id", 1L);
 
         List<SeniorSignUpRequest> requests = List.of(
-                new SeniorSignUpRequest("부모님", "01011112222", "서울시 강남구", "101호", "1234567"),
-                new SeniorSignUpRequest("할머니", "01033334444", "서울시 서초구", "202호", "7654321")
+                new SeniorSignUpRequest("부모님", LocalDate.of(1950, 1, 1), "01011112222", "서울시 강남구", "101호", "1234567"),
+                new SeniorSignUpRequest("할머니", LocalDate.of(1948, 2, 2), "01033334444", "서울시 서초구", "202호", "7654321")
         );
 
         Member seniorMember1 = Member.createMember(MemberType.SENIOR, "부모님", "01011112222");
@@ -93,7 +94,7 @@ class SeniorAuthServiceTest {
         given(familyMembershipRepository.findByGuardianId(1L)).willReturn(Optional.of(mock(FamilyMembership.class)));
 
         List<SeniorSignUpRequest> requests = List.of(
-                new SeniorSignUpRequest("부모님", "01011112222", "서울", "101호", "1234567")
+                new SeniorSignUpRequest("부모님", LocalDate.of(1950, 1, 1), "01011112222", "서울", "101호", "1234567")
         );
 
         // when & then
@@ -141,7 +142,7 @@ class SeniorAuthServiceTest {
         ReflectionTestUtils.setField(family, "id", 1L);
 
         SeniorProfile seniorProfile = SeniorProfile.createSeniorProfile(
-                seniorMember, family, "서울", "101호", inviteCode
+                seniorMember, family, "서울", "101호", inviteCode, LocalDate.of(1950, 1, 1)
         );
         TokenPairResponse expectedToken = TokenPairResponse.of(2L, "access", "refresh");
 
@@ -179,7 +180,7 @@ class SeniorAuthServiceTest {
         given(familyRepository.existsByFamilyCode(anyString())).willReturn(true);
 
         List<SeniorSignUpRequest> requests = List.of(
-                new SeniorSignUpRequest("부모님", "01011112222", "서울", "101호", "1234567")
+                new SeniorSignUpRequest("부모님", LocalDate.of(1950, 1, 1), "01011112222", "서울", "101호", "1234567")
         );
 
         // when & then
@@ -201,8 +202,8 @@ class SeniorAuthServiceTest {
         given(familyRepository.save(any(Family.class))).willReturn(family);
 
         List<SeniorSignUpRequest> requests = List.of(
-                new SeniorSignUpRequest("부모님", "01011112222", "서울", "101호", "1234567"),
-                new SeniorSignUpRequest("할머니", "01033334444", "부산", "202호", "7654321")
+                new SeniorSignUpRequest("부모님", LocalDate.of(1950, 1, 1), "01011112222", "서울", "101호", "1234567"),
+                new SeniorSignUpRequest("할머니", LocalDate.of(1948, 2, 2), "01033334444", "부산", "202호", "7654321")
         );
 
         given(memberRepository.saveAll(anyList())).willAnswer(inv -> {

--- a/backend/widyu-api/src/test/java/com/widyu/mypage/application/GuardianMyPageServiceTest.java
+++ b/backend/widyu-api/src/test/java/com/widyu/mypage/application/GuardianMyPageServiceTest.java
@@ -33,6 +33,7 @@ import com.widyu.mypage.dto.response.FamilyMemberListResponse;
 import com.widyu.mypage.dto.response.GuardianInfoResponse;
 import com.widyu.mypage.dto.response.GuardianProfileDetailResponse;
 import com.widyu.mypage.dto.response.SeniorProfileForGuardianResponse;
+import java.time.LocalDate;
 import java.util.List;
 import java.util.Optional;
 import org.junit.jupiter.api.DisplayName;
@@ -241,6 +242,7 @@ class GuardianMyPageServiceTest {
         given(seniorProfile.getMember()).willReturn(seniorMember);
         given(seniorMember.getId()).willReturn(10L);
         given(seniorMember.getName()).willReturn("오일남");
+        given(seniorProfile.getBirthDate()).willReturn(LocalDate.of(1950, 1, 1));
         given(seniorProfile.getInviteCode()).willReturn("1234567");
 
         // when
@@ -248,6 +250,7 @@ class GuardianMyPageServiceTest {
 
         // then
         assertThat(response.name()).isEqualTo("오일남");
+        assertThat(response.birthDate()).isEqualTo(LocalDate.of(1950, 1, 1));
         assertThat(response.inviteCode()).isEqualTo("1234567");
     }
 

--- a/backend/widyu-api/src/test/java/com/widyu/mypage/application/SeniorMyPageServiceTest.java
+++ b/backend/widyu-api/src/test/java/com/widyu/mypage/application/SeniorMyPageServiceTest.java
@@ -27,6 +27,7 @@ import com.widyu.mypage.dto.response.FamilyCodeResponse;
 import com.widyu.mypage.dto.response.PointHistoryResponse;
 import com.widyu.mypage.dto.response.SeniorInfoResponse;
 import com.widyu.mypage.dto.response.SeniorProfileDetailResponse;
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
 import org.junit.jupiter.api.DisplayName;
@@ -109,6 +110,7 @@ class SeniorMyPageServiceTest {
         given(member.getName()).willReturn("오일남");
         given(member.getPhoneNumber()).willReturn("01012345678");
         given(member.getProfileImage()).willReturn("image.png");
+        given(seniorProfile.getBirthDate()).willReturn(LocalDate.of(1950, 1, 1));
         given(seniorProfile.getAddress()).willReturn("서울시 강서구");
         given(seniorProfile.getDetailAddress()).willReturn("101호");
         given(seniorProfile.getInviteCode()).willReturn("1234567");
@@ -118,6 +120,7 @@ class SeniorMyPageServiceTest {
 
         // then
         assertThat(response.name()).isEqualTo("오일남");
+        assertThat(response.birthDate()).isEqualTo(LocalDate.of(1950, 1, 1));
         assertThat(response.inviteCode()).isEqualTo("1234567");
     }
 

--- a/backend/widyu-domain/src/main/java/com/widyu/member/SeniorProfile.java
+++ b/backend/widyu-domain/src/main/java/com/widyu/member/SeniorProfile.java
@@ -11,6 +11,7 @@ import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.OneToOne;
 import jakarta.persistence.Table;
+import java.time.LocalDate;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
@@ -42,6 +43,9 @@ public class SeniorProfile extends BaseTimeEntity {
     @Column(name = "invite_code", nullable = false, unique = true, length = 7)
     private String inviteCode;
 
+    @Column(name = "birth_date")
+    private LocalDate birthDate;
+
     @Column(nullable = false)
     private Long points = 0L;
 
@@ -50,24 +54,26 @@ public class SeniorProfile extends BaseTimeEntity {
 
     @Builder(access = AccessLevel.PRIVATE)
     private SeniorProfile(Member member, Family family, String address, String detailAddress,
-                          String inviteCode, Long points, Integer defaultWalkGoal) {
+                          String inviteCode, LocalDate birthDate, Long points, Integer defaultWalkGoal) {
         this.member = member;
         this.family = family;
         this.address = address;
         this.detailAddress = detailAddress;
         this.inviteCode = inviteCode;
+        this.birthDate = birthDate;
         this.points = points;
         this.defaultWalkGoal = defaultWalkGoal;
     }
 
     public static SeniorProfile createSeniorProfile(Member member, Family family, String address,
-                                                    String detailAddress, String inviteCode) {
+                                                    String detailAddress, String inviteCode, LocalDate birthDate) {
         return SeniorProfile.builder()
                 .member(member)
                 .family(family)
                 .address(address)
                 .detailAddress(detailAddress)
                 .inviteCode(inviteCode)
+                .birthDate(birthDate)
                 .points(100L)
                 .defaultWalkGoal(null)
                 .build();


### PR DESCRIPTION
## #️⃣연관된 이슈
  >PR과 연관된 이슈 번호를 작성해주세요. ex) #이슈 번호, #이슈 번호

  - close: #262

  ## 🪄작업 내용
  >해당 이슈 그리고 이번 PR에서 작업한 내용들을 작성해주세요.
  >뷰 작업 내용이 포함되었을 경우 사진 혹은 동영상 파일 첨부를 부탁드립니다!

  - 부모님 회원가입 요청 DTO에 `birthDate`를 추가하고 `yyyy-MM-dd` 형식 및 과거 날짜 검증을 적용했습니다.
  - 시니어 회원가입 로직에서 생년월일을 `SeniorProfile.birthDate`에 저장하도록 반영했습니다.
  - 시니어 프로필 조회 응답에 생년월일이 포함되도록 응답 DTO를 수정했습니다.
  - `DevDataInitializer`의 시니어 시드 데이터에 생년월일을 추가했습니다.
  - 관련 서비스/마이페이지 테스트를 생년월일 기준으로 갱신했습니다.
  - `./gradlew test` 통과 확인했습니다.

  ## 💖리뷰 요청사항