### PR TITLE
fix(#298): 시니어 일괄 등록 시 초대코드 중복 검사 추가

### DIFF
--- a/backend/widyu-api/src/main/java/com/widyu/auth/application/senior/SeniorAuthService.java
+++ b/backend/widyu-api/src/main/java/com/widyu/auth/application/senior/SeniorAuthService.java
@@ -18,7 +18,9 @@ import com.widyu.member.repository.MemberRepository;
 import com.widyu.member.repository.SeniorProfileRepository;
 import java.security.SecureRandom;
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -51,6 +53,8 @@ public class SeniorAuthService {
             throw new BusinessException(ErrorCode.ALREADY_CONNECTED_TO_FAMILY, "이미 가족에 소속되어 있습니다.");
         }
 
+        validateInviteCodesUnique(requests);
+
         Family family = createAndSaveFamily();
 
         List<Member> members = buildMembersFromRequests(requests);
@@ -73,6 +77,19 @@ public class SeniorAuthService {
         if (requests == null || requests.isEmpty()) {
             throw new BusinessException(ErrorCode.SENIOR_SIGNUP_REQUEST_EMPTY);
         }
+    }
+
+    private void validateInviteCodesUnique(List<SeniorSignUpRequest> requests) {
+        List<String> codes = requests.stream().map(SeniorSignUpRequest::inviteCode).toList();
+        Set<String> uniqueCodes = new HashSet<>(codes);
+        if (uniqueCodes.size() != codes.size()) {
+            throw new BusinessException(ErrorCode.BAD_REQUEST, "배치 내에 중복된 초대코드가 있습니다.");
+        }
+        codes.forEach(code -> {
+            if (seniorProfileRepository.existsByInviteCode(code)) {
+                throw new BusinessException(ErrorCode.BAD_REQUEST, "이미 사용 중인 초대코드입니다: " + code);
+            }
+        });
     }
 
     private Family createAndSaveFamily() {


### PR DESCRIPTION
## #️⃣연관된 이슈

- close: #298

## 🪄작업 내용

- `SeniorAuthService.validateInviteCodesUnique()` 추가
- `saveAll` 호출 전 배치 내 코드 중복 여부 (Set 비교) 검사
- DB 기존 초대코드 존재 여부 (`existsByInviteCode`) 검사
- `DataIntegrityViolationException(500)` 대신 `BusinessException(400)` 으로 응답

## 💖리뷰 요청사항

- DB 중복 검사를 코드별로 개별 쿼리(`existsByInviteCode`)로 처리하고 있습니다. 배치 크기가 크다면 `IN` 쿼리로 한 번에 조회하는 방식으로 최적화할 수 있습니다.