### PR TITLE
보호자 내 정보 조회 응답 필드명 수정

### DIFF
--- a/backend/widyu-api/src/main/java/com/widyu/auth/controller/docs/GuardianAuthDocs.java
+++ b/backend/widyu-api/src/main/java/com/widyu/auth/controller/docs/GuardianAuthDocs.java
@@ -656,7 +656,7 @@ public interface GuardianAuthDocs {
                                       "message": "현재 회원 정보 조회 성공",
                                       "data": {
                                         "name": "ghdrlfehd",
-                                        "phone": "01012341234",
+                                        "phoneNumber": "01012341234",
                                         "email": "abc@abc.com",
                                         "providers": ["kakao"],
                                         "hasParents": true

--- a/backend/widyu-api/src/main/java/com/widyu/auth/dto/response/CurrentMemberResponse.java
+++ b/backend/widyu-api/src/main/java/com/widyu/auth/dto/response/CurrentMemberResponse.java
@@ -11,7 +11,7 @@ public record CurrentMemberResponse(
         String name,
         
         @Schema(description = "전화번호", example = "01012341234")
-        String phone,
+        String phoneNumber,
         
         @Schema(description = "이메일", example = "abc@abc.com")
         String email,
@@ -22,7 +22,7 @@ public record CurrentMemberResponse(
         @Schema(description = "부모 계정 보유 여부", example = "true")
         boolean hasParents
 ) {
-    public static CurrentMemberResponse of(String name, String phone, String email, List<String> providers, boolean hasParents) {
-        return new CurrentMemberResponse(name, phone, email, providers, hasParents);
+    public static CurrentMemberResponse of(String name, String phoneNumber, String email, List<String> providers, boolean hasParents) {
+        return new CurrentMemberResponse(name, phoneNumber, email, providers, hasParents);
     }
 }

--- a/backend/widyu-api/src/test/java/com/widyu/auth/application/guardian/GuardianAuthServiceTest.java
+++ b/backend/widyu-api/src/test/java/com/widyu/auth/application/guardian/GuardianAuthServiceTest.java
@@ -95,6 +95,7 @@ class GuardianAuthServiceTest {
         CurrentMemberResponse response = guardianAuthService.getCurrentMemberInfo();
 
         // then
+        assertThat(response.phoneNumber()).isEqualTo("01012341234");
         assertThat(response.email()).isEqualTo("test@test.com");
         assertThat(response.providers()).contains("local");
         assertThat(response.hasParents()).isFalse();


### PR DESCRIPTION
## #️⃣연관된 이슈
  >PR과 연관된 이슈 번호를 작성해주세요. ex) #이슈 번호, #이슈 번호

  - close: #275

  ## 🪄작업 내용
  >해당 이슈 그리고 이번 PR에서 작업한 내용들을 작성해주세요.
  >뷰 작업 내용이 포함되었을 경우 사진 혹은 동영상 파일 첨부를 부탁드립니다!

  - `GET /api/v1/auth/guardians/me` 응답의 전화번호 필드명을 `phone`에서 `phoneNumber`로 변경했습니다.
  - Swagger 문서 예시를 실제 응답 키에 맞게 수정했습니다.
  - `GuardianAuthServiceTest`에 `phoneNumber` 응답 검증을 추가했습니다.
