### PR TITLE
refactor(#285): 앨범 응답 임시값 제거 및 날짜 필터 쿼리 range 방식으로 변경

### DIFF
--- a/backend/widyu-api/src/main/java/com/widyu/album/application/AlbumFacadeImpl.java
+++ b/backend/widyu-api/src/main/java/com/widyu/album/application/AlbumFacadeImpl.java
@@ -20,9 +20,6 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
 
-import java.io.File;
-import java.io.IOException;
-import java.util.ArrayList;
 import java.util.List;
 
 /**
@@ -45,48 +42,17 @@ public class AlbumFacadeImpl implements AlbumFacade {
     @Override
     public AlbumUploadAcceptedResponse uploadAlbum(AlbumUploadRequest request) {
         Member currentMember = memberUtil.getCurrentMember();
-        mediaPolicy.validate(request.mediaFiles());
 
-        List<String> mediaUrls = new ArrayList<>();
-        List<String> thumbnailUrls = new ArrayList<>();
-        List<Integer> durations = new ArrayList<>();
-        List<AlbumVideoProcessingService.VideoEntry> videoEntries = new ArrayList<>();
+        AlbumFileService.AsyncUploadPreparation prep =
+                albumFileService.prepareForAsyncUpload(request.mediaFiles(), currentMember.getId());
 
-        for (int i = 0; i < request.mediaFiles().size(); i++) {
-            MultipartFile file = request.mediaFiles().get(i);
-            String contentType = file.getContentType();
-
-            if (contentType == null) {
-                throw new BusinessException(ErrorCode.INVALID_FILE_TYPE);
-            }
-
-            if (contentType.startsWith("image/")) {
-                String url = albumFileService.uploadAlbumPhoto(file, currentMember.getId());
-                mediaUrls.add(url);
-                thumbnailUrls.add(null);
-                durations.add(null);
-            } else if (contentType.startsWith("video/")) {
-                try {
-                    File tempFile = albumFileService.toTempFile(file);
-                    videoEntries.add(new AlbumVideoProcessingService.VideoEntry(
-                            i, tempFile, file.getOriginalFilename(), contentType));
-                    mediaUrls.add("");
-                    thumbnailUrls.add(null);
-                    durations.add(null);
-                } catch (IOException e) {
-                    throw new BusinessException(ErrorCode.FILE_UPLOAD_FAILED);
-                }
-            } else {
-                throw new BusinessException(ErrorCode.INVALID_FILE_TYPE);
-            }
-        }
-
-        boolean hasVideos = !videoEntries.isEmpty();
         Long albumId = albumService.saveAlbum(
-                currentMember, request.content(), mediaUrls, thumbnailUrls, durations, hasVideos);
+                currentMember, request.content(),
+                prep.mediaUrls(), prep.thumbnailUrls(), prep.durations(),
+                prep.hasVideos());
 
-        if (hasVideos) {
-            albumVideoProcessingService.processVideosAsync(albumId, currentMember.getId(), videoEntries);
+        if (prep.hasVideos()) {
+            albumVideoProcessingService.processVideosAsync(albumId, currentMember.getId(), prep.videoEntries());
         }
 
         return new AlbumUploadAcceptedResponse(albumId);

--- a/backend/widyu-api/src/main/java/com/widyu/album/application/AlbumFeedService.java
+++ b/backend/widyu-api/src/main/java/com/widyu/album/application/AlbumFeedService.java
@@ -11,6 +11,7 @@ import com.widyu.member.Member;
 import com.widyu.global.dto.CursorPage;
 import com.widyu.global.util.MemberUtil;
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.HashMap;
@@ -95,9 +96,11 @@ public class AlbumFeedService {
 
     private Slice<Long> findAlbumIdSlice(Long lastPostId, LocalDate date, Pageable pageable) {
         if (date != null) {
+            LocalDateTime startOfDay = date.atStartOfDay();
+            LocalDateTime startOfNextDay = date.plusDays(1).atStartOfDay();
             return (lastPostId != null)
-                    ? albumRepository.findAlbumIdsAfterPostIdByDate(lastPostId, date, pageable)
-                    : albumRepository.findLatestAlbumIdsByDate(date, pageable);
+                    ? albumRepository.findAlbumIdsAfterPostIdByDate(lastPostId, startOfDay, startOfNextDay, pageable)
+                    : albumRepository.findLatestAlbumIdsByDate(startOfDay, startOfNextDay, pageable);
         } else {
             return (lastPostId != null)
                     ? albumRepository.findAlbumIdsAfterPostId(lastPostId, pageable)

--- a/backend/widyu-api/src/main/java/com/widyu/album/application/AlbumFileService.java
+++ b/backend/widyu-api/src/main/java/com/widyu/album/application/AlbumFileService.java
@@ -33,16 +33,21 @@ public class AlbumFileService {
     private static final String ALBUM_VIDEO_PREFIX = "albums/videos";
     private static final String THUMBNAIL_PREFIX = "albums/thumbnails";
 
-    /**
-     * 업로드 결과(미디어 URL/썸네일 URL/길이)
-     */
     public static record UploadResult(List<String> mediaUrls, List<String> thumbnailUrls, List<Integer> durations) {
     }
 
-    /**
-     * 단일 비디오 업로드 결과
-     */
     public static record VideoUploadResult(String videoUrl, String thumbnailUrl, Integer duration) {
+    }
+
+    public static record AsyncUploadPreparation(
+            List<String> mediaUrls,
+            List<String> thumbnailUrls,
+            List<Integer> durations,
+            List<AlbumVideoProcessingService.VideoEntry> videoEntries
+    ) {
+        public boolean hasVideos() {
+            return !videoEntries.isEmpty();
+        }
     }
 
     /**
@@ -194,6 +199,50 @@ public class AlbumFileService {
 
     public List<String> uploadMediaFiles(List<MultipartFile> mediaFiles, Long memberId) {
         return uploadMediaFilesWithThumbnails(mediaFiles, memberId).mediaUrls();
+    }
+
+    public AsyncUploadPreparation prepareForAsyncUpload(List<MultipartFile> mediaFiles, Long memberId) {
+        mediaPolicy.validate(mediaFiles);
+
+        List<String> mediaUrls = new ArrayList<>();
+        List<String> thumbnailUrls = new ArrayList<>();
+        List<Integer> durations = new ArrayList<>();
+        List<AlbumVideoProcessingService.VideoEntry> videoEntries = new ArrayList<>();
+
+        List<String> uploadedPhotoUrls = new ArrayList<>();
+
+        try {
+            for (int i = 0; i < mediaFiles.size(); i++) {
+                MultipartFile file = mediaFiles.get(i);
+                String contentType = file.getContentType();
+
+                if (contentType == null) {
+                    throw new BusinessException(ErrorCode.INVALID_FILE_TYPE);
+                }
+
+                if (contentType.startsWith("image/")) {
+                    String url = uploadAlbumPhoto(file, memberId);
+                    uploadedPhotoUrls.add(url);
+                    mediaUrls.add(url);
+                    thumbnailUrls.add(null);
+                    durations.add(null);
+                } else if (contentType.startsWith("video/")) {
+                    File tempFile = toTempFile(file);
+                    videoEntries.add(new AlbumVideoProcessingService.VideoEntry(i, tempFile, file.getOriginalFilename(), contentType));
+                    mediaUrls.add("");
+                    thumbnailUrls.add(null);
+                    durations.add(null);
+                } else {
+                    throw new BusinessException(ErrorCode.INVALID_FILE_TYPE);
+                }
+            }
+        } catch (Exception e) {
+            cleanupUploadedFiles(uploadedPhotoUrls);
+            if (e instanceof BusinessException be) throw be;
+            throw new BusinessException(ErrorCode.FILE_UPLOAD_FAILED);
+        }
+
+        return new AsyncUploadPreparation(mediaUrls, thumbnailUrls, durations, videoEntries);
     }
 
     private void validateInternalImage(MultipartFile file) {

--- a/backend/widyu-api/src/main/java/com/widyu/album/dto/FamilyAlbumResponse.java
+++ b/backend/widyu-api/src/main/java/com/widyu/album/dto/FamilyAlbumResponse.java
@@ -50,7 +50,7 @@ public record FamilyAlbumResponse(
             return new AuthorInfo(
                     member.getId(),
                     member.getName(),
-                    null  // TODO: 프로필 이미지 필드가 추가되면 수정
+                    member.getProfileImage()
             );
         }
     }
@@ -64,7 +64,7 @@ public record FamilyAlbumResponse(
             return new ViewerInfo(
                     member.getId(),
                     member.getName(),
-                    null  // TODO: 프로필 이미지 필드가 추가되면 수정
+                    member.getProfileImage()
             );
         }
     }

--- a/backend/widyu-api/src/main/java/com/widyu/album/dto/response/AlbumDetailResponse.java
+++ b/backend/widyu-api/src/main/java/com/widyu/album/dto/response/AlbumDetailResponse.java
@@ -91,6 +91,8 @@ public record AlbumDetailResponse(
         }
     }
 
+    private static final int ALBUM_UNLOCK_PRICE = 50;
+
     public static AlbumDetailResponse from(Album album, Long currentUserId, List<Member> viewers,
                                            List<AlbumComment> comments) {
         return new AlbumDetailResponse(
@@ -103,7 +105,7 @@ public record AlbumDetailResponse(
                 album.getCreatedAt(),
                 AuthorInfo.from(album.getMember()),
                 viewers.stream().map(ViewerInfo::from).toList(),
-                50, // 게시물 해금 가격 임시 고정
+                ALBUM_UNLOCK_PRICE,
                 comments.stream()
                         .map(comment -> CommentInfo.from(comment, currentUserId))
                         .toList(),

--- a/backend/widyu-api/src/main/java/com/widyu/album/dto/response/AlbumFeedResponse.java
+++ b/backend/widyu-api/src/main/java/com/widyu/album/dto/response/AlbumFeedResponse.java
@@ -4,6 +4,7 @@ import com.widyu.album.Album;
 import com.widyu.album.MediaType;
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Objects;
 
 public record AlbumFeedResponse(
         Long albumId,
@@ -30,10 +31,16 @@ public record AlbumFeedResponse(
     ) {}
 
     public static AlbumFeedResponse from(Album album, Boolean canEdit, List<ViewerInfo> viewers) {
+        String primaryVideoDuration = album.getDurations().stream()
+                .filter(Objects::nonNull)
+                .findFirst()
+                .map(d -> String.format("%d:%02d", d / 60, d % 60))
+                .orElse(null);
+
         return new AlbumFeedResponse(
                 album.getId(),
                 album.getMember().getName(),
-                null, // TODO: 프로필 이미지 구현 시 추가
+                album.getMember().getProfileImage(),
                 album.getContent(),
                 album.getMediaUrls(),
                 album.getThumbnailUrls(),
@@ -47,7 +54,7 @@ public record AlbumFeedResponse(
                 viewers,
                 album.getCreatedAt(),
                 canEdit,
-                null // TODO: 비디오 지속시간 구현 시 추가
+                primaryVideoDuration
         );
     }
 }

--- a/backend/widyu-api/src/main/java/com/widyu/album/repository/AlbumRepository.java
+++ b/backend/widyu-api/src/main/java/com/widyu/album/repository/AlbumRepository.java
@@ -54,13 +54,14 @@ public interface AlbumRepository extends JpaRepository<Album, Long> {
     @Query("SELECT COUNT(a) FROM Album a WHERE a.status = 'ACTIVE' AND a.createdAt >= :start AND a.createdAt < :end")
     long countActiveAlbumsCreatedBetween(@Param("start") LocalDateTime start, @Param("end") LocalDateTime end);
     
-    @Query("SELECT a.id FROM Album a WHERE a.status = 'ACTIVE' AND DATE(a.createdAt) = :date ORDER BY a.createdAt DESC, a.id DESC")
-    org.springframework.data.domain.Slice<Long> findLatestAlbumIdsByDate(@Param("date") LocalDate date, Pageable pageable);
-    
-    @Query("SELECT a.id FROM Album a WHERE a.status = 'ACTIVE' AND DATE(a.createdAt) = :date AND a.id < :lastPostId ORDER BY a.id DESC")
+    @Query("SELECT a.id FROM Album a WHERE a.status = 'ACTIVE' AND a.createdAt >= :startOfDay AND a.createdAt < :startOfNextDay ORDER BY a.createdAt DESC, a.id DESC")
+    org.springframework.data.domain.Slice<Long> findLatestAlbumIdsByDate(@Param("startOfDay") LocalDateTime startOfDay, @Param("startOfNextDay") LocalDateTime startOfNextDay, Pageable pageable);
+
+    @Query("SELECT a.id FROM Album a WHERE a.status = 'ACTIVE' AND a.createdAt >= :startOfDay AND a.createdAt < :startOfNextDay AND a.id < :lastPostId ORDER BY a.id DESC")
     org.springframework.data.domain.Slice<Long> findAlbumIdsAfterPostIdByDate(
             @Param("lastPostId") Long lastPostId,
-            @Param("date") LocalDate date,
+            @Param("startOfDay") LocalDateTime startOfDay,
+            @Param("startOfNextDay") LocalDateTime startOfNextDay,
             Pageable pageable
     );
 

--- a/backend/widyu-api/src/main/java/com/widyu/goal/healthschedule/application/HealthScheduleService.java
+++ b/backend/widyu-api/src/main/java/com/widyu/goal/healthschedule/application/HealthScheduleService.java
@@ -207,9 +207,8 @@ public class HealthScheduleService {
     public List<HealthScheduleDetailWithRewardResponse> getHealthSchedulesByDateForMe(LocalDate date) {
         Member currentMember = memberUtil.getCurrentMember();
 
-        // 특정 날짜의 일정 조회
         List<HealthSchedule> schedules = healthScheduleRepository.findByMemberIdAndDate(
-                currentMember.getId(), date
+                currentMember.getId(), date.atStartOfDay(), date.plusDays(1).atStartOfDay()
         );
 
         return schedules.stream()
@@ -220,11 +219,9 @@ public class HealthScheduleService {
     public List<HealthScheduleDetailResponse> getHealthSchedulesByDateForSenior(Long memberId, LocalDate date) {
         Member currentMember = memberUtil.getCurrentMember();
 
-        // 시니어 프로필 조회
         SeniorProfile seniorProfile = seniorProfileRepository.findByMemberId(memberId)
                 .orElseThrow(() -> new BusinessException(ErrorCode.SENIOR_PROFILE_NOT_FOUND));
 
-        // 보호자-시니어 연결 확인
         boolean isConnected = familyMembershipRepository.existsByGuardianIdAndSeniorProfileId(
                 currentMember.getId(), seniorProfile.getId()
         );
@@ -233,9 +230,8 @@ public class HealthScheduleService {
             throw new BusinessException(ErrorCode.FORBIDDEN, "해당 시니어의 일정을 조회할 권한이 없습니다.");
         }
 
-        // 특정 날짜의 일정 조회
         List<HealthSchedule> schedules = healthScheduleRepository.findByMemberIdAndDate(
-                memberId, date
+                memberId, date.atStartOfDay(), date.plusDays(1).atStartOfDay()
         );
 
         return schedules.stream()

--- a/backend/widyu-api/src/main/java/com/widyu/goal/healthschedule/repository/HealthScheduleRepository.java
+++ b/backend/widyu-api/src/main/java/com/widyu/goal/healthschedule/repository/HealthScheduleRepository.java
@@ -19,10 +19,11 @@ public interface HealthScheduleRepository extends JpaRepository<HealthSchedule, 
             @Param("endDate") LocalDateTime endDate
     );
 
-    @Query("SELECT h FROM HealthSchedule h WHERE h.member.id = :memberId AND DATE(h.scheduledAt) = :date")
+    @Query("SELECT h FROM HealthSchedule h WHERE h.member.id = :memberId AND h.scheduledAt >= :startOfDay AND h.scheduledAt < :startOfNextDay")
     List<HealthSchedule> findByMemberIdAndDate(
             @Param("memberId") Long memberId,
-            @Param("date") java.time.LocalDate date
+            @Param("startOfDay") LocalDateTime startOfDay,
+            @Param("startOfNextDay") LocalDateTime startOfNextDay
     );
 
     @Query("SELECT h FROM HealthSchedule h WHERE h.member.id = :memberId AND h.scheduledAt >= :startDate AND h.scheduledAt < :endDate ORDER BY h.scheduledAt ASC")

--- a/backend/widyu-api/src/main/java/com/widyu/home/application/GuardianHomeService.java
+++ b/backend/widyu-api/src/main/java/com/widyu/home/application/GuardianHomeService.java
@@ -219,7 +219,7 @@ public class GuardianHomeService {
     }
 
     private GuardianHomeCardsResponse.HealthScheduleInfo getHealthScheduleInfo(Member senior, LocalDate today) {
-        return healthScheduleRepository.findByMemberIdAndDate(senior.getId(), today)
+        return healthScheduleRepository.findByMemberIdAndDate(senior.getId(), today.atStartOfDay(), today.plusDays(1).atStartOfDay())
                 .stream()
                 .min(Comparator.comparing(HealthSchedule::getScheduledAt))
                 .map(GuardianHomeCardsResponse.HealthScheduleInfo::from)

--- a/backend/widyu-api/src/test/java/com/widyu/home/GuardianHomeServiceTest.java
+++ b/backend/widyu-api/src/test/java/com/widyu/home/GuardianHomeServiceTest.java
@@ -103,7 +103,7 @@ class GuardianHomeServiceTest {
         given(seniorProfileRepository.findAllByFamilyIdWithMember(any())).willReturn(List.of(seniorProfile));
         given(heartRateResultRepository.findByMemberId(any())).willReturn(Optional.empty());
         given(medicineScheduleRepository.findByMemberAndStatusWithDetails(any(), any())).willReturn(List.of());
-        given(healthScheduleRepository.findByMemberIdAndDate(any(), any())).willReturn(List.of());
+        given(healthScheduleRepository.findByMemberIdAndDate(any(), any(), any())).willReturn(List.of());
         given(walkRepository.findByMemberAndWalkDate(any(), any())).willReturn(Optional.empty());
         given(seniorProfileRepository.findByMemberId(any())).willReturn(Optional.of(seniorProfile));
         given(seniorProfileRepository.findAllByFamilyId(any())).willReturn(List.of(seniorProfile));
@@ -134,7 +134,7 @@ class GuardianHomeServiceTest {
         given(seniorProfileRepository.findAllByFamilyIdWithMember(any())).willReturn(List.of(seniorProfile));
         given(heartRateResultRepository.findByMemberId(any())).willReturn(Optional.empty());
         given(medicineScheduleRepository.findByMemberAndStatusWithDetails(any(), any())).willReturn(List.of());
-        given(healthScheduleRepository.findByMemberIdAndDate(any(), any())).willReturn(List.of());
+        given(healthScheduleRepository.findByMemberIdAndDate(any(), any(), any())).willReturn(List.of());
         given(walkRepository.findByMemberAndWalkDate(any(), any())).willReturn(Optional.empty());
         given(seniorProfileRepository.findByMemberId(any())).willReturn(Optional.of(seniorProfile));
         given(seniorProfileRepository.findAllByFamilyId(any())).willReturn(List.of(seniorProfile));
@@ -165,7 +165,7 @@ class GuardianHomeServiceTest {
         given(seniorProfileRepository.findAllByFamilyIdWithMember(any())).willReturn(List.of(seniorProfile));
         given(heartRateResultRepository.findByMemberId(any())).willReturn(Optional.empty());
         given(medicineScheduleRepository.findByMemberAndStatusWithDetails(any(), any())).willReturn(List.of());
-        given(healthScheduleRepository.findByMemberIdAndDate(any(), any())).willReturn(List.of());
+        given(healthScheduleRepository.findByMemberIdAndDate(any(), any(), any())).willReturn(List.of());
         given(walkRepository.findByMemberAndWalkDate(any(), any())).willReturn(Optional.empty());
         given(seniorProfileRepository.findByMemberId(any())).willReturn(Optional.of(seniorProfile));
         given(seniorProfileRepository.findAllByFamilyId(any())).willReturn(List.of(seniorProfile));
@@ -206,7 +206,7 @@ class GuardianHomeServiceTest {
                 .willReturn(List.of(schedule1, schedule2));
         given(medicationProofRepository.findByMemberIdAndDateRange(any(), any(), any()))
                 .willReturn(List.of());
-        given(healthScheduleRepository.findByMemberIdAndDate(any(), any())).willReturn(List.of());
+        given(healthScheduleRepository.findByMemberIdAndDate(any(), any(), any())).willReturn(List.of());
         given(walkRepository.findByMemberAndWalkDate(any(), any())).willReturn(Optional.empty());
         given(seniorProfileRepository.findByMemberId(any())).willReturn(Optional.of(seniorProfile));
         given(seniorProfileRepository.findAllByFamilyId(any())).willReturn(List.of(seniorProfile));


### PR DESCRIPTION
## #️⃣연관된 이슈

- close: #285

## 🪄작업 내용

- `AlbumFeedResponse` — 작성자 프로필 이미지 `Member.getProfileImage()` 연결, `videoDuration` 실제 값 연결
- `FamilyAlbumResponse` · `AlbumDetailResponse` — 프로필 이미지 null 고정 제거, 잠금 해제 가격 상수화
- `AlbumFeedService` · `AlbumFileService` · `AlbumFacadeImpl` — duration 저장 흐름 연결 및 업로드 오케스트레이션 정리
- `AlbumRepository` · `HealthScheduleRepository` — `DATE(createdAt) = :date` 제거, `startOfDay ≤ createdAt < nextDayStart` range 쿼리로 변경
- `HealthScheduleService` — range 쿼리에 맞게 파라미터 조정

## 💖리뷰 요청사항

- `DATE(...)` 제거로 인덱스 활용이 개선됩니다. 날짜 경계값(`startOfDay`, `nextDayStart`)이 서버 타임존 기준으로 계산되므로 운영 서버 타임존 설정과 일치하는지 확인 부탁드립니다.