### PR TITLE
feat: admin SPA를 Nginx로 서빙하도록 배포 파이프라인 구성

### DIFF
--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -20,6 +20,19 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: "npm"
+          cache-dependency-path: admin/package-lock.json
+
+      - name: Build admin SPA
+        run: |
+          cd admin
+          npm ci
+          npm run build
+
       - name: Set up JDK 21
         uses: actions/setup-java@v4
         with:
@@ -83,6 +96,10 @@ jobs:
           rsync -avz --delete -e "ssh -i private_key.pem -o StrictHostKeyChecking=no" \
             scripts/ \
             ${{ env.EC2_SSH_USER }}@${{ env.EC2_HOST }}:/home/ec2-user/widyu/scripts/
+
+          rsync -avz --delete -e "ssh -i private_key.pem -o StrictHostKeyChecking=no" \
+            admin/dist/ \
+            ${{ env.EC2_SSH_USER }}@${{ env.EC2_HOST }}:/home/ec2-user/widyu/admin/dist/
 
           # rsync -avz --delete -e "ssh -i private_key.pem -o StrictHostKeyChecking=no" \
           #   monitoring/ \

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -66,6 +66,24 @@ docker run -p 5000:5000 rchagnhoon/widyu-ai-ver2:latest
   - Docker Hub 레지스트리 캐시(`cache-from`/`cache-to`)로 빌드 후 `latest`·`sha` 태그 push
   - EC2에 compose 파일 `rsync` 후 `--no-deps --force-recreate widyu-api` 배포 (DB·Redis 유지)
 
+## Admin Dashboard (admin/)
+
+`admin/` 디렉터리는 React + TypeScript 기반 운영 모니터링 대시보드입니다. Spring Boot 백엔드와 별개로 동작하는 SPA입니다.
+
+**Tech Stack**: React 19, TypeScript, Vite, Tailwind CSS, React Query, React Router, Recharts, Zustand
+
+**Pages**: Dashboard (KPI·경고 카드·주간 추이 차트), Members, Families, Albums, Payments, Notifications, Logs, DevTools (개발 환경 전용)
+
+**Dev**:
+```bash
+cd admin
+npm install
+npm run dev   # localhost:5173
+npm run build # dist/ 생성
+```
+
+**인증**: authStore(Zustand)에 JWT 저장, PrivateRoute로 보호. 백엔드 `/api/admin/login` 연동.
+
 ## Application Architecture
 
 ### Multi-Module Structure

--- a/admin/src/App.tsx
+++ b/admin/src/App.tsx
@@ -23,7 +23,7 @@ function PrivateRoute({ children }: { children: React.ReactNode }) {
 export default function App() {
   return (
     <QueryClientProvider client={queryClient}>
-      <BrowserRouter>
+      <BrowserRouter basename={import.meta.env.BASE_URL.replace(/\/$/, '')}>
         <Routes>
           <Route path="/login" element={<LoginPage />} />
           <Route

--- a/admin/src/api/client.ts
+++ b/admin/src/api/client.ts
@@ -36,7 +36,7 @@ client.interceptors.response.use(
     const refreshToken = localStorage.getItem('admin_refresh_token')
     if (!refreshToken) {
       localStorage.removeItem('admin_token')
-      window.location.href = '/login'
+      window.location.href = import.meta.env.BASE_URL + 'login'
       return Promise.reject(error)
     }
 
@@ -72,7 +72,7 @@ client.interceptors.response.use(
       rejectQueue(refreshError)
       localStorage.removeItem('admin_token')
       localStorage.removeItem('admin_refresh_token')
-      window.location.href = '/login'
+      window.location.href = import.meta.env.BASE_URL + 'login'
       return Promise.reject(refreshError)
     } finally {
       isRefreshing = false

--- a/admin/vite.config.ts
+++ b/admin/vite.config.ts
@@ -2,11 +2,12 @@ import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
 import tailwindcss from '@tailwindcss/vite'
 
-export default defineConfig({
+export default defineConfig(({ command }) => ({
+  base: command === 'build' ? '/admin' : '/',
   plugins: [react(), tailwindcss()],
   server: {
     proxy: {
       '/api': 'http://localhost:8080',
     },
   },
-})
+}))

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -143,6 +143,7 @@ services:
       - "${NGINX_HTTPS_PORT}:443"
     volumes:
       - ./nginx/nginx.conf:/etc/nginx/nginx.conf:ro
+      - ./admin/dist:/usr/share/nginx/admin:ro
       - nginx_logs:/var/log/nginx
       - certbot_webroot:/var/www/certbot:ro
       - certbot_certs:/etc/letsencrypt:ro

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -150,6 +150,13 @@ http {
             proxy_set_header X-Forwarded-Proto $scheme;
         }
 
+        # Admin SPA
+        location /admin {
+            alias /usr/share/nginx/admin;
+            index index.html;
+            try_files $uri $uri/ /admin/index.html;
+        }
+
         # Actuator endpoints
         location /actuator/ {
             proxy_pass http://spring_backend;


### PR DESCRIPTION
## #️⃣연관된 이슈
>PR과 연관된 이슈 번호를 작성해주세요. ex) #이슈 번호, #이슈 번호

  - close: #266

## 🪄 작업 내용
  
  - nginx/nginx.conf에 /admin location 추가해 React SPA 정적 파일 서빙 및 라우팅 처리
  - docker-compose.yml nginx 컨테이너에 admin/dist 볼륨 마운트
  - deploy-dev.yml에 Node 20 셋업 + npm ci && npm run build + admin/dist/ rsync 단계 추가
  - vite.config.ts 빌드 시 base: '/admin' 적용 (로컬 dev는 기존 localhost:5173 그대로)
  - BrowserRouter에 basename 적용 및 토큰 만료 리다이렉트 경로 BASE_URL 기반으로 수정
  - 배포 후 https://dev.widyu.shop/admin 으로 접근 가능

## 💖리뷰 요청사항
>특별히 봐주셨으면 하는 부분, 나 좀 잘했다 하는 부분! 기타 당부의 말씀 등 자유롭게 작성해주세요.

-
