### PR TITLE
fix: 초대코드 수정 시 영문 허용으로 인한 시니어 로그인 불가 버그

### DIFF
--- a/backend/widyu-api/src/main/java/com/widyu/mypage/dto/request/UpdateInviteCodeRequest.java
+++ b/backend/widyu-api/src/main/java/com/widyu/mypage/dto/request/UpdateInviteCodeRequest.java
@@ -7,6 +7,6 @@ import jakarta.validation.constraints.Size;
 public record UpdateInviteCodeRequest(
         @NotBlank(message = "초대코드는 필수입니다.")
         @Size(min = 7, max = 7, message = "초대코드는 7자리여야 합니다.")
-        @Pattern(regexp = "^[A-Za-z0-9]{7}$", message = "초대코드는 영문자와 숫자로만 구성되어야 합니다.")
+        @Pattern(regexp = "^\\d{7}$", message = "초대코드는 숫자만 7자리로 입력해주세요.")
         String inviteCode
 ) {}


### PR DESCRIPTION
## #️⃣연관된 이슈

- close: #294

## 🪄작업 내용

- `UpdateInviteCodeRequest`의 `@Pattern`을 `^[A-Za-z0-9]{7}$`에서 `^\d{7}$`로 수정

`SeniorSignInRequest`, `SeniorSignUpRequest`는 초대코드를 숫자 7자리만 허용하는데, `UpdateInviteCodeRequest`만 영문+숫자를 허용하고 있었습니다. 보호자가 영문 포함 초대코드로 변경하면 시니어가 해당 코드로 로그인할 수 없게 되는 버그를 수정했습니다.

## 💖리뷰 요청사항

- 초대코드 관련 세 DTO(`SeniorSignInRequest`, `SeniorSignUpRequest`, `UpdateInviteCodeRequest`) 패턴이 모두 `^\d{7}$`로 통일된 것 확인 부탁드립니다.