### PR TITLE
admin 빌드 단계를 deploy job으로 이동해 rsync 실패 문제 해결

### DIFF
--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -20,19 +20,6 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
-      - name: Set up Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version: "20"
-          cache: "npm"
-          cache-dependency-path: admin/package-lock.json
-
-      - name: Build admin SPA
-        run: |
-          cd admin
-          npm ci
-          npm run build
-
       - name: Set up JDK 21
         uses: actions/setup-java@v4
         with:
@@ -75,6 +62,19 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: "npm"
+          cache-dependency-path: admin/package-lock.json
+
+      - name: Build admin SPA
+        run: |
+          cd admin
+          npm ci
+          npm run build
+
       - name: Sync compose files to EC2
         run: |
           printf "%s" "${{ env.PRIVATE_KEY }}" > private_key.pem
@@ -82,7 +82,7 @@ jobs:
 
           ssh -i private_key.pem -o StrictHostKeyChecking=no \
             ${{ env.EC2_SSH_USER }}@${{ env.EC2_HOST }} \
-            "mkdir -p /home/ec2-user/widyu/nginx"
+            "mkdir -p /home/ec2-user/widyu/nginx /home/ec2-user/widyu/admin/dist"
             # "mkdir -p /home/ec2-user/widyu/nginx /home/ec2-user/widyu/monitoring"
 
           rsync -avz -e "ssh -i private_key.pem -o StrictHostKeyChecking=no" \


### PR DESCRIPTION
## #️연관된 이슈

  - close: #270
  
  ## 🪄작업 내용

  - `build-and-push-docker` job에 있던 Node 셋업 + `npm run build` 단계를 `deploy-to-ec2` job의 rsync 직전으로 이동
  - EC2 `mkdir -p`에 `admin/dist` 경로 추가 (receiver 측 디렉터리 미생성으로 인한 rsync 실패 방지)

  ## 💖리뷰 요청사항