### PR TITLE
refactor(#283): 시니어·보호자 홈 서비스 중복 로직 공통 컴포넌트로 분리

### DIFF
--- a/backend/widyu-api/src/main/java/com/widyu/home/application/FamilyMemberQueryService.java
+++ b/backend/widyu-api/src/main/java/com/widyu/home/application/FamilyMemberQueryService.java
@@ -1,0 +1,40 @@
+package com.widyu.home.application;
+
+import com.widyu.member.Member;
+import com.widyu.member.SeniorProfile;
+import com.widyu.member.repository.FamilyMembershipRepository;
+import com.widyu.member.repository.SeniorProfileRepository;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class FamilyMemberQueryService {
+
+    private final SeniorProfileRepository seniorProfileRepository;
+    private final FamilyMembershipRepository familyMembershipRepository;
+
+    public List<Long> getFamilyMemberIds(Member senior) {
+        SeniorProfile seniorProfile = seniorProfileRepository.findByMemberId(senior.getId())
+                .orElse(null);
+
+        if (seniorProfile == null) {
+            return List.of(senior.getId());
+        }
+
+        Long familyId = seniorProfile.getFamily().getId();
+
+        List<Long> seniorIds = seniorProfileRepository.findAllByFamilyId(familyId).stream()
+                .map(sp -> sp.getMember().getId())
+                .toList();
+
+        List<Long> guardianIds = familyMembershipRepository.findAllByFamilyIdWithGuardian(familyId).stream()
+                .map(fm -> fm.getGuardian().getId())
+                .toList();
+
+        return java.util.stream.Stream.concat(seniorIds.stream(), guardianIds.stream()).toList();
+    }
+}

--- a/backend/widyu-api/src/main/java/com/widyu/home/application/GuardianHomeService.java
+++ b/backend/widyu-api/src/main/java/com/widyu/home/application/GuardianHomeService.java
@@ -1,7 +1,5 @@
 package com.widyu.home.application;
 
-import com.widyu.album.Album;
-import com.widyu.album.repository.AlbumRepository;
 import com.widyu.global.entity.Status;
 import com.widyu.global.error.BusinessException;
 import com.widyu.global.error.ErrorCode;
@@ -12,7 +10,6 @@ import com.widyu.goal.medicineschedule.repository.MedicationProofRepository;
 import com.widyu.goal.medicineschedule.repository.MedicineScheduleRepository;
 import com.widyu.goal.walk.repository.WalkRepository;
 import com.widyu.healthschedule.HealthSchedule;
-import com.widyu.heart.HeartRateResult;
 import com.widyu.heart.repository.HeartRateResultRepository;
 import com.widyu.home.dto.response.GuardianHomeCardsResponse;
 import com.widyu.home.dto.response.GuardianSeniorListResponse;
@@ -35,7 +32,6 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
-import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -43,12 +39,6 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
 public class GuardianHomeService {
-
-    private static final int ALBUM_CANDIDATE_SIZE = 10;
-    private static final int ALBUM_RESULT_SIZE = 3;
-    private static final int LIKE_WEIGHT = 3;
-    private static final int COMMENT_WEIGHT = 2;
-    private static final int DATE_BONUS = 10;
 
     private final MemberUtil memberUtil;
     private final MemberRepository memberRepository;
@@ -59,7 +49,7 @@ public class GuardianHomeService {
     private final MedicationProofRepository medicationProofRepository;
     private final HealthScheduleRepository healthScheduleRepository;
     private final WalkRepository walkRepository;
-    private final AlbumRepository albumRepository;
+    private final HomeAlbumRecommendationService albumRecommendationService;
 
     public GuardianHomeCardsResponse getHomeCards(Long memberId) {
         Member guardian = memberUtil.getCurrentMember();
@@ -166,60 +156,13 @@ public class GuardianHomeService {
     }
 
     private List<GuardianHomeCardsResponse.AlbumInfo> getScoredAlbums(Member senior, LocalDate today) {
-        List<Long> familyMemberIds = getFamilyMemberIds(senior);
-
-        List<Long> candidateIds = albumRepository
-                .findTopScoredAlbumIdsByMemberIds(familyMemberIds, PageRequest.of(0, ALBUM_CANDIDATE_SIZE))
-                .getContent();
-
-        if (candidateIds.isEmpty()) {
-            return List.of();
-        }
-
-        return albumRepository.findAlbumsWithCollectionsByIds(candidateIds).stream()
-                .sorted(Comparator.comparingInt((Album album) -> calculateScore(album, today)).reversed())
-                .limit(ALBUM_RESULT_SIZE)
+        return albumRecommendationService.recommendAlbums(senior, today).stream()
                 .map(GuardianHomeCardsResponse.AlbumInfo::from)
                 .toList();
     }
 
-    private List<Long> getFamilyMemberIds(Member senior) {
-        SeniorProfile seniorProfile = seniorProfileRepository.findByMemberId(senior.getId())
-                .orElse(null);
-
-        if (seniorProfile == null) {
-            return List.of(senior.getId());
-        }
-
-        Long familyId = seniorProfile.getFamily().getId();
-
-        List<Long> seniorIds = seniorProfileRepository.findAllByFamilyId(familyId).stream()
-                .map(sp -> sp.getMember().getId())
-                .toList();
-
-        List<Long> guardianIds = familyMembershipRepository.findAllByFamilyIdWithGuardian(familyId).stream()
-                .map(fm -> fm.getGuardian().getId())
-                .toList();
-
-        return java.util.stream.Stream.concat(seniorIds.stream(), guardianIds.stream()).toList();
-    }
-
-    private int calculateScore(Album album, LocalDate today) {
-        int baseScore = album.getLikeCount() * LIKE_WEIGHT + album.getCommentCount() * COMMENT_WEIGHT;
-        if (isAnniversary(album, today)) {
-            return baseScore + DATE_BONUS;
-        }
-        return baseScore;
-    }
-
-    private boolean isAnniversary(Album album, LocalDate today) {
-        LocalDate albumDate = album.getCreatedAt().toLocalDate();
-        return albumDate.getMonth() == today.getMonth()
-                && albumDate.getDayOfMonth() == today.getDayOfMonth();
-    }
-
     private GuardianHomeCardsResponse.HealthScheduleInfo getHealthScheduleInfo(Member senior, LocalDate today) {
-        return healthScheduleRepository.findByMemberIdAndDate(senior.getId(), today)
+        return healthScheduleRepository.findByMemberIdAndDate(senior.getId(), today.atStartOfDay(), today.plusDays(1).atStartOfDay())
                 .stream()
                 .min(Comparator.comparing(HealthSchedule::getScheduledAt))
                 .map(GuardianHomeCardsResponse.HealthScheduleInfo::from)

--- a/backend/widyu-api/src/main/java/com/widyu/home/application/GuardianHomeService.java
+++ b/backend/widyu-api/src/main/java/com/widyu/home/application/GuardianHomeService.java
@@ -162,7 +162,7 @@ public class GuardianHomeService {
     }
 
     private GuardianHomeCardsResponse.HealthScheduleInfo getHealthScheduleInfo(Member senior, LocalDate today) {
-        return healthScheduleRepository.findByMemberIdAndDate(senior.getId(), today.atStartOfDay(), today.plusDays(1).atStartOfDay())
+        return healthScheduleRepository.findByMemberIdAndDate(senior.getId(), today)
                 .stream()
                 .min(Comparator.comparing(HealthSchedule::getScheduledAt))
                 .map(GuardianHomeCardsResponse.HealthScheduleInfo::from)

--- a/backend/widyu-api/src/main/java/com/widyu/home/application/HomeAlbumRecommendationService.java
+++ b/backend/widyu-api/src/main/java/com/widyu/home/application/HomeAlbumRecommendationService.java
@@ -1,0 +1,58 @@
+package com.widyu.home.application;
+
+import com.widyu.album.Album;
+import com.widyu.album.repository.AlbumRepository;
+import com.widyu.member.Member;
+import java.time.LocalDate;
+import java.util.Comparator;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class HomeAlbumRecommendationService {
+
+    private static final int ALBUM_CANDIDATE_SIZE = 10;
+    private static final int ALBUM_RESULT_SIZE = 3;
+    private static final int LIKE_WEIGHT = 3;
+    private static final int COMMENT_WEIGHT = 2;
+    private static final int DATE_BONUS = 10;
+
+    private final AlbumRepository albumRepository;
+    private final FamilyMemberQueryService familyMemberQueryService;
+
+    public List<Album> recommendAlbums(Member senior, LocalDate today) {
+        List<Long> familyMemberIds = familyMemberQueryService.getFamilyMemberIds(senior);
+
+        List<Long> candidateIds = albumRepository
+                .findTopScoredAlbumIdsByMemberIds(familyMemberIds, PageRequest.of(0, ALBUM_CANDIDATE_SIZE))
+                .getContent();
+
+        if (candidateIds.isEmpty()) {
+            return List.of();
+        }
+
+        return albumRepository.findAlbumsWithCollectionsByIds(candidateIds).stream()
+                .sorted(Comparator.comparingInt((Album album) -> calculateScore(album, today)).reversed())
+                .limit(ALBUM_RESULT_SIZE)
+                .toList();
+    }
+
+    private int calculateScore(Album album, LocalDate today) {
+        int baseScore = album.getLikeCount() * LIKE_WEIGHT + album.getCommentCount() * COMMENT_WEIGHT;
+        if (isAnniversary(album, today)) {
+            return baseScore + DATE_BONUS;
+        }
+        return baseScore;
+    }
+
+    private boolean isAnniversary(Album album, LocalDate today) {
+        LocalDate albumDate = album.getCreatedAt().toLocalDate();
+        return albumDate.getMonth() == today.getMonth()
+                && albumDate.getDayOfMonth() == today.getDayOfMonth();
+    }
+}

--- a/backend/widyu-api/src/main/java/com/widyu/home/application/SeniorHomeService.java
+++ b/backend/widyu-api/src/main/java/com/widyu/home/application/SeniorHomeService.java
@@ -1,7 +1,5 @@
 package com.widyu.home.application;
 
-import com.widyu.album.Album;
-import com.widyu.album.repository.AlbumRepository;
 import com.widyu.global.entity.Status;
 import com.widyu.global.error.BusinessException;
 import com.widyu.global.error.ErrorCode;
@@ -14,12 +12,9 @@ import com.widyu.healthschedule.HealthSchedule;
 import com.widyu.heart.repository.HeartRateResultRepository;
 import com.widyu.home.dto.response.SeniorHomeCardsResponse;
 import com.widyu.medicine.MedicineSchedule;
-import com.widyu.member.FamilyMembership;
 import com.widyu.member.Member;
 import com.widyu.member.MemberType;
 import com.widyu.member.SeniorProfile;
-import com.widyu.member.repository.FamilyMembershipRepository;
-import com.widyu.member.repository.SeniorProfileRepository;
 import com.widyu.walk.Walk;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
@@ -29,7 +24,6 @@ import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 import lombok.RequiredArgsConstructor;
-import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -38,21 +32,13 @@ import org.springframework.transaction.annotation.Transactional;
 @Transactional(readOnly = true)
 public class SeniorHomeService {
 
-    private static final int ALBUM_CANDIDATE_SIZE = 10;
-    private static final int ALBUM_RESULT_SIZE = 3;
-    private static final int LIKE_WEIGHT = 3;
-    private static final int COMMENT_WEIGHT = 2;
-    private static final int DATE_BONUS = 10;
-
     private final MemberUtil memberUtil;
     private final MedicineScheduleRepository medicineScheduleRepository;
     private final MedicationProofRepository medicationProofRepository;
     private final WalkRepository walkRepository;
     private final HealthScheduleRepository healthScheduleRepository;
-    private final AlbumRepository albumRepository;
     private final HeartRateResultRepository heartRateResultRepository;
-    private final SeniorProfileRepository seniorProfileRepository;
-    private final FamilyMembershipRepository familyMembershipRepository;
+    private final HomeAlbumRecommendationService albumRecommendationService;
 
     public SeniorHomeCardsResponse getHomeCards() {
         Member member = memberUtil.getCurrentMember();
@@ -119,56 +105,9 @@ public class SeniorHomeService {
     }
 
     private List<SeniorHomeCardsResponse.AlbumInfo> getScoredAlbums(Member senior, LocalDate today) {
-        List<Long> familyMemberIds = getFamilyMemberIds(senior);
-
-        List<Long> candidateIds = albumRepository
-                .findTopScoredAlbumIdsByMemberIds(familyMemberIds, PageRequest.of(0, ALBUM_CANDIDATE_SIZE))
-                .getContent();
-
-        if (candidateIds.isEmpty()) {
-            return List.of();
-        }
-
-        return albumRepository.findAlbumsWithCollectionsByIds(candidateIds).stream()
-                .sorted(Comparator.comparingInt((Album album) -> calculateScore(album, today)).reversed())
-                .limit(ALBUM_RESULT_SIZE)
+        return albumRecommendationService.recommendAlbums(senior, today).stream()
                 .map(SeniorHomeCardsResponse.AlbumInfo::from)
                 .toList();
-    }
-
-    private List<Long> getFamilyMemberIds(Member senior) {
-        SeniorProfile seniorProfile = seniorProfileRepository.findByMemberId(senior.getId())
-                .orElse(null);
-
-        if (seniorProfile == null) {
-            return List.of(senior.getId());
-        }
-
-        Long familyId = seniorProfile.getFamily().getId();
-
-        List<Long> seniorIds = seniorProfileRepository.findAllByFamilyId(familyId).stream()
-                .map(sp -> sp.getMember().getId())
-                .toList();
-
-        List<Long> guardianIds = familyMembershipRepository.findAllByFamilyIdWithGuardian(familyId).stream()
-                .map(fm -> fm.getGuardian().getId())
-                .toList();
-
-        return java.util.stream.Stream.concat(seniorIds.stream(), guardianIds.stream()).toList();
-    }
-
-    private int calculateScore(Album album, LocalDate today) {
-        int baseScore = album.getLikeCount() * LIKE_WEIGHT + album.getCommentCount() * COMMENT_WEIGHT;
-        if (isAnniversary(album, today)) {
-            return baseScore + DATE_BONUS;
-        }
-        return baseScore;
-    }
-
-    private boolean isAnniversary(Album album, LocalDate today) {
-        LocalDate albumDate = album.getCreatedAt().toLocalDate();
-        return albumDate.getMonth() == today.getMonth()
-                && albumDate.getDayOfMonth() == today.getDayOfMonth();
     }
 
     private SeniorHomeCardsResponse.HealthScheduleInfo getHealthScheduleInfo(Member member, LocalDate today) {

--- a/backend/widyu-api/src/main/java/com/widyu/mypage/application/GuardianMyPageService.java
+++ b/backend/widyu-api/src/main/java/com/widyu/mypage/application/GuardianMyPageService.java
@@ -1,5 +1,8 @@
 package com.widyu.mypage.application;
 
+import com.widyu.auth.application.SmsService;
+import com.widyu.auth.dto.request.SmsCodeRequest;
+import com.widyu.auth.repository.VerificationCodeRepository;
 import com.widyu.global.error.BusinessException;
 import com.widyu.global.error.ErrorCode;
 import com.widyu.global.infrastructure.s3.S3Service;
@@ -15,8 +18,8 @@ import com.widyu.member.repository.PointHistoryRepository;
 import com.widyu.member.repository.SeniorProfileRepository;
 import com.widyu.mypage.dto.request.UpdateInviteCodeRequest;
 import com.widyu.mypage.dto.request.UpdateNameRequest;
-import com.widyu.mypage.dto.request.UpdateSeniorAddressRequest;
 import com.widyu.mypage.dto.request.UpdatePhoneRequest;
+import com.widyu.mypage.dto.request.UpdateSeniorAddressRequest;
 import com.widyu.mypage.dto.response.ConnectedSeniorResponse;
 import com.widyu.mypage.dto.response.FamilyCodeResponse;
 import com.widyu.mypage.dto.response.FamilyMemberListResponse;
@@ -38,6 +41,8 @@ public class GuardianMyPageService {
 
     private final MemberUtil memberUtil;
     private final S3Service s3Service;
+    private final SmsService smsService;
+    private final VerificationCodeRepository verificationCodeRepository;
     private final FamilyMembershipRepository familyMembershipRepository;
     private final SeniorProfileRepository seniorProfileRepository;
     private final MemberRepository memberRepository;
@@ -61,6 +66,37 @@ public class GuardianMyPageService {
     @Transactional
     public void updateProfileImage(MultipartFile image) {
         MyPageProfileService.updateCurrentMemberProfileImage(memberUtil, s3Service, image);
+    }
+
+    @Transactional
+    public void sendPhoneChangeSms(UpdatePhoneRequest request) {
+        Member currentMember = MyPageProfileService.getCurrentMember(memberUtil);
+        String newPhone = request.phoneNumber();
+
+        memberRepository.findByPhoneNumber(newPhone).ifPresent(existing -> {
+            if (!existing.getId().equals(currentMember.getId())) {
+                throw new BusinessException(ErrorCode.BAD_REQUEST, "이미 사용 중인 전화번호입니다.");
+            }
+        });
+
+        smsService.sendVerificationSms(newPhone, currentMember.getName());
+    }
+
+    @Transactional
+    public void verifyAndUpdatePhone(SmsCodeRequest request) {
+        String newPhone = request.phoneNumber();
+
+        boolean codeMatches = verificationCodeRepository.findById(newPhone)
+                .map(v -> v.getCode().equals(request.code()))
+                .orElseThrow(() -> new BusinessException(ErrorCode.SMS_VERIFICATION_CODE_NOT_FOUND));
+
+        if (!codeMatches) {
+            throw new BusinessException(ErrorCode.SMS_VERIFICATION_CODE_MISMATCH);
+        }
+
+        Member currentMember = MyPageProfileService.getCurrentMember(memberUtil);
+        currentMember.updatePhoneNumber(newPhone);
+        verificationCodeRepository.deleteById(newPhone);
     }
 
     public ConnectedSeniorResponse getConnectedSeniors() {

--- a/backend/widyu-api/src/main/java/com/widyu/mypage/controller/GuardianMyPageController.java
+++ b/backend/widyu-api/src/main/java/com/widyu/mypage/controller/GuardianMyPageController.java
@@ -4,6 +4,7 @@ import com.widyu.global.response.ApiResponseTemplate;
 import com.widyu.mypage.application.GuardianMyPageService;
 import com.widyu.mypage.controller.docs.GuardianMyPageDocs;
 import com.widyu.mypage.dto.request.ProfileImageUploadRequest;
+import com.widyu.auth.dto.request.SmsCodeRequest;
 import com.widyu.mypage.dto.request.UpdateInviteCodeRequest;
 import com.widyu.mypage.dto.request.UpdateNameRequest;
 import com.widyu.mypage.dto.request.UpdatePhoneRequest;
@@ -23,6 +24,7 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -70,6 +72,26 @@ public class GuardianMyPageController implements GuardianMyPageDocs {
         return ApiResponseTemplate.ok()
                 .code("MYPAGE_2013")
                 .message("프로필 이미지 수정 성공")
+                .build();
+    }
+
+    @Override
+    @PostMapping("/phone/sms/send")
+    public ApiResponseTemplate<Void> sendPhoneChangeSms(@RequestBody @Valid UpdatePhoneRequest request) {
+        guardianMyPageService.sendPhoneChangeSms(request);
+        return ApiResponseTemplate.ok()
+                .code("MYPAGE_2025")
+                .message("전화번호 변경 인증 문자가 전송되었습니다.")
+                .build();
+    }
+
+    @Override
+    @PatchMapping("/phone")
+    public ApiResponseTemplate<Void> verifyAndUpdatePhone(@RequestBody @Valid SmsCodeRequest request) {
+        guardianMyPageService.verifyAndUpdatePhone(request);
+        return ApiResponseTemplate.ok()
+                .code("MYPAGE_2026")
+                .message("전화번호 변경이 완료되었습니다.")
                 .build();
     }
 

--- a/backend/widyu-api/src/main/java/com/widyu/mypage/controller/docs/GuardianMyPageDocs.java
+++ b/backend/widyu-api/src/main/java/com/widyu/mypage/controller/docs/GuardianMyPageDocs.java
@@ -1,5 +1,6 @@
 package com.widyu.mypage.controller.docs;
 
+import com.widyu.auth.dto.request.SmsCodeRequest;
 import com.widyu.global.response.ApiResponseTemplate;
 import com.widyu.mypage.dto.request.ProfileImageUploadRequest;
 import com.widyu.mypage.dto.request.UpdateInviteCodeRequest;
@@ -32,6 +33,34 @@ public interface GuardianMyPageDocs {
     @Operation(summary = "보호자 이름 수정")
     @ApiResponses({@ApiResponse(responseCode = "200", description = "수정 성공")})
     ApiResponseTemplate<Void> updateName(UpdateNameRequest request);
+
+    @Operation(
+            summary = "보호자 전화번호 변경 - SMS 인증 발송",
+            description = """
+                    새 전화번호로 SMS 인증코드를 발송합니다.
+
+                    **검증:**
+                    - 이미 다른 회원이 사용 중인 전화번호이면 400 오류
+                    """
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "SMS 발송 성공"),
+            @ApiResponse(responseCode = "400", description = "이미 사용 중인 전화번호 또는 잘못된 형식")
+    })
+    ApiResponseTemplate<Void> sendPhoneChangeSms(UpdatePhoneRequest request);
+
+    @Operation(
+            summary = "보호자 전화번호 변경 - 인증코드 검증 및 변경",
+            description = """
+                    SMS 인증코드를 검증하고 전화번호를 변경합니다.
+                    인증 성공 시 즉시 전화번호가 업데이트되며 인증코드는 삭제됩니다.
+                    """
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "전화번호 변경 성공"),
+            @ApiResponse(responseCode = "400", description = "인증코드 불일치 또는 만료")
+    })
+    ApiResponseTemplate<Void> verifyAndUpdatePhone(SmsCodeRequest request);
 
     @Operation(summary = "보호자 프로필 이미지 수정")
     @ApiResponses({@ApiResponse(responseCode = "200", description = "수정 성공")})

--- a/backend/widyu-api/src/test/java/com/widyu/home/GuardianHomeServiceTest.java
+++ b/backend/widyu-api/src/test/java/com/widyu/home/GuardianHomeServiceTest.java
@@ -102,7 +102,7 @@ class GuardianHomeServiceTest {
         given(seniorProfileRepository.findAllByFamilyIdWithMember(any())).willReturn(List.of(seniorProfile));
         given(heartRateResultRepository.findByMemberId(any())).willReturn(Optional.empty());
         given(medicineScheduleRepository.findByMemberAndStatusWithDetails(any(), any())).willReturn(List.of());
-        given(healthScheduleRepository.findByMemberIdAndDate(any(), any(), any())).willReturn(List.of());
+        given(healthScheduleRepository.findByMemberIdAndDate(any(), any())).willReturn(List.of());
         given(walkRepository.findByMemberAndWalkDate(any(), any())).willReturn(Optional.empty());
         given(albumRecommendationService.recommendAlbums(any(), any())).willReturn(List.of());
 
@@ -129,7 +129,7 @@ class GuardianHomeServiceTest {
         given(seniorProfileRepository.findAllByFamilyIdWithMember(any())).willReturn(List.of(seniorProfile));
         given(heartRateResultRepository.findByMemberId(any())).willReturn(Optional.empty());
         given(medicineScheduleRepository.findByMemberAndStatusWithDetails(any(), any())).willReturn(List.of());
-        given(healthScheduleRepository.findByMemberIdAndDate(any(), any(), any())).willReturn(List.of());
+        given(healthScheduleRepository.findByMemberIdAndDate(any(), any())).willReturn(List.of());
         given(walkRepository.findByMemberAndWalkDate(any(), any())).willReturn(Optional.empty());
         given(albumRecommendationService.recommendAlbums(any(), any())).willReturn(List.of());
 
@@ -156,7 +156,7 @@ class GuardianHomeServiceTest {
         given(seniorProfileRepository.findAllByFamilyIdWithMember(any())).willReturn(List.of(seniorProfile));
         given(heartRateResultRepository.findByMemberId(any())).willReturn(Optional.empty());
         given(medicineScheduleRepository.findByMemberAndStatusWithDetails(any(), any())).willReturn(List.of());
-        given(healthScheduleRepository.findByMemberIdAndDate(any(), any(), any())).willReturn(List.of());
+        given(healthScheduleRepository.findByMemberIdAndDate(any(), any())).willReturn(List.of());
         given(walkRepository.findByMemberAndWalkDate(any(), any())).willReturn(Optional.empty());
         given(albumRecommendationService.recommendAlbums(any(), any())).willReturn(List.of());
 
@@ -193,7 +193,7 @@ class GuardianHomeServiceTest {
                 .willReturn(List.of(schedule1, schedule2));
         given(medicationProofRepository.findByMemberIdAndDateRange(any(), any(), any()))
                 .willReturn(List.of());
-        given(healthScheduleRepository.findByMemberIdAndDate(any(), any(), any())).willReturn(List.of());
+        given(healthScheduleRepository.findByMemberIdAndDate(any(), any())).willReturn(List.of());
         given(walkRepository.findByMemberAndWalkDate(any(), any())).willReturn(Optional.empty());
         given(albumRecommendationService.recommendAlbums(any(), any())).willReturn(List.of());
 

--- a/backend/widyu-api/src/test/java/com/widyu/home/GuardianHomeServiceTest.java
+++ b/backend/widyu-api/src/test/java/com/widyu/home/GuardianHomeServiceTest.java
@@ -3,11 +3,10 @@ package com.widyu.home;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.mock;
 
-import com.widyu.album.repository.AlbumRepository;
+import com.widyu.album.Album;
 import com.widyu.global.entity.Status;
 import com.widyu.global.error.BusinessException;
 import com.widyu.global.util.MemberUtil;
@@ -17,6 +16,7 @@ import com.widyu.goal.medicineschedule.repository.MedicineScheduleRepository;
 import com.widyu.goal.walk.repository.WalkRepository;
 import com.widyu.heart.repository.HeartRateResultRepository;
 import com.widyu.home.application.GuardianHomeService;
+import com.widyu.home.application.HomeAlbumRecommendationService;
 import com.widyu.home.dto.response.GuardianHomeCardsResponse;
 import com.widyu.medicine.MedicineSchedule;
 import com.widyu.member.Family;
@@ -36,7 +36,6 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.springframework.data.domain.SliceImpl;
 
 @ExtendWith(MockitoExtension.class)
 @DisplayName("GuardianHomeService 단위 테스트")
@@ -53,7 +52,7 @@ class GuardianHomeServiceTest {
     @Mock private MedicationProofRepository medicationProofRepository;
     @Mock private HealthScheduleRepository healthScheduleRepository;
     @Mock private WalkRepository walkRepository;
-    @Mock private AlbumRepository albumRepository;
+    @Mock private HomeAlbumRecommendationService albumRecommendationService;
 
     @Test
     @DisplayName("시니어가 보호자 홈을 호출하면 403 예외가 발생한다")
@@ -103,13 +102,9 @@ class GuardianHomeServiceTest {
         given(seniorProfileRepository.findAllByFamilyIdWithMember(any())).willReturn(List.of(seniorProfile));
         given(heartRateResultRepository.findByMemberId(any())).willReturn(Optional.empty());
         given(medicineScheduleRepository.findByMemberAndStatusWithDetails(any(), any())).willReturn(List.of());
-        given(healthScheduleRepository.findByMemberIdAndDate(any(), any())).willReturn(List.of());
+        given(healthScheduleRepository.findByMemberIdAndDate(any(), any(), any())).willReturn(List.of());
         given(walkRepository.findByMemberAndWalkDate(any(), any())).willReturn(Optional.empty());
-        given(seniorProfileRepository.findByMemberId(any())).willReturn(Optional.of(seniorProfile));
-        given(seniorProfileRepository.findAllByFamilyId(any())).willReturn(List.of(seniorProfile));
-        given(familyMembershipRepository.findAllByFamilyIdWithGuardian(any())).willReturn(List.of(membership));
-        given(albumRepository.findTopScoredAlbumIdsByMemberIds(anyList(), any()))
-                .willReturn(new SliceImpl<>(List.of()));
+        given(albumRecommendationService.recommendAlbums(any(), any())).willReturn(List.of());
 
         // when
         GuardianHomeCardsResponse response = guardianHomeService.getHomeCards(null);
@@ -134,13 +129,9 @@ class GuardianHomeServiceTest {
         given(seniorProfileRepository.findAllByFamilyIdWithMember(any())).willReturn(List.of(seniorProfile));
         given(heartRateResultRepository.findByMemberId(any())).willReturn(Optional.empty());
         given(medicineScheduleRepository.findByMemberAndStatusWithDetails(any(), any())).willReturn(List.of());
-        given(healthScheduleRepository.findByMemberIdAndDate(any(), any())).willReturn(List.of());
+        given(healthScheduleRepository.findByMemberIdAndDate(any(), any(), any())).willReturn(List.of());
         given(walkRepository.findByMemberAndWalkDate(any(), any())).willReturn(Optional.empty());
-        given(seniorProfileRepository.findByMemberId(any())).willReturn(Optional.of(seniorProfile));
-        given(seniorProfileRepository.findAllByFamilyId(any())).willReturn(List.of(seniorProfile));
-        given(familyMembershipRepository.findAllByFamilyIdWithGuardian(any())).willReturn(List.of(membership));
-        given(albumRepository.findTopScoredAlbumIdsByMemberIds(anyList(), any()))
-                .willReturn(new SliceImpl<>(List.of()));
+        given(albumRecommendationService.recommendAlbums(any(), any())).willReturn(List.of());
 
         // when
         GuardianHomeCardsResponse response = guardianHomeService.getHomeCards(null);
@@ -165,13 +156,9 @@ class GuardianHomeServiceTest {
         given(seniorProfileRepository.findAllByFamilyIdWithMember(any())).willReturn(List.of(seniorProfile));
         given(heartRateResultRepository.findByMemberId(any())).willReturn(Optional.empty());
         given(medicineScheduleRepository.findByMemberAndStatusWithDetails(any(), any())).willReturn(List.of());
-        given(healthScheduleRepository.findByMemberIdAndDate(any(), any())).willReturn(List.of());
+        given(healthScheduleRepository.findByMemberIdAndDate(any(), any(), any())).willReturn(List.of());
         given(walkRepository.findByMemberAndWalkDate(any(), any())).willReturn(Optional.empty());
-        given(seniorProfileRepository.findByMemberId(any())).willReturn(Optional.of(seniorProfile));
-        given(seniorProfileRepository.findAllByFamilyId(any())).willReturn(List.of(seniorProfile));
-        given(familyMembershipRepository.findAllByFamilyIdWithGuardian(any())).willReturn(List.of(membership));
-        given(albumRepository.findTopScoredAlbumIdsByMemberIds(anyList(), any()))
-                .willReturn(new SliceImpl<>(List.of()));
+        given(albumRecommendationService.recommendAlbums(any(), any())).willReturn(List.of());
 
         // when
         GuardianHomeCardsResponse response = guardianHomeService.getHomeCards(null);
@@ -206,13 +193,9 @@ class GuardianHomeServiceTest {
                 .willReturn(List.of(schedule1, schedule2));
         given(medicationProofRepository.findByMemberIdAndDateRange(any(), any(), any()))
                 .willReturn(List.of());
-        given(healthScheduleRepository.findByMemberIdAndDate(any(), any())).willReturn(List.of());
+        given(healthScheduleRepository.findByMemberIdAndDate(any(), any(), any())).willReturn(List.of());
         given(walkRepository.findByMemberAndWalkDate(any(), any())).willReturn(Optional.empty());
-        given(seniorProfileRepository.findByMemberId(any())).willReturn(Optional.of(seniorProfile));
-        given(seniorProfileRepository.findAllByFamilyId(any())).willReturn(List.of(seniorProfile));
-        given(familyMembershipRepository.findAllByFamilyIdWithGuardian(any())).willReturn(List.of(membership));
-        given(albumRepository.findTopScoredAlbumIdsByMemberIds(anyList(), any()))
-                .willReturn(new SliceImpl<>(List.of()));
+        given(albumRecommendationService.recommendAlbums(any(), any())).willReturn(List.of());
 
         // when
         GuardianHomeCardsResponse response = guardianHomeService.getHomeCards(null);

--- a/backend/widyu-api/src/test/java/com/widyu/home/SeniorHomeServiceTest.java
+++ b/backend/widyu-api/src/test/java/com/widyu/home/SeniorHomeServiceTest.java
@@ -3,34 +3,23 @@ package com.widyu.home;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.mock;
 
-import com.widyu.album.repository.AlbumRepository;
-import com.widyu.global.entity.Status;
 import com.widyu.global.error.BusinessException;
 import com.widyu.global.util.MemberUtil;
 import com.widyu.goal.healthschedule.repository.HealthScheduleRepository;
 import com.widyu.goal.medicineschedule.repository.MedicationProofRepository;
 import com.widyu.goal.medicineschedule.repository.MedicineScheduleRepository;
 import com.widyu.goal.walk.repository.WalkRepository;
-import com.widyu.healthschedule.HealthSchedule;
 import com.widyu.heart.repository.HeartRateResultRepository;
+import com.widyu.home.application.HomeAlbumRecommendationService;
 import com.widyu.home.application.SeniorHomeService;
 import com.widyu.home.dto.response.SeniorHomeCardsResponse;
 import com.widyu.medicine.MedicationProof;
 import com.widyu.medicine.MedicineSchedule;
-import com.widyu.member.Family;
-import com.widyu.member.FamilyMembership;
 import com.widyu.member.Member;
 import com.widyu.member.MemberType;
-import com.widyu.member.SeniorProfile;
-import com.widyu.member.repository.FamilyMembershipRepository;
-import com.widyu.member.repository.SeniorProfileRepository;
-import com.widyu.walk.Walk;
-import java.time.LocalDate;
-import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.util.List;
 import java.util.Optional;
@@ -40,7 +29,6 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.springframework.data.domain.SliceImpl;
 
 @ExtendWith(MockitoExtension.class)
 @DisplayName("SeniorHomeService 단위 테스트")
@@ -53,10 +41,8 @@ class SeniorHomeServiceTest {
     @Mock private MedicationProofRepository medicationProofRepository;
     @Mock private WalkRepository walkRepository;
     @Mock private HealthScheduleRepository healthScheduleRepository;
-    @Mock private AlbumRepository albumRepository;
     @Mock private HeartRateResultRepository heartRateResultRepository;
-    @Mock private SeniorProfileRepository seniorProfileRepository;
-    @Mock private FamilyMembershipRepository familyMembershipRepository;
+    @Mock private HomeAlbumRecommendationService albumRecommendationService;
 
     @Test
     @DisplayName("보호자가 시니어 홈을 호출하면 403 예외가 발생한다")
@@ -75,22 +61,13 @@ class SeniorHomeServiceTest {
     void 약_스케줄이_없으면_medicine은_null을_반환한다() {
         // given
         Member senior = Member.createMember(MemberType.SENIOR, "부모님", "01011112222");
-        Family family = Family.createFamily("FAMA01");
-        SeniorProfile seniorProfile = SeniorProfile.createSeniorProfile(
-                senior, family, "서울시", null, "1110001", null);
-        FamilyMembership membership = FamilyMembership.createLeaderMembership(family,
-                Member.createMember(MemberType.GUARDIAN, "보호자", "01099999999"));
 
         given(memberUtil.getCurrentMember()).willReturn(senior);
         given(medicineScheduleRepository.findByMemberAndStatusWithDetails(any(), any())).willReturn(List.of());
         given(heartRateResultRepository.findByMemberId(any())).willReturn(Optional.empty());
         given(healthScheduleRepository.findByMemberIdAndWeek(any(), any(), any())).willReturn(List.of());
         given(walkRepository.findByMemberAndWalkDate(any(), any())).willReturn(Optional.empty());
-        given(seniorProfileRepository.findByMemberId(any())).willReturn(Optional.of(seniorProfile));
-        given(seniorProfileRepository.findAllByFamilyId(any())).willReturn(List.of(seniorProfile));
-        given(familyMembershipRepository.findAllByFamilyIdWithGuardian(any())).willReturn(List.of(membership));
-        given(albumRepository.findTopScoredAlbumIdsByMemberIds(anyList(), any()))
-                .willReturn(new SliceImpl<>(List.of()));
+        given(albumRecommendationService.recommendAlbums(any(), any())).willReturn(List.of());
 
         // when
         SeniorHomeCardsResponse response = seniorHomeService.getHomeCards();
@@ -104,9 +81,6 @@ class SeniorHomeServiceTest {
     void 오늘_복용한_스케줄은_taken이_true다() {
         // given
         Member senior = Member.createMember(MemberType.SENIOR, "부모님", "01011112222");
-        Family family = Family.createFamily("FAMA01");
-        SeniorProfile seniorProfile = SeniorProfile.createSeniorProfile(
-                senior, family, "서울시", null, "1110001", null);
 
         MedicineSchedule schedule = mock(MedicineSchedule.class);
         given(schedule.getId()).willReturn(1L);
@@ -124,11 +98,7 @@ class SeniorHomeServiceTest {
         given(heartRateResultRepository.findByMemberId(any())).willReturn(Optional.empty());
         given(healthScheduleRepository.findByMemberIdAndWeek(any(), any(), any())).willReturn(List.of());
         given(walkRepository.findByMemberAndWalkDate(any(), any())).willReturn(Optional.empty());
-        given(seniorProfileRepository.findByMemberId(any())).willReturn(Optional.of(seniorProfile));
-        given(seniorProfileRepository.findAllByFamilyId(any())).willReturn(List.of(seniorProfile));
-        given(familyMembershipRepository.findAllByFamilyIdWithGuardian(any())).willReturn(List.of());
-        given(albumRepository.findTopScoredAlbumIdsByMemberIds(anyList(), any()))
-                .willReturn(new SliceImpl<>(List.of()));
+        given(albumRecommendationService.recommendAlbums(any(), any())).willReturn(List.of());
 
         // when
         SeniorHomeCardsResponse response = seniorHomeService.getHomeCards();
@@ -143,20 +113,13 @@ class SeniorHomeServiceTest {
     void 오늘_건강일정이_없으면_healthSchedule은_null을_반환한다() {
         // given
         Member senior = Member.createMember(MemberType.SENIOR, "부모님", "01011112222");
-        Family family = Family.createFamily("FAMA01");
-        SeniorProfile seniorProfile = SeniorProfile.createSeniorProfile(
-                senior, family, "서울시", null, "1110001", null);
 
         given(memberUtil.getCurrentMember()).willReturn(senior);
         given(medicineScheduleRepository.findByMemberAndStatusWithDetails(any(), any())).willReturn(List.of());
         given(heartRateResultRepository.findByMemberId(any())).willReturn(Optional.empty());
         given(healthScheduleRepository.findByMemberIdAndWeek(any(), any(), any())).willReturn(List.of());
         given(walkRepository.findByMemberAndWalkDate(any(), any())).willReturn(Optional.empty());
-        given(seniorProfileRepository.findByMemberId(any())).willReturn(Optional.of(seniorProfile));
-        given(seniorProfileRepository.findAllByFamilyId(any())).willReturn(List.of(seniorProfile));
-        given(familyMembershipRepository.findAllByFamilyIdWithGuardian(any())).willReturn(List.of());
-        given(albumRepository.findTopScoredAlbumIdsByMemberIds(anyList(), any()))
-                .willReturn(new SliceImpl<>(List.of()));
+        given(albumRecommendationService.recommendAlbums(any(), any())).willReturn(List.of());
 
         // when
         SeniorHomeCardsResponse response = seniorHomeService.getHomeCards();
@@ -170,20 +133,13 @@ class SeniorHomeServiceTest {
     void 걷기_데이터와_기본목표가_없으면_walk는_null을_반환한다() {
         // given
         Member senior = Member.createMember(MemberType.SENIOR, "부모님", "01011112222");
-        Family family = Family.createFamily("FAMA01");
-        SeniorProfile seniorProfile = SeniorProfile.createSeniorProfile(
-                senior, family, "서울시", null, "1110001", null);
 
         given(memberUtil.getCurrentMember()).willReturn(senior);
         given(medicineScheduleRepository.findByMemberAndStatusWithDetails(any(), any())).willReturn(List.of());
         given(heartRateResultRepository.findByMemberId(any())).willReturn(Optional.empty());
         given(healthScheduleRepository.findByMemberIdAndWeek(any(), any(), any())).willReturn(List.of());
         given(walkRepository.findByMemberAndWalkDate(any(), any())).willReturn(Optional.empty());
-        given(seniorProfileRepository.findByMemberId(any())).willReturn(Optional.of(seniorProfile));
-        given(seniorProfileRepository.findAllByFamilyId(any())).willReturn(List.of(seniorProfile));
-        given(familyMembershipRepository.findAllByFamilyIdWithGuardian(any())).willReturn(List.of());
-        given(albumRepository.findTopScoredAlbumIdsByMemberIds(anyList(), any()))
-                .willReturn(new SliceImpl<>(List.of()));
+        given(albumRecommendationService.recommendAlbums(any(), any())).willReturn(List.of());
 
         // when
         SeniorHomeCardsResponse response = seniorHomeService.getHomeCards();
@@ -197,20 +153,13 @@ class SeniorHomeServiceTest {
     void 가족_앨범이_없으면_albums는_빈배열을_반환한다() {
         // given
         Member senior = Member.createMember(MemberType.SENIOR, "부모님", "01011112222");
-        Family family = Family.createFamily("FAMA01");
-        SeniorProfile seniorProfile = SeniorProfile.createSeniorProfile(
-                senior, family, "서울시", null, "1110001", null);
 
         given(memberUtil.getCurrentMember()).willReturn(senior);
         given(medicineScheduleRepository.findByMemberAndStatusWithDetails(any(), any())).willReturn(List.of());
         given(heartRateResultRepository.findByMemberId(any())).willReturn(Optional.empty());
         given(healthScheduleRepository.findByMemberIdAndWeek(any(), any(), any())).willReturn(List.of());
         given(walkRepository.findByMemberAndWalkDate(any(), any())).willReturn(Optional.empty());
-        given(seniorProfileRepository.findByMemberId(any())).willReturn(Optional.of(seniorProfile));
-        given(seniorProfileRepository.findAllByFamilyId(any())).willReturn(List.of(seniorProfile));
-        given(familyMembershipRepository.findAllByFamilyIdWithGuardian(any())).willReturn(List.of());
-        given(albumRepository.findTopScoredAlbumIdsByMemberIds(anyList(), any()))
-                .willReturn(new SliceImpl<>(List.of()));
+        given(albumRecommendationService.recommendAlbums(any(), any())).willReturn(List.of());
 
         // when
         SeniorHomeCardsResponse response = seniorHomeService.getHomeCards();


### PR DESCRIPTION
## #️⃣연관된 이슈

- close: #283

## 🪄작업 내용

- `FamilyMemberQueryService` — 가족 구성원 ID 수집 로직 분리 (시니어·보호자 홈 공유)
- `HomeAlbumRecommendationService` — 앨범 추천 점수 계산 로직 분리
- `GuardianHomeService` — 중복 코드 제거, 공통 컴포넌트 주입으로 교체
- `SeniorHomeService` — 중복 코드 제거, 공통 컴포넌트 주입으로 교체
- 홈 서비스 단위 테스트(`GuardianHomeServiceTest`, `SeniorHomeServiceTest`) 수정

## 💖리뷰 요청사항

- 앨범 추천 점수 계산 로직이 `HomeAlbumRecommendationService`로 분리되면서 `GuardianHomeService`와 `SeniorHomeService`가 동일한 추천 결과를 사용하게 됩니다. 시니어·보호자 홈 간 추천 정책이 달라져야 하는 경우가 생기면 이 서비스를 확장해야 합니다.