### PR TITLE
refactor(#286): 관리자 refresh token을 HttpOnly Secure cookie로 이동

### DIFF
--- a/admin/src/api/client.ts
+++ b/admin/src/api/client.ts
@@ -2,6 +2,7 @@ import axios from 'axios'
 
 const client = axios.create({
   baseURL: '/api/v1',
+  withCredentials: true, // HttpOnly 쿠키 자동 전송
 })
 
 client.interceptors.request.use((config) => {
@@ -33,13 +34,6 @@ client.interceptors.response.use(
       return Promise.reject(error)
     }
 
-    const refreshToken = localStorage.getItem('admin_refresh_token')
-    if (!refreshToken) {
-      localStorage.removeItem('admin_token')
-      window.location.href = import.meta.env.BASE_URL + 'login'
-      return Promise.reject(error)
-    }
-
     if (isRefreshing) {
       return new Promise((resolve, reject) => {
         refreshQueue.push({
@@ -56,13 +50,11 @@ client.interceptors.response.use(
     isRefreshing = true
 
     try {
-      const { data } = await axios.post('/api/v1/auth/reissue', { refreshToken })
-      const newAccessToken: string = data.data.accessToken
-      const newRefreshToken: string = data.data.refreshToken
+      // refresh token은 HttpOnly 쿠키로 자동 전송됨 (withCredentials)
+      const { data } = await axios.post('/api/v1/auth/admin/refresh', null, { withCredentials: true })
+      const newAccessToken: string = data.accessToken
 
       localStorage.setItem('admin_token', newAccessToken)
-      localStorage.setItem('admin_refresh_token', newRefreshToken)
-
       client.defaults.headers.common.Authorization = `Bearer ${newAccessToken}`
       flushQueue(newAccessToken)
 
@@ -71,7 +63,6 @@ client.interceptors.response.use(
     } catch (refreshError) {
       rejectQueue(refreshError)
       localStorage.removeItem('admin_token')
-      localStorage.removeItem('admin_refresh_token')
       window.location.href = import.meta.env.BASE_URL + 'login'
       return Promise.reject(refreshError)
     } finally {

--- a/admin/src/components/layout/Header.tsx
+++ b/admin/src/components/layout/Header.tsx
@@ -2,6 +2,7 @@ import { useEffect, useState } from 'react'
 import { useNavigate } from 'react-router-dom'
 import { useAuthStore } from '../../store/authStore'
 import SearchModal from '../SearchModal'
+import client from '../../api/client'
 
 const ENV_MAP: Record<string, { label: string; style: string }> = {
   production: { label: 'PROD', style: 'bg-red-500 text-white' },
@@ -18,13 +19,17 @@ function EnvBadge() {
 }
 
 export default function Header() {
-  const logout = useAuthStore((s) => s.logout)
+  const clearToken = useAuthStore((s) => s.clearToken)
   const navigate = useNavigate()
   const [searchOpen, setSearchOpen] = useState(false)
 
-  const handleLogout = () => {
-    logout()
-    navigate('/login')
+  const handleLogout = async () => {
+    try {
+      await client.post('/auth/admin/logout')
+    } finally {
+      clearToken()
+      navigate('/login')
+    }
   }
 
   useEffect(() => {

--- a/admin/src/pages/LoginPage.tsx
+++ b/admin/src/pages/LoginPage.tsx
@@ -7,7 +7,7 @@ export default function LoginPage() {
   const [email, setEmail] = useState('')
   const [password, setPassword] = useState('')
   const [error, setError] = useState('')
-  const setTokens = useAuthStore((s) => s.setTokens)
+  const setToken = useAuthStore((s) => s.setToken)
   const navigate = useNavigate()
 
   const handleSubmit = async (e: React.FormEvent) => {
@@ -15,7 +15,7 @@ export default function LoginPage() {
     setError('')
     try {
       const { data } = await client.post('/auth/admin/login', { email, password })
-      setTokens(data.result.accessToken, data.result.refreshToken)
+      setToken(data.accessToken)
       navigate('/')
     } catch {
       setError('이메일 또는 비밀번호가 올바르지 않습니다.')

--- a/admin/src/store/authStore.ts
+++ b/admin/src/store/authStore.ts
@@ -2,27 +2,18 @@ import { create } from 'zustand'
 
 interface AuthState {
   token: string | null
-  refreshToken: string | null
-  setTokens: (accessToken: string, refreshToken: string) => void
   setToken: (token: string) => void
-  logout: () => void
+  clearToken: () => void
 }
 
 export const useAuthStore = create<AuthState>((set) => ({
   token: localStorage.getItem('admin_token'),
-  refreshToken: localStorage.getItem('admin_refresh_token'),
-  setTokens: (accessToken, refreshToken) => {
-    localStorage.setItem('admin_token', accessToken)
-    localStorage.setItem('admin_refresh_token', refreshToken)
-    set({ token: accessToken, refreshToken })
-  },
   setToken: (token) => {
     localStorage.setItem('admin_token', token)
     set({ token })
   },
-  logout: () => {
+  clearToken: () => {
     localStorage.removeItem('admin_token')
-    localStorage.removeItem('admin_refresh_token')
-    set({ token: null, refreshToken: null })
+    set({ token: null })
   },
 }))

--- a/backend/widyu-api/src/main/java/com/widyu/admin/application/AdminAuthService.java
+++ b/backend/widyu-api/src/main/java/com/widyu/admin/application/AdminAuthService.java
@@ -3,6 +3,7 @@ package com.widyu.admin.application;
 import com.widyu.admin.AdminAction;
 import com.widyu.admin.AdminAuditLog;
 import com.widyu.admin.repository.AdminAuditLogRepository;
+import com.widyu.auth.dto.RefreshTokenDto;
 import com.widyu.auth.dto.response.TokenPairResponse;
 import com.widyu.global.error.BusinessException;
 import com.widyu.global.error.ErrorCode;
@@ -44,5 +45,14 @@ public class AdminAuthService {
                 AdminAuditLog.of(member.getId(), member.getName(), AdminAction.ADMIN_LOGIN, null, null, null)
         );
         return tokens;
+    }
+
+    @Transactional
+    public TokenPairResponse refresh(String refreshToken) {
+        if (refreshToken == null || refreshToken.isBlank()) {
+            throw new BusinessException(ErrorCode.UNAUTHORIZED, "리프레시 토큰이 없습니다.");
+        }
+        RefreshTokenDto refreshTokenDto = jwtTokenProvider.retrieveRefreshToken(refreshToken);
+        return jwtTokenProvider.generateTokenPair(refreshTokenDto.memberId(), MemberRole.ADMIN, "local");
     }
 }

--- a/backend/widyu-api/src/main/java/com/widyu/admin/controller/AdminAuthController.java
+++ b/backend/widyu-api/src/main/java/com/widyu/admin/controller/AdminAuthController.java
@@ -2,12 +2,19 @@ package com.widyu.admin.controller;
 
 import com.widyu.admin.application.AdminAuthService;
 import com.widyu.admin.dto.response.AdminLoginResponse;
+import com.widyu.auth.dto.response.TokenPairResponse;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.ResponseCookie;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import java.util.Arrays;
 import java.util.Map;
 
 @RestController
@@ -15,12 +22,62 @@ import java.util.Map;
 @RequestMapping("/api/v1/auth/admin")
 public class AdminAuthController {
 
+    private static final String ADMIN_REFRESH_COOKIE = "admin_refresh_token";
+    private static final int COOKIE_MAX_AGE = 7 * 24 * 60 * 60; // 7일
+
     private final AdminAuthService adminAuthService;
 
     @PostMapping("/login")
-    public AdminLoginResponse login(@RequestBody Map<String, String> request) {
-        return AdminLoginResponse.of(
-                adminAuthService.login(request.get("email"), request.get("password"))
-        );
+    public AdminLoginResponse login(@RequestBody Map<String, String> request,
+                                    HttpServletResponse response) {
+        TokenPairResponse tokens = adminAuthService.login(request.get("email"), request.get("password"));
+        setRefreshTokenCookie(response, tokens.refreshToken());
+        return AdminLoginResponse.of(tokens.memberId(), tokens.accessToken());
+    }
+
+    @PostMapping("/refresh")
+    public AdminLoginResponse refresh(HttpServletRequest request, HttpServletResponse response) {
+        String refreshToken = extractRefreshTokenCookie(request);
+        TokenPairResponse tokens = adminAuthService.refresh(refreshToken);
+        setRefreshTokenCookie(response, tokens.refreshToken());
+        return AdminLoginResponse.of(tokens.memberId(), tokens.accessToken());
+    }
+
+    @PostMapping("/logout")
+    public void logout(HttpServletResponse response) {
+        clearRefreshTokenCookie(response);
+    }
+
+    private void setRefreshTokenCookie(HttpServletResponse response, String refreshToken) {
+        ResponseCookie cookie = ResponseCookie.from(ADMIN_REFRESH_COOKIE, refreshToken)
+                .httpOnly(true)
+                .secure(true)
+                .path("/api/v1/auth/admin/refresh")
+                .maxAge(COOKIE_MAX_AGE)
+                .sameSite("Strict")
+                .build();
+        response.addHeader(HttpHeaders.SET_COOKIE, cookie.toString());
+    }
+
+    private void clearRefreshTokenCookie(HttpServletResponse response) {
+        ResponseCookie cookie = ResponseCookie.from(ADMIN_REFRESH_COOKIE, "")
+                .httpOnly(true)
+                .secure(true)
+                .path("/api/v1/auth/admin/refresh")
+                .maxAge(0)
+                .sameSite("Strict")
+                .build();
+        response.addHeader(HttpHeaders.SET_COOKIE, cookie.toString());
+    }
+
+    private String extractRefreshTokenCookie(HttpServletRequest request) {
+        if (request.getCookies() == null) {
+            return null;
+        }
+        return Arrays.stream(request.getCookies())
+                .filter(c -> ADMIN_REFRESH_COOKIE.equals(c.getName()))
+                .map(Cookie::getValue)
+                .findFirst()
+                .orElse(null);
     }
 }

--- a/backend/widyu-api/src/main/java/com/widyu/admin/dto/response/AdminLoginResponse.java
+++ b/backend/widyu-api/src/main/java/com/widyu/admin/dto/response/AdminLoginResponse.java
@@ -1,10 +1,10 @@
 package com.widyu.admin.dto.response;
 
-import com.widyu.auth.dto.response.TokenPairResponse;
-
-public record AdminLoginResponse(TokenPairResponse result) {
-
-    public static AdminLoginResponse of(TokenPairResponse tokenPair) {
-        return new AdminLoginResponse(tokenPair);
+public record AdminLoginResponse(
+        Long memberId,
+        String accessToken
+) {
+    public static AdminLoginResponse of(Long memberId, String accessToken) {
+        return new AdminLoginResponse(memberId, accessToken);
     }
 }


### PR DESCRIPTION
## #️⃣연관된 이슈

- close: #286

## 🪄작업 내용

- `AdminAuthController` — refresh token을 `HttpOnly; Secure; SameSite=Strict` cookie로 Set-Cookie 응답
- `AdminAuthService` — 쿠키 기반 refresh token 처리 로직 추가
- `AdminLoginResponse` — 응답 DTO에서 refresh token 필드 제거 (쿠키로 이동)
- `authStore.ts` — localStorage에서 refresh token 제거, access token만 메모리 관리
- `client.ts` — refresh 요청 시 쿠키 자동 전송(`withCredentials: true`)으로 변경
- `LoginPage.tsx` · `Header.tsx` — 로그인/로그아웃 흐름 수정

## 💖리뷰 요청사항

- refresh token이 cookie로 이동하면서 CORS 설정에서 `allowCredentials(true)`와 명시적 origin 지정이 필요합니다. SecurityConfig CORS 설정과 함께 확인 부탁드립니다.