### PR TITLE
feature: 보호자 본인 전화번호 SMS 인증 변경 기능 구현

### DIFF
--- a/backend/widyu-api/src/main/java/com/widyu/mypage/application/GuardianMyPageService.java
+++ b/backend/widyu-api/src/main/java/com/widyu/mypage/application/GuardianMyPageService.java
@@ -1,5 +1,8 @@
 package com.widyu.mypage.application;
 
+import com.widyu.auth.application.SmsService;
+import com.widyu.auth.dto.request.SmsCodeRequest;
+import com.widyu.auth.repository.VerificationCodeRepository;
 import com.widyu.global.error.BusinessException;
 import com.widyu.global.error.ErrorCode;
 import com.widyu.global.infrastructure.s3.S3Service;
@@ -15,8 +18,8 @@ import com.widyu.member.repository.PointHistoryRepository;
 import com.widyu.member.repository.SeniorProfileRepository;
 import com.widyu.mypage.dto.request.UpdateInviteCodeRequest;
 import com.widyu.mypage.dto.request.UpdateNameRequest;
-import com.widyu.mypage.dto.request.UpdateSeniorAddressRequest;
 import com.widyu.mypage.dto.request.UpdatePhoneRequest;
+import com.widyu.mypage.dto.request.UpdateSeniorAddressRequest;
 import com.widyu.mypage.dto.response.ConnectedSeniorResponse;
 import com.widyu.mypage.dto.response.FamilyCodeResponse;
 import com.widyu.mypage.dto.response.FamilyMemberListResponse;
@@ -38,6 +41,8 @@ public class GuardianMyPageService {
 
     private final MemberUtil memberUtil;
     private final S3Service s3Service;
+    private final SmsService smsService;
+    private final VerificationCodeRepository verificationCodeRepository;
     private final FamilyMembershipRepository familyMembershipRepository;
     private final SeniorProfileRepository seniorProfileRepository;
     private final MemberRepository memberRepository;
@@ -61,6 +66,37 @@ public class GuardianMyPageService {
     @Transactional
     public void updateProfileImage(MultipartFile image) {
         MyPageProfileService.updateCurrentMemberProfileImage(memberUtil, s3Service, image);
+    }
+
+    @Transactional
+    public void sendPhoneChangeSms(UpdatePhoneRequest request) {
+        Member currentMember = MyPageProfileService.getCurrentMember(memberUtil);
+        String newPhone = request.phoneNumber();
+
+        memberRepository.findByPhoneNumber(newPhone).ifPresent(existing -> {
+            if (!existing.getId().equals(currentMember.getId())) {
+                throw new BusinessException(ErrorCode.BAD_REQUEST, "이미 사용 중인 전화번호입니다.");
+            }
+        });
+
+        smsService.sendVerificationSms(newPhone, currentMember.getName());
+    }
+
+    @Transactional
+    public void verifyAndUpdatePhone(SmsCodeRequest request) {
+        String newPhone = request.phoneNumber();
+
+        boolean codeMatches = verificationCodeRepository.findById(newPhone)
+                .map(v -> v.getCode().equals(request.code()))
+                .orElseThrow(() -> new BusinessException(ErrorCode.SMS_VERIFICATION_CODE_NOT_FOUND));
+
+        if (!codeMatches) {
+            throw new BusinessException(ErrorCode.SMS_VERIFICATION_CODE_MISMATCH);
+        }
+
+        Member currentMember = MyPageProfileService.getCurrentMember(memberUtil);
+        currentMember.updatePhoneNumber(newPhone);
+        verificationCodeRepository.deleteById(newPhone);
     }
 
     public ConnectedSeniorResponse getConnectedSeniors() {

--- a/backend/widyu-api/src/main/java/com/widyu/mypage/controller/GuardianMyPageController.java
+++ b/backend/widyu-api/src/main/java/com/widyu/mypage/controller/GuardianMyPageController.java
@@ -4,6 +4,7 @@ import com.widyu.global.response.ApiResponseTemplate;
 import com.widyu.mypage.application.GuardianMyPageService;
 import com.widyu.mypage.controller.docs.GuardianMyPageDocs;
 import com.widyu.mypage.dto.request.ProfileImageUploadRequest;
+import com.widyu.auth.dto.request.SmsCodeRequest;
 import com.widyu.mypage.dto.request.UpdateInviteCodeRequest;
 import com.widyu.mypage.dto.request.UpdateNameRequest;
 import com.widyu.mypage.dto.request.UpdatePhoneRequest;
@@ -23,6 +24,7 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -70,6 +72,26 @@ public class GuardianMyPageController implements GuardianMyPageDocs {
         return ApiResponseTemplate.ok()
                 .code("MYPAGE_2013")
                 .message("프로필 이미지 수정 성공")
+                .build();
+    }
+
+    @Override
+    @PostMapping("/phone/sms/send")
+    public ApiResponseTemplate<Void> sendPhoneChangeSms(@RequestBody @Valid UpdatePhoneRequest request) {
+        guardianMyPageService.sendPhoneChangeSms(request);
+        return ApiResponseTemplate.ok()
+                .code("MYPAGE_2025")
+                .message("전화번호 변경 인증 문자가 전송되었습니다.")
+                .build();
+    }
+
+    @Override
+    @PatchMapping("/phone")
+    public ApiResponseTemplate<Void> verifyAndUpdatePhone(@RequestBody @Valid SmsCodeRequest request) {
+        guardianMyPageService.verifyAndUpdatePhone(request);
+        return ApiResponseTemplate.ok()
+                .code("MYPAGE_2026")
+                .message("전화번호 변경이 완료되었습니다.")
                 .build();
     }
 

--- a/backend/widyu-api/src/main/java/com/widyu/mypage/controller/docs/GuardianMyPageDocs.java
+++ b/backend/widyu-api/src/main/java/com/widyu/mypage/controller/docs/GuardianMyPageDocs.java
@@ -1,5 +1,6 @@
 package com.widyu.mypage.controller.docs;
 
+import com.widyu.auth.dto.request.SmsCodeRequest;
 import com.widyu.global.response.ApiResponseTemplate;
 import com.widyu.mypage.dto.request.ProfileImageUploadRequest;
 import com.widyu.mypage.dto.request.UpdateInviteCodeRequest;
@@ -32,6 +33,34 @@ public interface GuardianMyPageDocs {
     @Operation(summary = "보호자 이름 수정")
     @ApiResponses({@ApiResponse(responseCode = "200", description = "수정 성공")})
     ApiResponseTemplate<Void> updateName(UpdateNameRequest request);
+
+    @Operation(
+            summary = "보호자 전화번호 변경 - SMS 인증 발송",
+            description = """
+                    새 전화번호로 SMS 인증코드를 발송합니다.
+
+                    **검증:**
+                    - 이미 다른 회원이 사용 중인 전화번호이면 400 오류
+                    """
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "SMS 발송 성공"),
+            @ApiResponse(responseCode = "400", description = "이미 사용 중인 전화번호 또는 잘못된 형식")
+    })
+    ApiResponseTemplate<Void> sendPhoneChangeSms(UpdatePhoneRequest request);
+
+    @Operation(
+            summary = "보호자 전화번호 변경 - 인증코드 검증 및 변경",
+            description = """
+                    SMS 인증코드를 검증하고 전화번호를 변경합니다.
+                    인증 성공 시 즉시 전화번호가 업데이트되며 인증코드는 삭제됩니다.
+                    """
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "전화번호 변경 성공"),
+            @ApiResponse(responseCode = "400", description = "인증코드 불일치 또는 만료")
+    })
+    ApiResponseTemplate<Void> verifyAndUpdatePhone(SmsCodeRequest request);
 
     @Operation(summary = "보호자 프로필 이미지 수정")
     @ApiResponses({@ApiResponse(responseCode = "200", description = "수정 성공")})


### PR DESCRIPTION
## #️⃣연관된 이슈
- close: #296

## 🪄작업 내용
보호자가 마이페이지에서 본인의 전화번호를 SMS 인증을 통해 변경하는 2단계 플로우를 구현했습니다.

- `POST /api/v1/mypage/guardian/phone/sms/send` — 새 전화번호로 SMS 인증코드 발송
  - 이미 다른 회원이 사용 중인 번호이면 400 오류
  - 현재 로그인한 보호자의 이름으로 SMS 발송 (별도 이름 입력 불필요)
- `PATCH /api/v1/mypage/guardian/phone` — 인증코드 검증 후 전화번호 업데이트
  - 인증 성공 시 즉시 전화번호 변경, 인증코드는 Redis에서 즉시 삭제 (재사용 방지)
- `GuardianMyPageDocs` — 두 엔드포인트 Swagger 문서 추가

기존 `SmsService` / `VerificationCodeRepository`를 재사용해 인증 로직 중복 없이 구현.
TemporaryToken 발급 없이 현재 JWT 인증 상태에서 바로 전화번호를 업데이트합니다.

## 💖리뷰 요청사항
- `verifyAndUpdatePhone`에서 인증코드 불일치/만료 케이스 분기 처리 방식이 괜찮은지 확인 부탁드립니다.