### PR TITLE
fix(#299): 초대코드 변경 시 본인 코드 중복 판단 버그 수정

### DIFF
--- a/backend/widyu-api/src/main/java/com/widyu/member/repository/SeniorProfileRepository.java
+++ b/backend/widyu-api/src/main/java/com/widyu/member/repository/SeniorProfileRepository.java
@@ -17,6 +17,8 @@ public interface SeniorProfileRepository extends JpaRepository<SeniorProfile, Lo
 
     boolean existsByInviteCode(String inviteCode);
 
+    boolean existsByInviteCodeAndIdNot(String inviteCode, Long id);
+
     @Query("SELECT sp FROM SeniorProfile sp WHERE sp.inviteCode = :inviteCode AND sp.member.phoneNumber = :phoneNumber")
     Optional<SeniorProfile> findByInviteCodeAndMemberPhoneNumber(@Param("inviteCode") String inviteCode,
                                                                    @Param("phoneNumber") String phoneNumber);

--- a/backend/widyu-api/src/main/java/com/widyu/mypage/application/GuardianMyPageService.java
+++ b/backend/widyu-api/src/main/java/com/widyu/mypage/application/GuardianMyPageService.java
@@ -155,7 +155,7 @@ public class GuardianMyPageService {
         Member guardian = MyPageProfileService.getCurrentMember(memberUtil);
         SeniorProfile seniorProfile = getSeniorProfileWithAccessCheck(memberId, guardian.getId());
         assertIsLeader(seniorProfile, guardian.getId());
-        if (seniorProfileRepository.existsByInviteCode(request.inviteCode())) {
+        if (seniorProfileRepository.existsByInviteCodeAndIdNot(request.inviteCode(), seniorProfile.getId())) {
             throw new BusinessException(ErrorCode.BAD_REQUEST, "이미 사용 중인 초대코드입니다.");
         }
         seniorProfile.updateInviteCode(request.inviteCode());


### PR DESCRIPTION
## #️⃣연관된 이슈

- close: #299

## 🪄작업 내용

- `SeniorProfileRepository`에 `existsByInviteCodeAndIdNot(String inviteCode, Long id)` 추가
- `updateSeniorInviteCode()`에서 `existsByInviteCode` → `existsByInviteCodeAndIdNot`으로 교체
- 본인의 현재 초대코드를 동일하게 입력해도 정상 처리됨

## 💖리뷰 요청사항

- 변경 자체는 단순하지만, 동일 코드 재입력을 허용하는 것이 의도된 동작인지 확인 부탁드립니다.