### PR TITLE
결제 주문 및 취소 플로우 개선

### DIFF
--- a/admin/src/pages/payments/PaymentsPage.tsx
+++ b/admin/src/pages/payments/PaymentsPage.tsx
@@ -8,7 +8,7 @@ interface PaymentItem {
   memberName: string
   orderName: string
   amount: number
-  status: 'READY' | 'DONE' | 'CANCELED'
+  status: 'READY' | 'DONE' | 'PARTIAL_CANCELED' | 'CANCELED'
   paymentMethod: string
   approvedAt: string | null
   canceledAt: string | null
@@ -26,9 +26,15 @@ interface PageResponse<T> {
 const STATUS_STYLE: Record<string, string> = {
   DONE: 'bg-green-100 text-green-700',
   READY: 'bg-yellow-100 text-yellow-700',
+  PARTIAL_CANCELED: 'bg-orange-100 text-orange-700',
   CANCELED: 'bg-red-100 text-red-600',
 }
-const STATUS_LABEL: Record<string, string> = { DONE: '승인', READY: '대기', CANCELED: '취소' }
+const STATUS_LABEL: Record<string, string> = {
+  DONE: '승인',
+  READY: '대기',
+  PARTIAL_CANCELED: '부분 취소',
+  CANCELED: '취소',
+}
 
 function toKRW(amount: number) {
   return amount.toLocaleString('ko-KR') + '원'
@@ -111,7 +117,7 @@ export default function PaymentsPage() {
                     </span>
                   </td>
                   <td className="px-4 py-3 text-gray-500">
-                    {p.status === 'CANCELED'
+                    {p.status === 'CANCELED' || p.status === 'PARTIAL_CANCELED'
                       ? <span className="text-red-400">{formatDateTime(p.canceledAt)} 취소</span>
                       : formatDateTime(p.approvedAt)
                     }

--- a/backend/widyu-api/src/main/java/com/widyu/member/application/SeniorProfileService.java
+++ b/backend/widyu-api/src/main/java/com/widyu/member/application/SeniorProfileService.java
@@ -67,6 +67,11 @@ public class SeniorProfileService {
 
     @Transactional
     public void addPointsToMember(Long memberId, Long points) {
+        addPointsToMember(memberId, points, "포인트 적립");
+    }
+
+    @Transactional
+    public void addPointsToMember(Long memberId, Long points, String description) {
         if (points == null || points <= 0) {
             log.warn("유효하지 않은 포인트 적립 시도: memberId={}, points={}", memberId, points);
             return;
@@ -76,8 +81,28 @@ public class SeniorProfileService {
                 .orElseThrow(() -> new BusinessException(ErrorCode.SENIOR_PROFILE_NOT_FOUND));
 
         seniorProfile.addPoints(points);
-        pointHistoryRepository.save(PointHistory.earn(seniorProfile, points, "포인트 적립"));
+        pointHistoryRepository.save(PointHistory.earn(seniorProfile, points, description));
         log.info("포인트 적립 완료: memberId={}, addedPoints={}, totalPoints={}",
+                memberId, points, seniorProfile.getPoints());
+    }
+
+    @Transactional
+    public void deductPointsFromMember(Long memberId, Long points, String description) {
+        if (points == null || points <= 0) {
+            log.warn("유효하지 않은 포인트 차감 시도: memberId={}, points={}", memberId, points);
+            return;
+        }
+
+        SeniorProfile seniorProfile = seniorProfileRepository.findByMemberId(memberId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.SENIOR_PROFILE_NOT_FOUND));
+
+        if (!seniorProfile.hasEnoughPoints(points)) {
+            throw new BusinessException(ErrorCode.BAD_REQUEST, "결제 취소에 필요한 포인트가 부족합니다.");
+        }
+
+        seniorProfile.deductPoints(points);
+        pointHistoryRepository.save(PointHistory.use(seniorProfile, points, description));
+        log.info("포인트 차감 완료: memberId={}, deductedPoints={}, totalPoints={}",
                 memberId, points, seniorProfile.getPoints());
     }
 }

--- a/backend/widyu-api/src/main/java/com/widyu/pay/application/PaymentService.java
+++ b/backend/widyu-api/src/main/java/com/widyu/pay/application/PaymentService.java
@@ -4,16 +4,31 @@ import com.widyu.global.error.BusinessException;
 import com.widyu.global.error.ErrorCode;
 import com.widyu.global.util.MemberUtil;
 import com.widyu.member.Member;
+import com.widyu.member.MemberType;
+import com.widyu.member.application.SeniorProfileService;
+import com.widyu.pay.Payment;
+import com.widyu.pay.PaymentCancel;
+import com.widyu.pay.PaymentOrder;
+import com.widyu.pay.PaymentStatus;
+import com.widyu.pay.PointChargePackage;
+import com.widyu.pay.config.PaymentClient;
 import com.widyu.pay.dto.mapper.PaymentMapper;
 import com.widyu.pay.dto.request.CancelRequest;
-import com.widyu.pay.dto.request.PaymentConfirmRequest;
+import com.widyu.pay.dto.request.PaymentApproveRequest;
+import com.widyu.pay.dto.request.PaymentGatewayConfirmRequest;
+import com.widyu.pay.dto.request.PaymentOrderCreateRequest;
 import com.widyu.pay.dto.response.PaymentConfirmResponse;
 import com.widyu.pay.dto.response.PaymentConfirmResponses;
-import com.widyu.pay.config.PaymentClient;
-import com.widyu.pay.Payment;
+import com.widyu.pay.dto.response.PaymentPackageResponse;
+import com.widyu.pay.dto.response.PaymentOrderResponse;
+import com.widyu.pay.repository.PaymentOrderRepository;
 import com.widyu.pay.repository.PaymentRepository;
+import java.time.ZonedDateTime;
 import java.util.List;
+import java.util.Objects;
+import java.util.UUID;
 import lombok.RequiredArgsConstructor;
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -22,31 +37,133 @@ import org.springframework.transaction.annotation.Transactional;
 @Transactional(readOnly = true)
 public class PaymentService {
 
+    private static final int ORDER_ID_MAX_ATTEMPTS = 5;
+    private static final int ORDER_EXPIRATION_MINUTES = 15;
+
     private final PaymentClient paymentClient;
     private final PaymentRepository paymentRepository;
+    private final PaymentOrderRepository paymentOrderRepository;
     private final MemberUtil memberUtil;
+    private final SeniorProfileService seniorProfileService;
+
+    public List<PaymentPackageResponse> getPackages() {
+        return java.util.Arrays.stream(PointChargePackage.values())
+                .map(PaymentPackageResponse::from)
+                .toList();
+    }
 
     @Transactional
-    public PaymentConfirmResponse confirmPayment(PaymentConfirmRequest request) {
-        PaymentConfirmResponse rawResponse = paymentClient.confirmPayment(request);
-
+    public PaymentOrderResponse createOrder(PaymentOrderCreateRequest request) {
         Member currentMember = memberUtil.getCurrentMember();
+        validateSeniorMember(currentMember);
+        PointChargePackage paymentPackage = resolvePackage(request.packageId());
+        PaymentOrder paymentOrder = PaymentOrder.create(
+                generateOrderId(),
+                currentMember,
+                paymentPackage.getOrderName(),
+                paymentPackage.getId(),
+                paymentPackage.getAmount(),
+                paymentPackage.getPointAmount(),
+                ZonedDateTime.now().plusMinutes(ORDER_EXPIRATION_MINUTES)
+        );
+        paymentOrderRepository.save(paymentOrder);
+        return PaymentOrderResponse.from(paymentOrder);
+    }
 
-        Payment payment = PaymentMapper.toEntity(rawResponse, currentMember);
-        paymentRepository.save(payment);
+    @Transactional
+    public PaymentConfirmResponse confirmPayment(PaymentApproveRequest request) {
+        Member currentMember = memberUtil.getCurrentMember();
+        validateSeniorMember(currentMember);
+        PaymentOrder paymentOrder = paymentOrderRepository.findByOrderId(request.orderId())
+                .orElseThrow(() -> new BusinessException(ErrorCode.PAYMENT_NOT_FOUND, "주문 정보를 찾을 수 없습니다."));
+
+        validatePaymentOrderOwnership(paymentOrder, currentMember.getId());
+        validatePaymentOrderState(paymentOrder);
+
+        Payment existingOrderPayment = paymentRepository.findByOrderId(request.orderId()).orElse(null);
+        if (existingOrderPayment != null) {
+            validatePaymentOwnership(existingOrderPayment, currentMember.getId());
+            if (!Objects.equals(existingOrderPayment.getPaymentKey(), request.paymentKey())) {
+                throw new BusinessException(ErrorCode.BAD_REQUEST, "이미 결제 완료된 주문입니다.");
+            }
+            return PaymentConfirmResponse.from(existingOrderPayment);
+        }
+
+        Payment existingPayment = paymentRepository.findByPaymentKey(request.paymentKey()).orElse(null);
+        if (existingPayment != null) {
+            validatePaymentOwnership(existingPayment, currentMember.getId());
+            validateExistingPaymentMatchesOrder(existingPayment, paymentOrder);
+            return PaymentConfirmResponse.from(existingPayment);
+        }
+
+        PaymentGatewayConfirmRequest gatewayRequest = new PaymentGatewayConfirmRequest(
+                paymentOrder.getOrderId(),
+                paymentOrder.getAmount(),
+                request.paymentKey()
+        );
+        PaymentConfirmResponse rawResponse = paymentClient.confirmPayment(gatewayRequest);
+        validateConfirmResponse(rawResponse, paymentOrder, request.paymentKey());
+
+        Payment payment = PaymentMapper.toEntity(rawResponse, currentMember, paymentOrder);
+
+        try {
+            paymentRepository.save(payment);
+            paymentOrder.markPaid();
+            PointChargePackage paymentPackage = resolvePackage(paymentOrder.getPackageId());
+            seniorProfileService.addPointsToMember(
+                    currentMember.getId(),
+                    (long) paymentPackage.getPointAmount(),
+                    paymentPackage.getOrderName()
+            );
+        } catch (DataIntegrityViolationException e) {
+            Payment duplicatedPayment = paymentRepository.findByPaymentKey(request.paymentKey())
+                    .orElseThrow(() -> new BusinessException(ErrorCode.PAYMENT_FAILED, "중복 결제 저장 처리에 실패했습니다."));
+            validatePaymentOwnership(duplicatedPayment, currentMember.getId());
+            validateExistingPaymentMatchesOrder(duplicatedPayment, paymentOrder);
+            return PaymentConfirmResponse.from(duplicatedPayment);
+        }
 
         return PaymentConfirmResponse.from(payment);
     }
 
-
     @Transactional
     public PaymentConfirmResponse cancelPayment(String paymentKey, CancelRequest cancelRequest) {
-        PaymentConfirmResponse response = paymentClient.cancelPayment(paymentKey, cancelRequest);
-
         Payment payment = paymentRepository.findByPaymentKey(paymentKey)
                 .orElseThrow(() -> new BusinessException(ErrorCode.PAYMENT_NOT_FOUND));
+        Member currentMember = memberUtil.getCurrentMember();
 
-        payment.cancel(cancelRequest.cancelReason());
+        validatePaymentOwnership(payment, currentMember.getId());
+
+        if (payment.isCanceled()) {
+            return PaymentConfirmResponse.from(payment);
+        }
+
+        CancelRequest effectiveRequest = sanitizeCancelRequest(payment, cancelRequest);
+        int refundPointAmount = calculateRefundPointAmount(payment, effectiveRequest.cancelAmount());
+        validateRefundPointBalance(currentMember, refundPointAmount);
+        PaymentConfirmResponse response = paymentClient.cancelPayment(paymentKey, effectiveRequest);
+        validateCancelResponse(response, paymentKey, effectiveRequest.cancelAmount());
+
+        ZonedDateTime canceledAt = ZonedDateTime.now();
+        PaymentCancel paymentCancel = PaymentCancel.create(
+                payment,
+                effectiveRequest.cancelAmount(),
+                refundPointAmount,
+                effectiveRequest.cancelReason(),
+                currentMember.getId(),
+                canceledAt
+        );
+        payment.addCancellation(paymentCancel);
+        payment.cancel(effectiveRequest.cancelAmount(), refundPointAmount, effectiveRequest.cancelReason(), canceledAt);
+        seniorProfileService.deductPointsFromMember(
+                currentMember.getId(),
+                (long) refundPointAmount,
+                effectiveRequest.cancelReason()
+        );
+
+        if (payment.getPaymentOrder() != null && payment.getStatus() == PaymentStatus.CANCELED) {
+            payment.getPaymentOrder().markCanceled();
+        }
 
         return PaymentConfirmResponse.from(payment);
     }
@@ -60,5 +177,114 @@ public class PaymentService {
         }
 
         return PaymentConfirmResponses.from(payments);
+    }
+
+    private void validatePaymentOwnership(Payment payment, Long memberId) {
+        if (!payment.isOwnedBy(memberId)) {
+            throw new BusinessException(ErrorCode.FORBIDDEN, "본인 결제만 접근할 수 있습니다.");
+        }
+    }
+
+    private void validateSeniorMember(Member member) {
+        if (member.getType() != MemberType.SENIOR || member.getSeniorProfile() == null) {
+            throw new BusinessException(ErrorCode.FORBIDDEN, "시니어 회원만 포인트를 충전할 수 있습니다.");
+        }
+    }
+
+    private void validatePaymentOrderOwnership(PaymentOrder paymentOrder, Long memberId) {
+        if (!paymentOrder.isOwnedBy(memberId)) {
+            throw new BusinessException(ErrorCode.FORBIDDEN, "본인 주문만 결제할 수 있습니다.");
+        }
+    }
+
+    private void validatePaymentOrderState(PaymentOrder paymentOrder) {
+        if (paymentOrder.isExpired()) {
+            paymentOrder.markExpired();
+            throw new BusinessException(ErrorCode.BAD_REQUEST, "만료된 주문입니다.");
+        }
+        if (!paymentOrder.isCreated()) {
+            throw new BusinessException(ErrorCode.BAD_REQUEST, "이미 처리된 주문입니다.");
+        }
+    }
+
+    private void validateExistingPaymentMatchesOrder(Payment payment, PaymentOrder paymentOrder) {
+        if (!payment.matches(paymentOrder.getOrderId(), paymentOrder.getAmount())) {
+            throw new BusinessException(ErrorCode.BAD_REQUEST, "기존 결제 요청 정보와 일치하지 않습니다.");
+        }
+    }
+
+    private void validateConfirmResponse(PaymentConfirmResponse response, PaymentOrder paymentOrder, String paymentKey) {
+        if (!Objects.equals(response.getPaymentKey(), paymentKey)
+                || !Objects.equals(response.getOrderId(), paymentOrder.getOrderId())
+                || response.getAmount() != paymentOrder.getAmount()) {
+            throw new BusinessException(ErrorCode.PAYMENT_FAILED, "PG 응답과 요청 정보가 일치하지 않습니다.");
+        }
+    }
+
+    private void validateCancelResponse(PaymentConfirmResponse response, String paymentKey, int cancelAmount) {
+        if (!Objects.equals(response.getPaymentKey(), paymentKey)) {
+            throw new BusinessException(ErrorCode.PAYMENT_FAILED, "취소 응답의 결제 키가 일치하지 않습니다.");
+        }
+        if (cancelAmount <= 0) {
+            throw new BusinessException(ErrorCode.BAD_REQUEST, "취소 금액은 0보다 커야 합니다.");
+        }
+    }
+
+    private CancelRequest sanitizeCancelRequest(Payment payment, CancelRequest cancelRequest) {
+        String reason = cancelRequest != null ? cancelRequest.cancelReason() : null;
+        if (reason == null || reason.isBlank()) {
+            reason = "사용자 요청";
+        }
+
+        int remainingAmount = payment.getRemainingAmount();
+        Integer requestedCancelAmount = cancelRequest != null ? cancelRequest.cancelAmount() : null;
+        int cancelAmount = requestedCancelAmount != null ? requestedCancelAmount : remainingAmount;
+
+        if (cancelAmount <= 0) {
+            throw new BusinessException(ErrorCode.BAD_REQUEST, "취소 금액은 0보다 커야 합니다.");
+        }
+        if (cancelAmount > remainingAmount) {
+            throw new BusinessException(ErrorCode.BAD_REQUEST, "남은 결제 금액보다 크게 취소할 수 없습니다.");
+        }
+
+        return new CancelRequest(reason, cancelAmount);
+    }
+
+    private int calculateRefundPointAmount(Payment payment, int cancelAmount) {
+        PaymentOrder paymentOrder = payment.getPaymentOrder();
+        if (paymentOrder == null) {
+            return cancelAmount;
+        }
+
+        int nextCanceledAmount = payment.getCanceledAmount() + cancelAmount;
+        int targetCanceledPoints = (int) (((long) paymentOrder.getPointAmount() * nextCanceledAmount) / payment.getAmount());
+        return targetCanceledPoints - payment.getCanceledPointAmount();
+    }
+
+    private void validateRefundPointBalance(Member currentMember, int refundPointAmount) {
+        if (refundPointAmount <= 0) {
+            return;
+        }
+        if (currentMember.getSeniorProfile() == null || !currentMember.getSeniorProfile().hasEnoughPoints((long) refundPointAmount)) {
+            throw new BusinessException(ErrorCode.BAD_REQUEST, "결제 취소에 필요한 포인트가 부족합니다.");
+        }
+    }
+
+    private String generateOrderId() {
+        for (int attempt = 0; attempt < ORDER_ID_MAX_ATTEMPTS; attempt++) {
+            String candidate = "order_" + UUID.randomUUID().toString().replace("-", "").substring(0, 16);
+            if (!paymentOrderRepository.existsByOrderId(candidate)) {
+                return candidate;
+            }
+        }
+        throw new BusinessException(ErrorCode.INTERNAL_SERVER_ERROR, "주문 ID 생성에 실패했습니다.");
+    }
+
+    private PointChargePackage resolvePackage(String packageId) {
+        try {
+            return PointChargePackage.fromId(packageId);
+        } catch (IllegalArgumentException e) {
+            throw new BusinessException(ErrorCode.BAD_REQUEST, e.getMessage());
+        }
     }
 }

--- a/backend/widyu-api/src/main/java/com/widyu/pay/config/PaymentClient.java
+++ b/backend/widyu-api/src/main/java/com/widyu/pay/config/PaymentClient.java
@@ -1,7 +1,7 @@
 package com.widyu.pay.config;
 
 import com.widyu.pay.dto.request.CancelRequest;
-import com.widyu.pay.dto.request.PaymentConfirmRequest;
+import com.widyu.pay.dto.request.PaymentGatewayConfirmRequest;
 import com.widyu.pay.dto.response.PaymentConfirmResponse;
 import org.springframework.cloud.openfeign.FeignClient;
 import org.springframework.http.MediaType;
@@ -13,10 +13,9 @@ import org.springframework.web.bind.annotation.RequestBody;
 public interface PaymentClient {
 
     @PostMapping(value = "/confirm", consumes = MediaType.APPLICATION_JSON_VALUE)
-    PaymentConfirmResponse confirmPayment(@RequestBody PaymentConfirmRequest paymentConfirmRequest);
+    PaymentConfirmResponse confirmPayment(@RequestBody PaymentGatewayConfirmRequest paymentConfirmRequest);
 
     @PostMapping(value = "/{paymentKey}/cancel", consumes = MediaType.APPLICATION_JSON_VALUE)
     PaymentConfirmResponse cancelPayment(@PathVariable("paymentKey") String paymentKey,
                                          @RequestBody CancelRequest cancelRequest);
 }
-

--- a/backend/widyu-api/src/main/java/com/widyu/pay/config/PaymentLoggingInterceptor.java
+++ b/backend/widyu-api/src/main/java/com/widyu/pay/config/PaymentLoggingInterceptor.java
@@ -12,6 +12,8 @@ public class PaymentLoggingInterceptor implements RequestInterceptor {
     @Override
     public void apply(RequestTemplate template) {
         logger.info("Payment Request: {} {}", template.method(), template.url());
-        logger.info("Payment Request Body: {}", new String(template.body()));
+        if (template.body() != null) {
+            logger.info("Payment Request Body: [redacted, {} bytes]", template.body().length);
+        }
     }
 }

--- a/backend/widyu-api/src/main/java/com/widyu/pay/controller/PaymentController.java
+++ b/backend/widyu-api/src/main/java/com/widyu/pay/controller/PaymentController.java
@@ -1,14 +1,23 @@
 package com.widyu.pay.controller;
 
 import com.widyu.global.response.ApiResponseTemplate;
+import com.widyu.pay.application.PaymentService;
 import com.widyu.pay.controller.docs.PaymentDocs;
 import com.widyu.pay.dto.request.CancelRequest;
-import com.widyu.pay.dto.request.PaymentConfirmRequest;
+import com.widyu.pay.dto.request.PaymentApproveRequest;
+import com.widyu.pay.dto.request.PaymentOrderCreateRequest;
 import com.widyu.pay.dto.response.PaymentConfirmResponse;
 import com.widyu.pay.dto.response.PaymentConfirmResponses;
-import com.widyu.pay.application.PaymentService;
+import com.widyu.pay.dto.response.PaymentPackageResponse;
+import com.widyu.pay.dto.response.PaymentOrderResponse;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequiredArgsConstructor
@@ -17,11 +26,31 @@ public class PaymentController implements PaymentDocs {
 
     private final PaymentService paymentService;
 
+    @GetMapping("/packages")
+    public ApiResponseTemplate<java.util.List<PaymentPackageResponse>> getPackages() {
+        return ApiResponseTemplate.ok()
+                .code("PAY_1999")
+                .message("결제 패키지 조회 성공")
+                .body(paymentService.getPackages());
+    }
+
+    @PostMapping("/orders")
+    public ApiResponseTemplate<PaymentOrderResponse> createOrder(
+            @RequestBody @Valid PaymentOrderCreateRequest paymentOrderCreateRequest
+    ) {
+        PaymentOrderResponse response = paymentService.createOrder(paymentOrderCreateRequest);
+
+        return ApiResponseTemplate.ok()
+                .code("PAY_2000")
+                .message("주문 생성 성공")
+                .body(response);
+    }
+
     @PostMapping
     public ApiResponseTemplate<PaymentConfirmResponse> confirm(
-            @RequestBody PaymentConfirmRequest paymentConfirmRequest
+            @RequestBody @Valid PaymentApproveRequest paymentApproveRequest
     ) {
-        PaymentConfirmResponse response = paymentService.confirmPayment(paymentConfirmRequest);
+        PaymentConfirmResponse response = paymentService.confirmPayment(paymentApproveRequest);
 
         return ApiResponseTemplate.ok()
                 .code("PAY_2001")
@@ -32,7 +61,7 @@ public class PaymentController implements PaymentDocs {
     @PostMapping("/{paymentKey}/cancel")
     public ApiResponseTemplate<PaymentConfirmResponse> cancelPayment(
             @PathVariable String paymentKey,
-            @RequestBody(required = false) CancelRequest cancelRequest
+            @RequestBody(required = false) @Valid CancelRequest cancelRequest
     ) {
         PaymentConfirmResponse response = paymentService.cancelPayment(paymentKey, cancelRequest);
 

--- a/backend/widyu-api/src/main/java/com/widyu/pay/controller/docs/PaymentDocs.java
+++ b/backend/widyu-api/src/main/java/com/widyu/pay/controller/docs/PaymentDocs.java
@@ -2,9 +2,12 @@ package com.widyu.pay.controller.docs;
 
 import com.widyu.global.response.ApiResponseTemplate;
 import com.widyu.pay.dto.request.CancelRequest;
-import com.widyu.pay.dto.request.PaymentConfirmRequest;
+import com.widyu.pay.dto.request.PaymentApproveRequest;
+import com.widyu.pay.dto.request.PaymentOrderCreateRequest;
 import com.widyu.pay.dto.response.PaymentConfirmResponse;
 import com.widyu.pay.dto.response.PaymentConfirmResponses;
+import com.widyu.pay.dto.response.PaymentPackageResponse;
+import com.widyu.pay.dto.response.PaymentOrderResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Content;
@@ -18,8 +21,38 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 public interface PaymentDocs {
 
     @Operation(
+            summary = "결제 패키지 목록 조회",
+            description = "서버가 제공하는 포인트 충전 패키지 목록을 조회합니다."
+    )
+    @ApiResponse(responseCode = "200", description = "패키지 조회 성공")
+    ApiResponseTemplate<java.util.List<PaymentPackageResponse>> getPackages();
+
+    @Operation(
+            summary = "결제 주문 생성",
+            description = "결제 승인 전에 서버에 선행 주문을 생성하고 주문 ID, 금액, 만료 시각을 반환합니다."
+    )
+    @ApiResponse(responseCode = "200", description = "주문 생성 성공")
+    ApiResponseTemplate<PaymentOrderResponse> createOrder(
+            @RequestBody(
+                    required = true,
+                    description = "주문 생성 요청 정보",
+                    content = @Content(
+                            schema = @Schema(implementation = PaymentOrderCreateRequest.class),
+                            examples = @ExampleObject(
+                                    name = "주문 생성 요청 예시",
+                                    value = """
+                                            {
+                                              "packageId": "POINT_10000"
+                                            }
+                                            """
+                            )
+                    )
+            ) final PaymentOrderCreateRequest paymentOrderCreateRequest
+    );
+
+    @Operation(
             summary = "결제 승인",
-            description = "결제를 승인하고 결제 정보를 반환합니다."
+            description = "미리 생성한 주문을 기준으로 결제를 승인하고 결제 정보를 반환합니다."
     )
     @ApiResponse(
             responseCode = "200",
@@ -47,19 +80,18 @@ public interface PaymentDocs {
                     required = true,
                     description = "결제 승인 요청 정보",
                     content = @Content(
-                            schema = @Schema(implementation = PaymentConfirmRequest.class),
+                            schema = @Schema(implementation = PaymentApproveRequest.class),
                             examples = @ExampleObject(
                                     name = "결제 승인 요청 예시",
                                     value = """
                                             {
                                               "orderId": "order_123456",
-                                              "amount": 10000,
                                               "paymentKey": "pay_abc123"
                                             }
                                             """
                             )
                     )
-            ) final PaymentConfirmRequest paymentConfirmRequest
+            ) final PaymentApproveRequest paymentApproveRequest
     );
 
     @Operation(
@@ -128,18 +160,20 @@ public interface PaymentDocs {
                                     {
                                       "code": "PAY_2003",
                                       "message": "결제 목록 조회 성공",
-                                      "data": [
-                                        {
-                                          "paymentKey": "pay_abc123",
-                                          "orderId": "order_123456",
-                                          "status": "DONE"
-                                        },
-                                        {
-                                          "paymentKey": "pay_xyz789",
-                                          "orderId": "order_789123",
-                                          "status": "CANCELED"
-                                        }
-                                      ]
+                                      "data": {
+                                        "payments": [
+                                          {
+                                            "paymentKey": "pay_abc123",
+                                            "orderId": "order_123456",
+                                            "status": "DONE"
+                                          },
+                                          {
+                                            "paymentKey": "pay_xyz789",
+                                            "orderId": "order_789123",
+                                            "status": "PARTIAL_CANCELED"
+                                          }
+                                        ]
+                                      }
                                     }
                                     """
                     )

--- a/backend/widyu-api/src/main/java/com/widyu/pay/dto/mapper/PaymentMapper.java
+++ b/backend/widyu-api/src/main/java/com/widyu/pay/dto/mapper/PaymentMapper.java
@@ -1,23 +1,27 @@
 package com.widyu.pay.dto.mapper;
 
-import com.widyu.member.Member;
-import com.widyu.pay.dto.response.PaymentConfirmResponse;
 import com.widyu.pay.Payment;
 import com.widyu.pay.PaymentCard;
 import com.widyu.pay.PaymentEasyPay;
+import com.widyu.pay.PaymentOrder;
 import com.widyu.pay.PaymentStatus;
 import com.widyu.pay.PaymentTransfer;
 import com.widyu.pay.PaymentVirtualAccount;
+import com.widyu.pay.dto.response.PaymentConfirmResponse;
+import com.widyu.member.Member;
 
 public class PaymentMapper {
 
-    public static Payment toEntity(PaymentConfirmResponse dto, Member member) {
+    public static Payment toEntity(PaymentConfirmResponse dto, Member member, PaymentOrder paymentOrder) {
         Payment payment = Payment.builder()
                 .member(member)
+                .paymentOrder(paymentOrder)
                 .paymentKey(dto.getPaymentKey())
                 .orderId(dto.getOrderId())
                 .orderName(dto.getOrderName())
                 .amount(dto.getAmount())
+                .canceledAmount(0)
+                .canceledPointAmount(0)
                 .status(dto.getStatus() != null ? dto.getStatus() : PaymentStatus.DONE)
                 .requestedAt(dto.getRequestedAt())
                 .approvedAt(dto.getApprovedAt())

--- a/backend/widyu-api/src/main/java/com/widyu/pay/dto/request/CancelRequest.java
+++ b/backend/widyu-api/src/main/java/com/widyu/pay/dto/request/CancelRequest.java
@@ -1,9 +1,13 @@
 package com.widyu.pay.dto.request;
 
+import jakarta.validation.constraints.Positive;
+import jakarta.validation.constraints.Size;
 
 public record CancelRequest(
+        @Size(max = 200, message = "취소 사유는 최대 200자입니다.")
         String cancelReason,
+
+        @Positive(message = "취소 금액은 0보다 커야 합니다.")
         Integer cancelAmount
 ) {
 }
-

--- a/backend/widyu-api/src/main/java/com/widyu/pay/dto/request/PaymentApproveRequest.java
+++ b/backend/widyu-api/src/main/java/com/widyu/pay/dto/request/PaymentApproveRequest.java
@@ -1,0 +1,12 @@
+package com.widyu.pay.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record PaymentApproveRequest(
+        @NotBlank(message = "주문 ID는 필수입니다.")
+        String orderId,
+
+        @NotBlank(message = "결제 키는 필수입니다.")
+        String paymentKey
+) {
+}

--- a/backend/widyu-api/src/main/java/com/widyu/pay/dto/request/PaymentGatewayConfirmRequest.java
+++ b/backend/widyu-api/src/main/java/com/widyu/pay/dto/request/PaymentGatewayConfirmRequest.java
@@ -1,9 +1,8 @@
 package com.widyu.pay.dto.request;
 
-public record PaymentConfirmRequest(
+public record PaymentGatewayConfirmRequest(
         String orderId,
         int amount,
         String paymentKey
 ) {
-
 }

--- a/backend/widyu-api/src/main/java/com/widyu/pay/dto/request/PaymentOrderCreateRequest.java
+++ b/backend/widyu-api/src/main/java/com/widyu/pay/dto/request/PaymentOrderCreateRequest.java
@@ -1,0 +1,9 @@
+package com.widyu.pay.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record PaymentOrderCreateRequest(
+        @NotBlank(message = "패키지 ID는 필수입니다.")
+        String packageId
+) {
+}

--- a/backend/widyu-api/src/main/java/com/widyu/pay/dto/response/PaymentConfirmResponse.java
+++ b/backend/widyu-api/src/main/java/com/widyu/pay/dto/response/PaymentConfirmResponse.java
@@ -1,11 +1,13 @@
 package com.widyu.pay.dto.response;
 
 import com.widyu.pay.Payment;
+import com.widyu.pay.PaymentCancel;
 import com.widyu.pay.PaymentCard;
 import com.widyu.pay.PaymentEasyPay;
 import com.widyu.pay.PaymentStatus;
 import com.widyu.pay.PaymentTransfer;
 import com.widyu.pay.PaymentVirtualAccount;
+import java.util.List;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -25,8 +27,12 @@ public class PaymentConfirmResponse {
     private PaymentStatus status;
     private ZonedDateTime requestedAt;
     private ZonedDateTime approvedAt;
+    private int canceledAmount;
+    private int canceledPointAmount;
+    private int remainingAmount;
     private boolean useEscrow;
     private boolean cultureExpense;
+    private List<CancelHistory> cancellations;
 
     // 세부 결제 수단
     private Card card;
@@ -70,6 +76,16 @@ public class PaymentConfirmResponse {
         private boolean expired;
     }
 
+    @Getter
+    @NoArgsConstructor
+    public static class CancelHistory {
+        private int cancelAmount;
+        private int cancelPointAmount;
+        private String cancelReason;
+        private Long requestedByMemberId;
+        private ZonedDateTime canceledAt;
+    }
+
     // ---------------------- 정적 팩토리 메서드 ----------------------
     public static PaymentConfirmResponse from(Payment payment) {
         PaymentConfirmResponse response = new PaymentConfirmResponse();
@@ -81,7 +97,13 @@ public class PaymentConfirmResponse {
         response.status = payment.getStatus();
         response.requestedAt = payment.getRequestedAt();
         response.approvedAt = payment.getApprovedAt();
+        response.canceledAmount = payment.getCanceledAmount();
+        response.canceledPointAmount = payment.getCanceledPointAmount();
+        response.remainingAmount = payment.getRemainingAmount();
         response.cultureExpense = payment.isCultureExpense();
+        response.cancellations = payment.getCancellations().stream()
+                .map(PaymentConfirmResponse::mapCancelHistory)
+                .toList();
 
         // 카드 결제 매핑
         if (payment.getCard() != null) {
@@ -128,6 +150,16 @@ public class PaymentConfirmResponse {
         }
 
         return response;
+    }
+
+    private static CancelHistory mapCancelHistory(PaymentCancel paymentCancel) {
+        CancelHistory cancelHistory = new CancelHistory();
+        cancelHistory.cancelAmount = paymentCancel.getCancelAmount();
+        cancelHistory.cancelPointAmount = paymentCancel.getCancelPointAmount();
+        cancelHistory.cancelReason = paymentCancel.getCancelReason();
+        cancelHistory.requestedByMemberId = paymentCancel.getRequestedByMemberId();
+        cancelHistory.canceledAt = paymentCancel.getCanceledAt();
+        return cancelHistory;
     }
 
 }

--- a/backend/widyu-api/src/main/java/com/widyu/pay/dto/response/PaymentOrderResponse.java
+++ b/backend/widyu-api/src/main/java/com/widyu/pay/dto/response/PaymentOrderResponse.java
@@ -1,0 +1,27 @@
+package com.widyu.pay.dto.response;
+
+import com.widyu.pay.PaymentOrder;
+import com.widyu.pay.PaymentOrderStatus;
+import java.time.ZonedDateTime;
+
+public record PaymentOrderResponse(
+        String orderId,
+        String packageId,
+        String orderName,
+        int amount,
+        int pointAmount,
+        PaymentOrderStatus status,
+        ZonedDateTime expiresAt
+) {
+    public static PaymentOrderResponse from(PaymentOrder paymentOrder) {
+        return new PaymentOrderResponse(
+                paymentOrder.getOrderId(),
+                paymentOrder.getPackageId(),
+                paymentOrder.getOrderName(),
+                paymentOrder.getAmount(),
+                paymentOrder.getPointAmount(),
+                paymentOrder.getStatus(),
+                paymentOrder.getExpiresAt()
+        );
+    }
+}

--- a/backend/widyu-api/src/main/java/com/widyu/pay/dto/response/PaymentPackageResponse.java
+++ b/backend/widyu-api/src/main/java/com/widyu/pay/dto/response/PaymentPackageResponse.java
@@ -1,0 +1,19 @@
+package com.widyu.pay.dto.response;
+
+import com.widyu.pay.PointChargePackage;
+
+public record PaymentPackageResponse(
+        String packageId,
+        String orderName,
+        int amount,
+        int pointAmount
+) {
+    public static PaymentPackageResponse from(PointChargePackage paymentPackage) {
+        return new PaymentPackageResponse(
+                paymentPackage.getId(),
+                paymentPackage.getOrderName(),
+                paymentPackage.getAmount(),
+                paymentPackage.getPointAmount()
+        );
+    }
+}

--- a/backend/widyu-api/src/main/java/com/widyu/pay/repository/PaymentOrderRepository.java
+++ b/backend/widyu-api/src/main/java/com/widyu/pay/repository/PaymentOrderRepository.java
@@ -1,0 +1,12 @@
+package com.widyu.pay.repository;
+
+import com.widyu.pay.PaymentOrder;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface PaymentOrderRepository extends JpaRepository<PaymentOrder, Long> {
+
+    Optional<PaymentOrder> findByOrderId(String orderId);
+
+    boolean existsByOrderId(String orderId);
+}

--- a/backend/widyu-api/src/main/java/com/widyu/pay/repository/PaymentRepository.java
+++ b/backend/widyu-api/src/main/java/com/widyu/pay/repository/PaymentRepository.java
@@ -9,7 +9,6 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
-import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
 public interface PaymentRepository extends JpaRepository<Payment, Long> {

--- a/backend/widyu-api/src/test/java/com/widyu/pay/application/PaymentServiceTest.java
+++ b/backend/widyu-api/src/test/java/com/widyu/pay/application/PaymentServiceTest.java
@@ -1,0 +1,305 @@
+package com.widyu.pay.application;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+import com.widyu.global.error.BusinessException;
+import com.widyu.global.error.ErrorCode;
+import com.widyu.global.util.MemberUtil;
+import com.widyu.member.Member;
+import com.widyu.member.MemberType;
+import com.widyu.member.SeniorProfile;
+import com.widyu.member.application.SeniorProfileService;
+import com.widyu.pay.Payment;
+import com.widyu.pay.PaymentOrder;
+import com.widyu.pay.PaymentOrderStatus;
+import com.widyu.pay.PaymentStatus;
+import com.widyu.pay.PointChargePackage;
+import com.widyu.pay.config.PaymentClient;
+import com.widyu.pay.dto.request.CancelRequest;
+import com.widyu.pay.dto.request.PaymentApproveRequest;
+import com.widyu.pay.dto.request.PaymentOrderCreateRequest;
+import com.widyu.pay.dto.response.PaymentConfirmResponse;
+import com.widyu.pay.dto.response.PaymentPackageResponse;
+import com.widyu.pay.dto.response.PaymentOrderResponse;
+import com.widyu.pay.repository.PaymentOrderRepository;
+import com.widyu.pay.repository.PaymentRepository;
+import java.time.ZonedDateTime;
+import java.util.Optional;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("PaymentService 단위 테스트")
+class PaymentServiceTest {
+
+    @Mock private PaymentClient paymentClient;
+    @Mock private PaymentRepository paymentRepository;
+    @Mock private PaymentOrderRepository paymentOrderRepository;
+    @Mock private MemberUtil memberUtil;
+    @Mock private SeniorProfileService seniorProfileService;
+
+    @InjectMocks
+    private PaymentService paymentService;
+
+    @Test
+    @DisplayName("주문 생성 시 서버가 orderId와 만료 시각을 포함한 주문을 저장한다")
+    void 주문_생성() {
+        Member member = createMember(1L, "보호자");
+        given(memberUtil.getCurrentMember()).willReturn(member);
+        given(paymentOrderRepository.save(any())).willAnswer(invocation -> invocation.getArgument(0));
+
+        PaymentOrderResponse response = paymentService.createOrder(new PaymentOrderCreateRequest("POINT_10000"));
+
+        assertThat(response.orderId()).startsWith("order_");
+        assertThat(response.packageId()).isEqualTo("POINT_10000");
+        assertThat(response.amount()).isEqualTo(10000);
+        assertThat(response.pointAmount()).isEqualTo(10000);
+        assertThat(response.status()).isEqualTo(PaymentOrderStatus.CREATED);
+        assertThat(response.expiresAt()).isAfter(ZonedDateTime.now());
+    }
+
+    @Test
+    @DisplayName("결제 패키지 목록을 조회하면 서버 카탈로그를 반환한다")
+    void 결제_패키지_목록_조회() {
+        java.util.List<PaymentPackageResponse> responses = paymentService.getPackages();
+
+        assertThat(responses).isNotEmpty();
+        assertThat(responses.get(0).packageId()).isEqualTo(PointChargePackage.POINT_10000.getId());
+    }
+
+    @Test
+    @DisplayName("이미 저장된 주문 결제면 기존 결제를 반환하고 PG 승인 호출을 생략한다")
+    void 중복_결제_승인_요청은_기존_결제를_반환한다() {
+        Member member = createMember(1L, "보호자");
+        PaymentOrder paymentOrder = createOrder(member, "order_123", 10000, PaymentOrderStatus.CREATED);
+        Payment payment = createPayment(member, paymentOrder, "pay_123", "order_123", 10000, PaymentStatus.DONE);
+        PaymentApproveRequest request = new PaymentApproveRequest("order_123", "pay_123");
+
+        given(memberUtil.getCurrentMember()).willReturn(member);
+        given(paymentOrderRepository.findByOrderId("order_123")).willReturn(Optional.of(paymentOrder));
+        given(paymentRepository.findByOrderId("order_123")).willReturn(Optional.of(payment));
+
+        PaymentConfirmResponse response = paymentService.confirmPayment(request);
+
+        assertThat(response.getPaymentKey()).isEqualTo("pay_123");
+        verify(paymentClient, never()).confirmPayment(any());
+    }
+
+    @Test
+    @DisplayName("다른 사용자의 주문을 승인하려 하면 예외가 발생한다")
+    void 타인_주문_결제_승인은_예외가_발생한다() {
+        Member currentMember = createMember(1L, "보호자");
+        Member otherMember = createMember(2L, "다른보호자");
+        PaymentOrder paymentOrder = createOrder(otherMember, "order_123", 10000, PaymentOrderStatus.CREATED);
+        PaymentApproveRequest request = new PaymentApproveRequest("order_123", "pay_123");
+
+        given(memberUtil.getCurrentMember()).willReturn(currentMember);
+        given(paymentOrderRepository.findByOrderId("order_123")).willReturn(Optional.of(paymentOrder));
+
+        assertThatThrownBy(() -> paymentService.confirmPayment(request))
+                .isInstanceOf(BusinessException.class)
+                .hasFieldOrPropertyWithValue("errorCode", ErrorCode.FORBIDDEN);
+
+        verify(paymentClient, never()).confirmPayment(any());
+    }
+
+    @Test
+    @DisplayName("결제 취소 시 본인 결제면 취소하고 승인 시각은 유지한다")
+    void 본인_결제_취소() {
+        Member member = createMember(1L, "보호자");
+        given(member.getSeniorProfile().hasEnoughPoints(10000L)).willReturn(true);
+        PaymentOrder paymentOrder = createOrder(member, "order_123", 10000, PaymentOrderStatus.PAID);
+        Payment payment = createPayment(member, paymentOrder, "pay_123", "order_123", 10000, PaymentStatus.DONE);
+        ZonedDateTime approvedAt = payment.getApprovedAt();
+        PaymentConfirmResponse canceledResponse = createResponse("pay_123", "order_123", 10000, PaymentStatus.CANCELED);
+
+        given(memberUtil.getCurrentMember()).willReturn(member);
+        given(paymentRepository.findByPaymentKey("pay_123")).willReturn(Optional.of(payment));
+        given(paymentClient.cancelPayment("pay_123", new CancelRequest("사용자 요청", 10000))).willReturn(canceledResponse);
+
+        PaymentConfirmResponse result = paymentService.cancelPayment("pay_123", null);
+
+        assertThat(result.getStatus()).isEqualTo(PaymentStatus.CANCELED);
+        assertThat(payment.getCancelReason()).isEqualTo("사용자 요청");
+        assertThat(payment.getCanceledAt()).isNotNull();
+        assertThat(payment.getCanceledAmount()).isEqualTo(10000);
+        assertThat(payment.getCanceledPointAmount()).isEqualTo(10000);
+        assertThat(payment.getRemainingAmount()).isZero();
+        assertThat(payment.getApprovedAt()).isEqualTo(approvedAt);
+        assertThat(paymentOrder.getStatus()).isEqualTo(PaymentOrderStatus.CANCELED);
+        assertThat(result.getCancellations()).hasSize(1);
+        verify(seniorProfileService).deductPointsFromMember(member.getId(), 10000L, "사용자 요청");
+    }
+
+    @Test
+    @DisplayName("다른 사용자의 결제를 취소하려 하면 예외가 발생한다")
+    void 타인_결제_취소는_예외가_발생한다() {
+        Member currentMember = createMember(1L, "보호자");
+        Member otherMember = createMember(2L, "다른보호자");
+        PaymentOrder paymentOrder = createOrder(otherMember, "order_123", 10000, PaymentOrderStatus.PAID);
+        Payment payment = createPayment(otherMember, paymentOrder, "pay_123", "order_123", 10000, PaymentStatus.DONE);
+
+        given(memberUtil.getCurrentMember()).willReturn(currentMember);
+        given(paymentRepository.findByPaymentKey("pay_123")).willReturn(Optional.of(payment));
+
+        assertThatThrownBy(() -> paymentService.cancelPayment("pay_123", new CancelRequest("사용자 요청", null)))
+                .isInstanceOf(BusinessException.class)
+                .hasFieldOrPropertyWithValue("errorCode", ErrorCode.FORBIDDEN);
+
+        verify(paymentClient, never()).cancelPayment(any(), any());
+    }
+
+    @Test
+    @DisplayName("이미 취소된 결제는 PG 재호출 없이 기존 상태를 반환한다")
+    void 이미_취소된_결제는_멱등하게_처리한다() {
+        Member member = createMember(1L, "보호자");
+        PaymentOrder paymentOrder = createOrder(member, "order_123", 10000, PaymentOrderStatus.CANCELED);
+        Payment payment = createPayment(member, paymentOrder, "pay_123", "order_123", 10000, PaymentStatus.DONE);
+        payment.cancel(10000, 10000, "기존 취소", ZonedDateTime.now());
+
+        given(memberUtil.getCurrentMember()).willReturn(member);
+        given(paymentRepository.findByPaymentKey("pay_123")).willReturn(Optional.of(payment));
+
+        PaymentConfirmResponse result = paymentService.cancelPayment("pay_123", new CancelRequest("다시 취소", null));
+
+        assertThat(result.getStatus()).isEqualTo(PaymentStatus.CANCELED);
+        assertThat(payment.getCancelReason()).isEqualTo("기존 취소");
+        verify(paymentClient, never()).cancelPayment(any(), any());
+    }
+
+    @Test
+    @DisplayName("부분 취소 시 취소 이력이 누적되고 상태가 PARTIAL_CANCELED로 변경된다")
+    void 부분_취소() {
+        Member member = createMember(1L, "보호자");
+        given(member.getSeniorProfile().hasEnoughPoints(3000L)).willReturn(true);
+        PaymentOrder paymentOrder = createOrder(member, "order_123", 10000, PaymentOrderStatus.PAID);
+        Payment payment = createPayment(member, paymentOrder, "pay_123", "order_123", 10000, PaymentStatus.DONE);
+        PaymentConfirmResponse partialCanceledResponse = createResponse("pay_123", "order_123", 10000, PaymentStatus.PARTIAL_CANCELED);
+
+        given(memberUtil.getCurrentMember()).willReturn(member);
+        given(paymentRepository.findByPaymentKey("pay_123")).willReturn(Optional.of(payment));
+        given(paymentClient.cancelPayment("pay_123", new CancelRequest("부분 취소", 3000))).willReturn(partialCanceledResponse);
+
+        PaymentConfirmResponse result = paymentService.cancelPayment("pay_123", new CancelRequest("부분 취소", 3000));
+
+        assertThat(result.getStatus()).isEqualTo(PaymentStatus.PARTIAL_CANCELED);
+        assertThat(payment.getCanceledAmount()).isEqualTo(3000);
+        assertThat(payment.getCanceledPointAmount()).isEqualTo(3000);
+        assertThat(payment.getRemainingAmount()).isEqualTo(7000);
+        assertThat(result.getCancellations()).hasSize(1);
+        assertThat(paymentOrder.getStatus()).isEqualTo(PaymentOrderStatus.PAID);
+        verify(seniorProfileService).deductPointsFromMember(member.getId(), 3000L, "부분 취소");
+    }
+
+    @Test
+    @DisplayName("결제 취소에 필요한 포인트가 부족하면 PG 취소 전에 예외가 발생한다")
+    void 결제_취소_전_포인트_부족_검증() {
+        Member member = createMember(1L, "시니어");
+        SeniorProfile seniorProfile = member.getSeniorProfile();
+        given(seniorProfile.hasEnoughPoints(10000L)).willReturn(false);
+
+        PaymentOrder paymentOrder = createOrder(member, "order_123", 10000, PaymentOrderStatus.PAID);
+        Payment payment = createPayment(member, paymentOrder, "pay_123", "order_123", 10000, PaymentStatus.DONE);
+
+        given(memberUtil.getCurrentMember()).willReturn(member);
+        given(paymentRepository.findByPaymentKey("pay_123")).willReturn(Optional.of(payment));
+
+        assertThatThrownBy(() -> paymentService.cancelPayment("pay_123", null))
+                .isInstanceOf(BusinessException.class)
+                .hasFieldOrPropertyWithValue("errorCode", ErrorCode.BAD_REQUEST);
+
+        verify(paymentClient, never()).cancelPayment(any(), any());
+    }
+
+    @Test
+    @DisplayName("결제 승인 성공 시 패키지 포인트가 적립된다")
+    void 결제_승인_성공_시_포인트_적립() {
+        Member member = createMember(1L, "시니어");
+        PaymentOrder paymentOrder = createOrder(member, "order_123", 10000, PaymentOrderStatus.CREATED);
+        PaymentApproveRequest request = new PaymentApproveRequest("order_123", "pay_123");
+        PaymentConfirmResponse approvedResponse = createResponse("pay_123", "order_123", 10000, PaymentStatus.DONE);
+
+        given(memberUtil.getCurrentMember()).willReturn(member);
+        given(paymentOrderRepository.findByOrderId("order_123")).willReturn(Optional.of(paymentOrder));
+        given(paymentRepository.findByOrderId("order_123")).willReturn(Optional.empty());
+        given(paymentRepository.findByPaymentKey("pay_123")).willReturn(Optional.empty());
+        given(paymentClient.confirmPayment(any())).willReturn(approvedResponse);
+        given(paymentRepository.save(any())).willAnswer(invocation -> invocation.getArgument(0));
+
+        PaymentConfirmResponse result = paymentService.confirmPayment(request);
+
+        assertThat(result.getStatus()).isEqualTo(PaymentStatus.DONE);
+        verify(seniorProfileService).addPointsToMember(member.getId(), 10000L, "포인트 충전 10,000원");
+    }
+
+    @Test
+    @DisplayName("시니어가 아닌 회원은 주문 생성이 불가능하다")
+    void 시니어가_아니면_주문_생성_불가() {
+        Member member = Member.createMember(MemberType.GUARDIAN, "보호자", "01012345678");
+        ReflectionTestUtils.setField(member, "id", 1L);
+        given(memberUtil.getCurrentMember()).willReturn(member);
+
+        assertThatThrownBy(() -> paymentService.createOrder(new PaymentOrderCreateRequest("POINT_10000")))
+                .isInstanceOf(BusinessException.class)
+                .hasFieldOrPropertyWithValue("errorCode", ErrorCode.FORBIDDEN);
+    }
+
+    private Member createMember(Long id, String name) {
+        Member member = Member.createMember(MemberType.SENIOR, name, "01012345678");
+        ReflectionTestUtils.setField(member, "id", id);
+        SeniorProfile seniorProfile = org.mockito.Mockito.mock(SeniorProfile.class);
+        ReflectionTestUtils.setField(member, "seniorProfile", seniorProfile);
+        return member;
+    }
+
+    private PaymentOrder createOrder(Member member, String orderId, int amount, PaymentOrderStatus status) {
+        PaymentOrder paymentOrder = PaymentOrder.create(
+                orderId,
+                member,
+                "포인트 충전",
+                "POINT_10000",
+                amount,
+                10000,
+                ZonedDateTime.now().plusMinutes(15)
+        );
+        ReflectionTestUtils.setField(paymentOrder, "status", status);
+        return paymentOrder;
+    }
+
+    private Payment createPayment(Member member, PaymentOrder paymentOrder, String paymentKey, String orderId,
+                                  int amount, PaymentStatus status) {
+        return Payment.builder()
+                .member(member)
+                .paymentOrder(paymentOrder)
+                .paymentKey(paymentKey)
+                .orderId(orderId)
+                .orderName("포인트 충전")
+                .amount(amount)
+                .canceledAmount(0)
+                .status(status)
+                .requestedAt(ZonedDateTime.now().minusMinutes(1))
+                .approvedAt(ZonedDateTime.now())
+                .cultureExpense(false)
+                .build();
+    }
+
+    private PaymentConfirmResponse createResponse(String paymentKey, String orderId, int amount, PaymentStatus status) {
+        PaymentConfirmResponse response = new PaymentConfirmResponse();
+        ReflectionTestUtils.setField(response, "paymentKey", paymentKey);
+        ReflectionTestUtils.setField(response, "orderId", orderId);
+        ReflectionTestUtils.setField(response, "amount", amount);
+        ReflectionTestUtils.setField(response, "status", status);
+        return response;
+    }
+}

--- a/backend/widyu-api/src/test/java/com/widyu/pay/controller/PaymentControllerTest.java
+++ b/backend/widyu-api/src/test/java/com/widyu/pay/controller/PaymentControllerTest.java
@@ -1,0 +1,125 @@
+package com.widyu.pay.controller;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isNull;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.springframework.http.MediaType.APPLICATION_JSON;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import com.widyu.global.error.ErrorCode;
+import com.widyu.global.error.GlobalExceptionHandler;
+import com.widyu.pay.PaymentOrderStatus;
+import com.widyu.pay.PaymentStatus;
+import com.widyu.pay.application.PaymentService;
+import com.widyu.pay.dto.response.PaymentConfirmResponse;
+import com.widyu.pay.dto.response.PaymentOrderResponse;
+import java.time.ZonedDateTime;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.converter.json.MappingJackson2HttpMessageConverter;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.validation.beanvalidation.LocalValidatorFactoryBean;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("PaymentController API 테스트")
+class PaymentControllerTest {
+
+    @Mock
+    private PaymentService paymentService;
+
+    private MockMvc mockMvc;
+    private ObjectMapper objectMapper;
+
+    @BeforeEach
+    void setUp() {
+        objectMapper = new ObjectMapper().registerModule(new JavaTimeModule());
+
+        LocalValidatorFactoryBean validator = new LocalValidatorFactoryBean();
+        validator.afterPropertiesSet();
+
+        mockMvc = MockMvcBuilders.standaloneSetup(new PaymentController(paymentService))
+                .setControllerAdvice(new GlobalExceptionHandler())
+                .setMessageConverters(new MappingJackson2HttpMessageConverter(objectMapper))
+                .setValidator(validator)
+                .build();
+    }
+
+    @Test
+    @DisplayName("주문 생성 요청은 표준 응답 형태로 반환된다")
+    void 주문_생성_API() throws Exception {
+        PaymentOrderResponse response = new PaymentOrderResponse(
+                "order_123456",
+                "POINT_10000",
+                "포인트 충전 10,000원",
+                10000,
+                10000,
+                PaymentOrderStatus.CREATED,
+                ZonedDateTime.parse("2026-05-28T12:00:00+09:00")
+        );
+        given(paymentService.createOrder(any())).willReturn(response);
+
+        mockMvc.perform(post("/api/v1/payment/orders")
+                        .contentType(APPLICATION_JSON)
+                        .content("""
+                                {
+                                  "packageId": "POINT_10000"
+                                }
+                                """))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.code").value("PAY_2000"))
+                .andExpect(jsonPath("$.message").value("주문 생성 성공"))
+                .andExpect(jsonPath("$.data.orderId").value("order_123456"))
+                .andExpect(jsonPath("$.data.packageId").value("POINT_10000"))
+                .andExpect(jsonPath("$.data.amount").value(10000));
+    }
+
+    @Test
+    @DisplayName("결제 승인 요청의 필수값이 비어 있으면 400을 반환한다")
+    void 결제_승인_API_검증() throws Exception {
+        mockMvc.perform(post("/api/v1/payment")
+                        .contentType(APPLICATION_JSON)
+                        .content("""
+                                {
+                                  "orderId": "order_123456",
+                                  "paymentKey": ""
+                                }
+                                """))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.code").value(ErrorCode.BAD_REQUEST.getCode()))
+                .andExpect(jsonPath("$.message").value("결제 키는 필수입니다 (paymentKey)"));
+
+        verifyNoInteractions(paymentService);
+    }
+
+    @Test
+    @DisplayName("결제 취소는 요청 본문 없이도 호출할 수 있다")
+    void 결제_취소_API_본문_없음() throws Exception {
+        PaymentConfirmResponse response = new PaymentConfirmResponse();
+        ReflectionTestUtils.setField(response, "paymentKey", "pay_123456");
+        ReflectionTestUtils.setField(response, "orderId", "order_123456");
+        ReflectionTestUtils.setField(response, "status", PaymentStatus.CANCELED);
+        given(paymentService.cancelPayment("pay_123456", null)).willReturn(response);
+
+        mockMvc.perform(post("/api/v1/payment/pay_123456/cancel")
+                        .contentType(APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.code").value("PAY_2002"))
+                .andExpect(jsonPath("$.data.paymentKey").value("pay_123456"))
+                .andExpect(jsonPath("$.data.status").value("CANCELED"));
+
+        verify(paymentService).cancelPayment(eq("pay_123456"), isNull());
+    }
+}

--- a/backend/widyu-api/src/test/java/com/widyu/pay/integration/PaymentIntegrationTest.java
+++ b/backend/widyu-api/src/test/java/com/widyu/pay/integration/PaymentIntegrationTest.java
@@ -1,0 +1,212 @@
+package com.widyu.pay.integration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+
+import com.widyu.auth.application.SmsService;
+import com.widyu.auth.repository.RefreshTokenRepository;
+import com.widyu.auth.repository.TemporaryMemberRepository;
+import com.widyu.auth.repository.VerificationCodeRepository;
+import com.widyu.global.util.MemberUtil;
+import com.widyu.member.Family;
+import com.widyu.member.Member;
+import com.widyu.member.MemberType;
+import com.widyu.member.PointHistoryType;
+import com.widyu.member.SeniorProfile;
+import com.widyu.member.repository.FamilyRepository;
+import com.widyu.member.repository.MemberRepository;
+import com.widyu.member.repository.PointHistoryRepository;
+import com.widyu.member.repository.SeniorProfileRepository;
+import com.widyu.pay.Payment;
+import com.widyu.pay.PaymentOrder;
+import com.widyu.pay.PaymentStatus;
+import com.widyu.pay.application.PaymentService;
+import com.widyu.pay.config.PaymentClient;
+import com.widyu.pay.dto.request.CancelRequest;
+import com.widyu.pay.dto.request.PaymentApproveRequest;
+import com.widyu.pay.dto.request.PaymentOrderCreateRequest;
+import com.widyu.pay.dto.response.PaymentConfirmResponse;
+import com.widyu.pay.dto.response.PaymentOrderResponse;
+import com.widyu.pay.repository.PaymentOrderRepository;
+import com.widyu.pay.repository.PaymentRepository;
+import java.time.LocalDate;
+import java.time.ZonedDateTime;
+import java.util.List;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.util.ReflectionTestUtils;
+import software.amazon.awssdk.services.s3.S3Client;
+
+@SpringBootTest
+@ActiveProfiles("test")
+@TestPropertySource(properties = {
+        "firebase.config-path=/dev/null",
+        "s3.credentials.access-key=test",
+        "s3.credentials.secret-key=test",
+        "s3.region.statics=ap-northeast-2",
+        "s3.bucket-name=test-bucket",
+        "coolsms.api-key=test",
+        "coolsms.api-secret=test",
+        "coolsms.api-url=https://api.coolsms.co.kr",
+        "coolsms.from-phone-number=01000000000",
+        "coolsms.verification-code-length=6",
+        "coolsms.verification-code-ttl=300",
+        "coolsms.message-template=인증번호: {code}"
+})
+@DisplayName("결제 통합 테스트")
+class PaymentIntegrationTest {
+
+    @Autowired private PaymentService paymentService;
+    @Autowired private PaymentRepository paymentRepository;
+    @Autowired private PaymentOrderRepository paymentOrderRepository;
+    @Autowired private PointHistoryRepository pointHistoryRepository;
+    @Autowired private MemberRepository memberRepository;
+    @Autowired private SeniorProfileRepository seniorProfileRepository;
+    @Autowired private FamilyRepository familyRepository;
+
+    @MockBean private PaymentClient paymentClient;
+    @MockBean private MemberUtil memberUtil;
+    @MockBean private VerificationCodeRepository verificationCodeRepository;
+    @MockBean private TemporaryMemberRepository temporaryMemberRepository;
+    @MockBean private RefreshTokenRepository refreshTokenRepository;
+    @MockBean private S3Client s3Client;
+    @MockBean private SmsService smsService;
+    @MockBean private net.bramp.ffmpeg.FFmpeg ffmpeg;
+    @MockBean private net.bramp.ffmpeg.FFprobe ffprobe;
+
+    @AfterEach
+    void tearDown() {
+        pointHistoryRepository.deleteAll();
+        paymentRepository.deleteAll();
+        paymentOrderRepository.deleteAll();
+        seniorProfileRepository.deleteAll();
+        familyRepository.deleteAll();
+        memberRepository.deleteAll();
+    }
+
+    @Test
+    @DisplayName("결제 승인 시 주문, 결제, 포인트 적립 이력이 함께 저장된다")
+    void 결제_승인_통합() {
+        Member currentMember = createSeniorMember("홍길동", "01012345678", "FAM001", "INV0011");
+        given(memberUtil.getCurrentMember()).willReturn(currentMember, currentMember);
+
+        PaymentOrderResponse orderResponse = paymentService.createOrder(new PaymentOrderCreateRequest("POINT_10000"));
+        given(paymentClient.confirmPayment(any())).willReturn(createGatewayResponse(
+                "pay_123456",
+                orderResponse.orderId(),
+                "포인트 충전 10,000원",
+                PaymentStatus.DONE
+        ));
+        PaymentConfirmResponse confirmResponse = paymentService.confirmPayment(
+                new PaymentApproveRequest(orderResponse.orderId(), "pay_123456")
+        );
+
+        PaymentOrder paymentOrder = paymentOrderRepository.findByOrderId(orderResponse.orderId()).orElseThrow();
+        Payment payment = paymentRepository.findByPaymentKey("pay_123456").orElseThrow();
+        SeniorProfile seniorProfile = seniorProfileRepository.findByMemberId(currentMember.getId()).orElseThrow();
+        var pointHistories = pointHistoryRepository.findAllBySeniorProfileIdOrderByCreatedAtDesc(seniorProfile.getId());
+
+        assertThat(confirmResponse.getStatus()).isEqualTo(PaymentStatus.DONE);
+        assertThat(paymentOrder.getStatus()).isEqualTo(com.widyu.pay.PaymentOrderStatus.PAID);
+        assertThat(payment.getOrderId()).isEqualTo(orderResponse.orderId());
+        assertThat(payment.getAmount()).isEqualTo(10000);
+        assertThat(seniorProfile.getPoints()).isEqualTo(10100L);
+        assertThat(pointHistories).hasSize(1);
+        assertThat(pointHistories.get(0).getType()).isEqualTo(PointHistoryType.EARN);
+        assertThat(pointHistories.get(0).getAmount()).isEqualTo(10000L);
+        assertThat(pointHistories.get(0).getDescription()).isEqualTo("포인트 충전 10,000원");
+    }
+
+    @Test
+    @DisplayName("부분 취소 시 취소 이력과 포인트 차감 이력이 함께 반영된다")
+    void 부분_취소_통합() {
+        Member currentMember = createSeniorMember("김영희", "01099998888", "FAM002", "INV0022");
+        given(memberUtil.getCurrentMember()).willReturn(currentMember, currentMember);
+
+        PaymentOrderResponse orderResponse = paymentService.createOrder(new PaymentOrderCreateRequest("POINT_10000"));
+        given(paymentClient.confirmPayment(any())).willReturn(createGatewayResponse(
+                "pay_654321",
+                orderResponse.orderId(),
+                "포인트 충전 10,000원",
+                PaymentStatus.DONE
+        ));
+        paymentService.confirmPayment(new PaymentApproveRequest(orderResponse.orderId(), "pay_654321"));
+        given(memberUtil.getCurrentMember()).willReturn(reloadCurrentMember(currentMember.getId()));
+        given(paymentClient.cancelPayment("pay_654321", new CancelRequest("부분 취소", 3000)))
+                .willReturn(createGatewayResponse(
+                        "pay_654321",
+                        orderResponse.orderId(),
+                        "포인트 충전 10,000원",
+                        PaymentStatus.PARTIAL_CANCELED
+                ));
+        PaymentConfirmResponse cancelResponse = paymentService.cancelPayment(
+                "pay_654321",
+                new CancelRequest("부분 취소", 3000)
+        );
+
+        Payment payment = paymentRepository.findByPaymentKey("pay_654321").orElseThrow();
+        SeniorProfile seniorProfile = seniorProfileRepository.findByMemberId(currentMember.getId()).orElseThrow();
+        List<com.widyu.member.PointHistory> pointHistories =
+                pointHistoryRepository.findAllBySeniorProfileIdOrderByCreatedAtDesc(seniorProfile.getId());
+
+        assertThat(cancelResponse.getStatus()).isEqualTo(PaymentStatus.PARTIAL_CANCELED);
+        assertThat(payment.getStatus()).isEqualTo(PaymentStatus.PARTIAL_CANCELED);
+        assertThat(payment.getCanceledAmount()).isEqualTo(3000);
+        assertThat(payment.getCanceledPointAmount()).isEqualTo(3000);
+        assertThat(payment.getRemainingAmount()).isEqualTo(7000);
+        assertThat(cancelResponse.getCancellations()).hasSize(1);
+        assertThat(seniorProfile.getPoints()).isEqualTo(7100L);
+        assertThat(pointHistories).hasSize(2);
+        assertThat(pointHistories.get(0).getType()).isEqualTo(PointHistoryType.USE);
+        assertThat(pointHistories.get(0).getAmount()).isEqualTo(3000L);
+        assertThat(pointHistories.get(0).getDescription()).isEqualTo("부분 취소");
+    }
+
+    private Member createSeniorMember(String name, String phoneNumber, String familyCode, String inviteCode) {
+        Family family = familyRepository.save(Family.createFamily(familyCode));
+        Member member = memberRepository.save(Member.createMember(MemberType.SENIOR, name, phoneNumber));
+        SeniorProfile seniorProfile = seniorProfileRepository.save(
+                SeniorProfile.createSeniorProfile(
+                        member,
+                        family,
+                        "서울시 강남구",
+                        "101호",
+                        inviteCode,
+                        LocalDate.of(1950, 1, 1)
+                )
+        );
+        ReflectionTestUtils.setField(member, "seniorProfile", seniorProfile);
+        return member;
+    }
+
+    private Member reloadCurrentMember(Long memberId) {
+        Member member = memberRepository.findById(memberId).orElseThrow();
+        SeniorProfile seniorProfile = seniorProfileRepository.findByMemberId(memberId).orElseThrow();
+        ReflectionTestUtils.setField(member, "seniorProfile", seniorProfile);
+        return member;
+    }
+
+    private PaymentConfirmResponse createGatewayResponse(
+            String paymentKey,
+            String orderId,
+            String orderName,
+            PaymentStatus status
+    ) {
+        PaymentConfirmResponse response = new PaymentConfirmResponse();
+        ReflectionTestUtils.setField(response, "paymentKey", paymentKey);
+        ReflectionTestUtils.setField(response, "orderId", orderId);
+        ReflectionTestUtils.setField(response, "orderName", orderName);
+        ReflectionTestUtils.setField(response, "amount", 10000);
+        ReflectionTestUtils.setField(response, "status", status);
+        ReflectionTestUtils.setField(response, "requestedAt", ZonedDateTime.parse("2026-05-28T10:00:00+09:00"));
+        ReflectionTestUtils.setField(response, "approvedAt", ZonedDateTime.parse("2026-05-28T10:01:00+09:00"));
+        return response;
+    }
+}

--- a/backend/widyu-domain/src/main/java/com/widyu/pay/Payment.java
+++ b/backend/widyu-domain/src/main/java/com/widyu/pay/Payment.java
@@ -1,10 +1,28 @@
 package com.widyu.pay;
 
 import com.widyu.member.Member;
-import jakarta.persistence.*;
-import lombok.*;
-
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToMany;
+import jakarta.persistence.OneToOne;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 import java.time.ZonedDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
 
 @Entity
 @Getter
@@ -17,30 +35,26 @@ public class Payment {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    // PG사에서 제공하는 결제 키
     @Column(unique = true, nullable = false)
     private String paymentKey;
 
-    // 주문 관련 정보
     private String orderId;
     private String orderName;
     private int amount;
+    private int canceledAmount;
+    private int canceledPointAmount;
 
-    // 결제 상태
     @Enumerated(EnumType.STRING)
     private PaymentStatus status;
 
-    // 결제 시각 정보
-    private ZonedDateTime requestedAt; // 결제 요청 시각
-    private ZonedDateTime approvedAt;  // 결제 승인 시각
+    private ZonedDateTime requestedAt;
+    private ZonedDateTime approvedAt;
 
-    // 취소 관련 필드
-    private String cancelReason;       // 취소 사유
-    private ZonedDateTime canceledAt;  // 취소된 시각
+    private String cancelReason;
+    private ZonedDateTime canceledAt;
 
-    private boolean cultureExpense;    // 문화비 여부
+    private boolean cultureExpense;
 
-    // 결제 수단별 상세 매핑 (1:1 관계)
     @OneToOne(mappedBy = "payment", cascade = CascadeType.ALL)
     private PaymentCard card;
 
@@ -53,11 +67,18 @@ public class Payment {
     @OneToOne(mappedBy = "payment", cascade = CascadeType.ALL)
     private PaymentEasyPay easyPay;
 
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "payment_order_id", unique = true)
+    private PaymentOrder paymentOrder;
+
+    @Builder.Default
+    @OneToMany(mappedBy = "payment", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<PaymentCancel> cancellations = new ArrayList<>();
+
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "member_id", nullable = false)
     private Member member;
 
-    // -------------------- 연관관계 편의 메서드 --------------------
     public void assignCard(PaymentCard card) {
         this.card = card;
         if (card != null) {
@@ -86,10 +107,36 @@ public class Payment {
         }
     }
 
-    public void cancel(String reason) {
-        this.status = PaymentStatus.CANCELED; // 상태 변경
-        this.cancelReason = reason;        // 취소 사유 저장
-        this.canceledAt = ZonedDateTime.now(); // 취소 시간 기록
-        this.approvedAt = null;            // 더 이상 승인 상태가 아님
+    public void assignPaymentOrder(PaymentOrder paymentOrder) {
+        this.paymentOrder = paymentOrder;
+    }
+
+    public void addCancellation(PaymentCancel cancellation) {
+        this.cancellations.add(cancellation);
+        cancellation.assignPayment(this);
+    }
+
+    public boolean isOwnedBy(Long memberId) {
+        return member != null && Objects.equals(member.getId(), memberId);
+    }
+
+    public boolean isCanceled() {
+        return this.status == PaymentStatus.CANCELED;
+    }
+
+    public boolean matches(String orderId, int amount) {
+        return Objects.equals(this.orderId, orderId) && this.amount == amount;
+    }
+
+    public int getRemainingAmount() {
+        return this.amount - this.canceledAmount;
+    }
+
+    public void cancel(int cancelAmount, int cancelPointAmount, String reason, ZonedDateTime canceledAt) {
+        this.canceledAmount += cancelAmount;
+        this.canceledPointAmount += cancelPointAmount;
+        this.cancelReason = reason;
+        this.canceledAt = canceledAt;
+        this.status = this.canceledAmount >= this.amount ? PaymentStatus.CANCELED : PaymentStatus.PARTIAL_CANCELED;
     }
 }

--- a/backend/widyu-domain/src/main/java/com/widyu/pay/PaymentCancel.java
+++ b/backend/widyu-domain/src/main/java/com/widyu/pay/PaymentCancel.java
@@ -1,0 +1,74 @@
+package com.widyu.pay;
+
+import com.widyu.global.entity.BaseTimeEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import java.time.ZonedDateTime;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "payment_cancel")
+public class PaymentCancel extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "payment_id", nullable = false)
+    private Payment payment;
+
+    @Column(name = "cancel_amount", nullable = false)
+    private int cancelAmount;
+
+    @Column(name = "cancel_point_amount", nullable = false)
+    private int cancelPointAmount;
+
+    @Column(name = "cancel_reason", nullable = false)
+    private String cancelReason;
+
+    @Column(name = "requested_by_member_id", nullable = false)
+    private Long requestedByMemberId;
+
+    @Column(name = "canceled_at", nullable = false)
+    private ZonedDateTime canceledAt;
+
+    @Builder(access = AccessLevel.PRIVATE)
+    private PaymentCancel(Payment payment, int cancelAmount, int cancelPointAmount, String cancelReason,
+                          Long requestedByMemberId, ZonedDateTime canceledAt) {
+        this.payment = payment;
+        this.cancelAmount = cancelAmount;
+        this.cancelPointAmount = cancelPointAmount;
+        this.cancelReason = cancelReason;
+        this.requestedByMemberId = requestedByMemberId;
+        this.canceledAt = canceledAt;
+    }
+
+    public static PaymentCancel create(Payment payment, int cancelAmount, int cancelPointAmount, String cancelReason,
+                                       Long requestedByMemberId, ZonedDateTime canceledAt) {
+        return PaymentCancel.builder()
+                .payment(payment)
+                .cancelAmount(cancelAmount)
+                .cancelPointAmount(cancelPointAmount)
+                .cancelReason(cancelReason)
+                .requestedByMemberId(requestedByMemberId)
+                .canceledAt(canceledAt)
+                .build();
+    }
+
+    void assignPayment(Payment payment) {
+        this.payment = payment;
+    }
+}

--- a/backend/widyu-domain/src/main/java/com/widyu/pay/PaymentOrder.java
+++ b/backend/widyu-domain/src/main/java/com/widyu/pay/PaymentOrder.java
@@ -1,0 +1,109 @@
+package com.widyu.pay;
+
+import com.widyu.global.entity.BaseTimeEntity;
+import com.widyu.member.Member;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import java.time.ZonedDateTime;
+import java.util.Objects;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "payment_order")
+public class PaymentOrder extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "order_id", nullable = false, unique = true)
+    private String orderId;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "member_id", nullable = false)
+    private Member member;
+
+    @Column(name = "order_name", nullable = false)
+    private String orderName;
+
+    @Column(name = "package_id", nullable = false)
+    private String packageId;
+
+    @Column(nullable = false)
+    private int amount;
+
+    @Column(name = "point_amount", nullable = false)
+    private int pointAmount;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private PaymentOrderStatus status;
+
+    @Column(name = "expires_at", nullable = false)
+    private ZonedDateTime expiresAt;
+
+    @Builder(access = AccessLevel.PRIVATE)
+    private PaymentOrder(String orderId, Member member, String orderName, String packageId, int amount, int pointAmount,
+                         PaymentOrderStatus status, ZonedDateTime expiresAt) {
+        this.orderId = orderId;
+        this.member = member;
+        this.orderName = orderName;
+        this.packageId = packageId;
+        this.amount = amount;
+        this.pointAmount = pointAmount;
+        this.status = status;
+        this.expiresAt = expiresAt;
+    }
+
+    public static PaymentOrder create(String orderId, Member member, String orderName, String packageId, int amount, int pointAmount,
+                                      ZonedDateTime expiresAt) {
+        return PaymentOrder.builder()
+                .orderId(orderId)
+                .member(member)
+                .orderName(orderName)
+                .packageId(packageId)
+                .amount(amount)
+                .pointAmount(pointAmount)
+                .status(PaymentOrderStatus.CREATED)
+                .expiresAt(expiresAt)
+                .build();
+    }
+
+    public boolean isOwnedBy(Long memberId) {
+        return member != null && Objects.equals(member.getId(), memberId);
+    }
+
+    public boolean isExpired() {
+        return expiresAt.isBefore(ZonedDateTime.now());
+    }
+
+    public boolean isCreated() {
+        return status == PaymentOrderStatus.CREATED;
+    }
+
+    public void markPaid() {
+        this.status = PaymentOrderStatus.PAID;
+    }
+
+    public void markCanceled() {
+        this.status = PaymentOrderStatus.CANCELED;
+    }
+
+    public void markExpired() {
+        this.status = PaymentOrderStatus.EXPIRED;
+    }
+}

--- a/backend/widyu-domain/src/main/java/com/widyu/pay/PaymentOrderStatus.java
+++ b/backend/widyu-domain/src/main/java/com/widyu/pay/PaymentOrderStatus.java
@@ -1,0 +1,8 @@
+package com.widyu.pay;
+
+public enum PaymentOrderStatus {
+    CREATED,
+    PAID,
+    CANCELED,
+    EXPIRED
+}

--- a/backend/widyu-domain/src/main/java/com/widyu/pay/PaymentStatus.java
+++ b/backend/widyu-domain/src/main/java/com/widyu/pay/PaymentStatus.java
@@ -3,5 +3,6 @@ package com.widyu.pay;
 public enum PaymentStatus {
     READY,      // 결제 준비
     DONE,   // 결제 승인 완료
+    PARTIAL_CANCELED,
     CANCELED;   // 결제 취소
 }

--- a/backend/widyu-domain/src/main/java/com/widyu/pay/PointChargePackage.java
+++ b/backend/widyu-domain/src/main/java/com/widyu/pay/PointChargePackage.java
@@ -1,0 +1,44 @@
+package com.widyu.pay;
+
+import java.util.Arrays;
+
+public enum PointChargePackage {
+    POINT_10000("POINT_10000", "포인트 충전 10,000원", 10000, 10000),
+    POINT_30000("POINT_30000", "포인트 충전 30,000원", 30000, 30000),
+    POINT_50000("POINT_50000", "포인트 충전 50,000원", 50000, 50000);
+
+    private final String id;
+    private final String orderName;
+    private final int amount;
+    private final int pointAmount;
+
+    PointChargePackage(String id, String orderName, int amount, int pointAmount) {
+        this.id = id;
+        this.orderName = orderName;
+        this.amount = amount;
+        this.pointAmount = pointAmount;
+    }
+
+    public String getId() {
+        return id;
+    }
+
+    public String getOrderName() {
+        return orderName;
+    }
+
+    public int getAmount() {
+        return amount;
+    }
+
+    public int getPointAmount() {
+        return pointAmount;
+    }
+
+    public static PointChargePackage fromId(String id) {
+        return Arrays.stream(values())
+                .filter(value -> value.id.equals(id))
+                .findFirst()
+                .orElseThrow(() -> new IllegalArgumentException("지원하지 않는 결제 패키지입니다: " + id));
+    }
+}


### PR DESCRIPTION
## 연관된 이슈
  >PR과 연관된 이슈 번호를 작성해주세요. ex) #이슈 번호, #이슈 번호

  - close: #264

  ## 🪄작업 내용
  >해당 이슈 그리고 이번 PR에서 작업한 내용들을 작성해주세요.
  >뷰 작업 내용이 포함되었을 경우 사진 혹은 동영상 파일 첨부를 부탁드립니다!

  - 결제 선행 주문 구조를 도입해 `PaymentOrder`, `PaymentOrderStatus`, `PaymentOrderRepository`를 추가하고, `packageId` 기반으로 서버가 주문 금액과 포인트를 확정하도록 변경했습니다.
  - 결제 승인/취소 흐름을 개선해 `PaymentApproveRequest`, `PaymentGatewayConfirmRequest`, `PaymentOrderCreateRequest`로 역할을 분리하고, 주문 소유권 검증, 중복 승인 멱등 처리, 취소 이력 누적(`PaymentCancel`) 및 부분 취소 상태
  (`PARTIAL_CANCELED`)를 반영했습니다.
  - 결제 승인 시 포인트 적립, 취소 시 포인트 차감 및 `PointHistory` 저장이 함께 이루어지도록 `SeniorProfileService`와 `PaymentService`를 확장했습니다.
  - 결제 응답에 `canceledAmount`, `canceledPointAmount`, `remainingAmount`, `cancellations`를 포함하도록 수정하고, Swagger 예시도 현재 스펙에 맞게 갱신했습니다.
  - 관리자 결제 화면에서 `PARTIAL_CANCELED` 상태를 표시하도록 프론트 UI를 수정했습니다.
  - 구 DTO인 `PaymentConfirmRequest`를 제거하고 새 결제 요청 DTO로 정리했습니다.
  - 테스트를 보강했습니다.
  - `PaymentServiceTest` 단위 테스트 추가/확장
  - `PaymentControllerTest`로 결제 API 요청/응답 및 validation 검증 추가
  - `PaymentIntegrationTest`로 주문 생성 → 승인 → 포인트 적립, 부분 취소 → 포인트 차감 → 이력 저장 흐름 검증 추가
  - `./gradlew test`, `admin/npm run build` 통과 확인했습니다.

  ## 💖리뷰 요청사항
  >특별히 봐주셨으면 하는 부분, 나 좀 잘했다 하는 부분! 기타 당부의 말씀 등 자유롭게 작성해주세요.
