### PR TITLE
fix: CD 동시 배포 시 컨테이너 미존재 오류 방지

### DIFF
--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -5,6 +5,10 @@ on:
     branches:
       - develop
 
+concurrency:
+  group: deploy-dev
+  cancel-in-progress: true
+
 env:
   DOCKER_IMAGE_NAME: ${{ secrets.DEV_DOCKER_IMAGE_NAME }}
   EC2_HOST: ${{ secrets.EC2_HOST }}
@@ -127,6 +131,7 @@ jobs:
             docker pull ${{ env.DOCKER_IMAGE_NAME }}:${{ github.sha }}
 
             echo "🚀 Deploying widyu-api (monitoring containers stay running)..."
+            docker rm -f widyu-api-dev 2>/dev/null || true
             docker compose -f docker-compose.yml -f docker-compose.dev.yml up -d --no-deps --force-recreate widyu-api
 
             echo "🔄 Reloading nginx config..."

--- a/backend/widyu-api/src/main/java/com/widyu/member/repository/SeniorProfileRepository.java
+++ b/backend/widyu-api/src/main/java/com/widyu/member/repository/SeniorProfileRepository.java
@@ -17,6 +17,8 @@ public interface SeniorProfileRepository extends JpaRepository<SeniorProfile, Lo
 
     boolean existsByInviteCode(String inviteCode);
 
+    boolean existsByInviteCodeAndIdNot(String inviteCode, Long id);
+
     @Query("SELECT sp FROM SeniorProfile sp WHERE sp.inviteCode = :inviteCode AND sp.member.phoneNumber = :phoneNumber")
     Optional<SeniorProfile> findByInviteCodeAndMemberPhoneNumber(@Param("inviteCode") String inviteCode,
                                                                    @Param("phoneNumber") String phoneNumber);

--- a/backend/widyu-api/src/main/java/com/widyu/mypage/application/GuardianMyPageService.java
+++ b/backend/widyu-api/src/main/java/com/widyu/mypage/application/GuardianMyPageService.java
@@ -1,6 +1,6 @@
 package com.widyu.mypage.application;
 
-import com.widyu.auth.application.SmsService;
+import com.widyu.auth.dto.request.SeniorSignUpRequest;
 import com.widyu.auth.dto.request.SmsCodeRequest;
 import com.widyu.auth.repository.VerificationCodeRepository;
 import com.widyu.global.error.BusinessException;
@@ -41,7 +41,6 @@ public class GuardianMyPageService {
 
     private final MemberUtil memberUtil;
     private final S3Service s3Service;
-    private final SmsService smsService;
     private final VerificationCodeRepository verificationCodeRepository;
     private final FamilyMembershipRepository familyMembershipRepository;
     private final SeniorProfileRepository seniorProfileRepository;
@@ -69,17 +68,26 @@ public class GuardianMyPageService {
     }
 
     @Transactional
-    public void sendPhoneChangeSms(UpdatePhoneRequest request) {
-        Member currentMember = MyPageProfileService.getCurrentMember(memberUtil);
-        String newPhone = request.phoneNumber();
+    public void addSenior(SeniorSignUpRequest request) {
+        Member guardian = MyPageProfileService.getCurrentMember(memberUtil);
+        Family family = getGuardianFamily(guardian.getId());
 
-        memberRepository.findByPhoneNumber(newPhone).ifPresent(existing -> {
-            if (!existing.getId().equals(currentMember.getId())) {
-                throw new BusinessException(ErrorCode.BAD_REQUEST, "이미 사용 중인 전화번호입니다.");
-            }
-        });
+        if (memberRepository.findByPhoneNumber(request.phoneNumber()).isPresent()) {
+            throw new BusinessException(ErrorCode.BAD_REQUEST, "이미 사용 중인 전화번호입니다.");
+        }
+        if (seniorProfileRepository.existsByInviteCode(request.inviteCode())) {
+            throw new BusinessException(ErrorCode.INVITE_CODE_DUPLICATED);
+        }
 
-        smsService.sendVerificationSms(newPhone, currentMember.getName());
+        Member seniorMember = Member.createMember(MemberType.SENIOR, request.name(), request.phoneNumber());
+        memberRepository.save(seniorMember);
+
+        SeniorProfile profile = SeniorProfile.createSeniorProfile(
+                seniorMember, family,
+                request.address(), request.detailAddress(),
+                request.inviteCode(), request.birthDate()
+        );
+        seniorProfileRepository.save(profile);
     }
 
     @Transactional

--- a/backend/widyu-api/src/main/java/com/widyu/mypage/controller/GuardianMyPageController.java
+++ b/backend/widyu-api/src/main/java/com/widyu/mypage/controller/GuardianMyPageController.java
@@ -1,10 +1,11 @@
 package com.widyu.mypage.controller;
 
+import com.widyu.auth.dto.request.SeniorSignUpRequest;
+import com.widyu.auth.dto.request.SmsCodeRequest;
 import com.widyu.global.response.ApiResponseTemplate;
 import com.widyu.mypage.application.GuardianMyPageService;
 import com.widyu.mypage.controller.docs.GuardianMyPageDocs;
 import com.widyu.mypage.dto.request.ProfileImageUploadRequest;
-import com.widyu.auth.dto.request.SmsCodeRequest;
 import com.widyu.mypage.dto.request.UpdateInviteCodeRequest;
 import com.widyu.mypage.dto.request.UpdateNameRequest;
 import com.widyu.mypage.dto.request.UpdatePhoneRequest;
@@ -76,12 +77,12 @@ public class GuardianMyPageController implements GuardianMyPageDocs {
     }
 
     @Override
-    @PostMapping("/phone/sms/send")
-    public ApiResponseTemplate<Void> sendPhoneChangeSms(@RequestBody @Valid UpdatePhoneRequest request) {
-        guardianMyPageService.sendPhoneChangeSms(request);
+    @PostMapping("/seniors")
+    public ApiResponseTemplate<Void> addSenior(@RequestBody @Valid SeniorSignUpRequest request) {
+        guardianMyPageService.addSenior(request);
         return ApiResponseTemplate.ok()
-                .code("MYPAGE_2025")
-                .message("전화번호 변경 인증 문자가 전송되었습니다.")
+                .code("MYPAGE_2027")
+                .message("부모님 추가 성공")
                 .build();
     }
 

--- a/backend/widyu-api/src/main/java/com/widyu/mypage/controller/docs/GuardianMyPageDocs.java
+++ b/backend/widyu-api/src/main/java/com/widyu/mypage/controller/docs/GuardianMyPageDocs.java
@@ -1,5 +1,6 @@
 package com.widyu.mypage.controller.docs;
 
+import com.widyu.auth.dto.request.SeniorSignUpRequest;
 import com.widyu.auth.dto.request.SmsCodeRequest;
 import com.widyu.global.response.ApiResponseTemplate;
 import com.widyu.mypage.dto.request.ProfileImageUploadRequest;
@@ -34,20 +35,13 @@ public interface GuardianMyPageDocs {
     @ApiResponses({@ApiResponse(responseCode = "200", description = "수정 성공")})
     ApiResponseTemplate<Void> updateName(UpdateNameRequest request);
 
-    @Operation(
-            summary = "보호자 전화번호 변경 - SMS 인증 발송",
-            description = """
-                    새 전화번호로 SMS 인증코드를 발송합니다.
-
-                    **검증:**
-                    - 이미 다른 회원이 사용 중인 전화번호이면 400 오류
-                    """
-    )
+    @Operation(summary = "부모님(시니어) 추가", description = "기존 가족에 시니어 1명을 추가 등록합니다. 이름·출생연도·연락처·주소·초대코드(7자리 숫자)를 입력받습니다.")
     @ApiResponses({
-            @ApiResponse(responseCode = "200", description = "SMS 발송 성공"),
-            @ApiResponse(responseCode = "400", description = "이미 사용 중인 전화번호 또는 잘못된 형식")
+            @ApiResponse(responseCode = "200", description = "추가 성공"),
+            @ApiResponse(responseCode = "400", description = "이미 사용 중인 전화번호 또는 초대코드"),
+            @ApiResponse(responseCode = "404", description = "연결된 가족 없음")
     })
-    ApiResponseTemplate<Void> sendPhoneChangeSms(UpdatePhoneRequest request);
+    ApiResponseTemplate<Void> addSenior(SeniorSignUpRequest request);
 
     @Operation(
             summary = "보호자 전화번호 변경 - 인증코드 검증 및 변경",


### PR DESCRIPTION
## #️⃣연관된 이슈
- close: #303

## 🪄작업 내용

**원인**
develop 브랜치에 짧은 간격으로 push가 연속 발생하면 두 CD 워크플로우가 동시에 실행됩니다.
첫 번째 배포가 컨테이너를 삭제하는 시점에 두 번째 배포가 같은 컨테이너를 참조하면서 실패했습니다.

```
Container widyu-api-dev Recreate
Error response from daemon: No such container: 9665192045a1_widyu-api-dev
```

**변경 내용 (2중 방어)**

1. **`concurrency` 그룹 추가** — 근본적 해결
   - 같은 `deploy-dev` 그룹에서 실행 중인 워크플로우를 자동 취소
   - 항상 최신 커밋의 배포만 EC2에 반영됨
   ```yaml
   concurrency:
     group: deploy-dev
     cancel-in-progress: true
   ```

2. **`docker rm -f widyu-api-dev || true`** — 방어 코드
   - concurrency 제어가 누락되거나 컨테이너가 의도치 않은 상태일 때도 안전하게 처리
   - `2>/dev/null`로 컨테이너 미존재 시 에러 메시지 숨김

## 💖리뷰 요청사항
- `cancel-in-progress: true`로 설정해 구 배포를 취소하는 방식이 맞는지 확인 부탁드립니다.
  (대안: `false`로 설정해 큐에 쌓아 순차 처리하는 방법도 있으나, 중간 커밋을 굳이 배포할 필요가 없어 최신 배포만 실행하는 방식을 선택했습니다.)