### PR TITLE
feat: 마이페이지에서 부모님(시니어) 추가 기능 구현

### DIFF
--- a/backend/widyu-api/src/main/java/com/widyu/mypage/application/GuardianMyPageService.java
+++ b/backend/widyu-api/src/main/java/com/widyu/mypage/application/GuardianMyPageService.java
@@ -163,7 +163,7 @@ public class GuardianMyPageService {
         Member guardian = MyPageProfileService.getCurrentMember(memberUtil);
         SeniorProfile seniorProfile = getSeniorProfileWithAccessCheck(memberId, guardian.getId());
         assertIsLeader(seniorProfile, guardian.getId());
-        if (seniorProfileRepository.existsByInviteCode(request.inviteCode())) {
+        if (seniorProfileRepository.existsByInviteCodeAndIdNot(request.inviteCode(), seniorProfile.getId())) {
             throw new BusinessException(ErrorCode.BAD_REQUEST, "이미 사용 중인 초대코드입니다.");
         }
         seniorProfile.updateInviteCode(request.inviteCode());

--- a/backend/widyu-api/src/test/java/com/widyu/mypage/application/GuardianMyPageServiceTest.java
+++ b/backend/widyu-api/src/test/java/com/widyu/mypage/application/GuardianMyPageServiceTest.java
@@ -744,7 +744,7 @@ class GuardianMyPageServiceTest {
         given(seniorProfile.getId()).willReturn(100L);
         given(familyMembershipRepository.existsByGuardianIdAndSeniorProfileId(1L, 100L)).willReturn(true);
         given(familyMembershipRepository.existsByGuardianIdAndSeniorProfileIdAndIsLeaderTrue(1L, 100L)).willReturn(true);
-        given(seniorProfileRepository.existsByInviteCode("ABC1234")).willReturn(false);
+        given(seniorProfileRepository.existsByInviteCodeAndIdNot("ABC1234", 100L)).willReturn(false);
 
         // when
         guardianMyPageService.updateSeniorInviteCode(10L, new UpdateInviteCodeRequest("ABC1234"));
@@ -785,7 +785,7 @@ class GuardianMyPageServiceTest {
         given(seniorProfile.getId()).willReturn(100L);
         given(familyMembershipRepository.existsByGuardianIdAndSeniorProfileId(1L, 100L)).willReturn(true);
         given(familyMembershipRepository.existsByGuardianIdAndSeniorProfileIdAndIsLeaderTrue(1L, 100L)).willReturn(true);
-        given(seniorProfileRepository.existsByInviteCode("ABC1234")).willReturn(true);
+        given(seniorProfileRepository.existsByInviteCodeAndIdNot("ABC1234", 100L)).willReturn(true);
 
         // when & then
         assertThatThrownBy(() -> guardianMyPageService.updateSeniorInviteCode(10L, new UpdateInviteCodeRequest("ABC1234")))


### PR DESCRIPTION
## #️⃣연관된 이슈

- close: #302

## 🪄작업 내용

- `POST /api/v1/mypage/guardian/seniors` 엔드포인트 추가 (`MYPAGE_2027`)
- `GuardianMyPageService.addSenior()` 구현
- `GuardianMyPageDocs` 인터페이스 메서드 추가

**기존 플로우와의 차이:**
기존 `POST /api/v1/auth/seniors/sign-up`은 가족이 없는 보호자가 처음 가족을 생성하며 시니어를 일괄 등록하는 플로우입니다. 이미 가족이 있는 보호자가 추가로 시니어를 등록하는 경로가 없어서 마이페이지 화면의 '가족 추가하기' 흐름을 구현했습니다.

**검증 로직:**
- 이미 다른 회원이 사용 중인 전화번호 → 400
- 이미 사용 중인 초대코드 → 400 (`INVITE_CODE_DUPLICATED`)
- 가족에 소속되지 않은 보호자 → 404

## 💖리뷰 요청사항

- `addSenior`는 방장 여부와 무관하게 가족에 속한 모든 보호자가 호출 가능합니다. 방장만 시니어를 추가할 수 있도록 제한이 필요한지 확인 부탁드립니다.