### PR TITLE
feat(#308): 가족 내 마지막 시니어 삭제 방지

### DIFF
--- a/backend/widyu-api/src/main/java/com/widyu/member/repository/SeniorProfileRepository.java
+++ b/backend/widyu-api/src/main/java/com/widyu/member/repository/SeniorProfileRepository.java
@@ -1,9 +1,11 @@
 package com.widyu.member.repository;
 
 import com.widyu.member.SeniorProfile;
+import jakarta.persistence.LockModeType;
 import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
@@ -27,4 +29,8 @@ public interface SeniorProfileRepository extends JpaRepository<SeniorProfile, Lo
     List<SeniorProfile> findAllByFamilyIdWithMember(@Param("familyId") Long familyId);
 
     List<SeniorProfile> findAllByFamilyId(Long familyId);
+
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("SELECT sp FROM SeniorProfile sp WHERE sp.family.id = :familyId")
+    List<SeniorProfile> findAllByFamilyIdWithLock(@Param("familyId") Long familyId);
 }

--- a/backend/widyu-api/src/main/java/com/widyu/mypage/application/GuardianMyPageService.java
+++ b/backend/widyu-api/src/main/java/com/widyu/mypage/application/GuardianMyPageService.java
@@ -241,6 +241,11 @@ public class GuardianMyPageService {
             throw new BusinessException(ErrorCode.FORBIDDEN, "해당 시니어에 접근 권한이 없습니다.");
         }
 
+        List<SeniorProfile> familySeniors = seniorProfileRepository.findAllByFamilyIdWithLock(familyId);
+        if (familySeniors.size() <= 1) {
+            throw new BusinessException(ErrorCode.BAD_REQUEST, "가족에 시니어가 최소 1명은 있어야 합니다.");
+        }
+
         pointHistoryRepository.deleteBySeniorProfileId(seniorProfile.getId());
         seniorProfileRepository.delete(seniorProfile);
     }

--- a/backend/widyu-api/src/test/java/com/widyu/mypage/application/GuardianMyPageServiceTest.java
+++ b/backend/widyu-api/src/test/java/com/widyu/mypage/application/GuardianMyPageServiceTest.java
@@ -729,6 +729,66 @@ class GuardianMyPageServiceTest {
         verify(familyMembershipRepository).delete(targetMembership);
     }
 
+    @Test
+    @DisplayName("방장이 시니어를 삭제할 때 가족에 시니어가 2명 이상이면 삭제에 성공한다")
+    void 가족_멤버_삭제_시니어_2명_이상() {
+        // given
+        Member guardian = mock(Member.class);
+        FamilyMembership myMembership = mock(FamilyMembership.class);
+        Family family = mock(Family.class);
+        Member targetMember = mock(Member.class);
+        SeniorProfile targetSeniorProfile = mock(SeniorProfile.class);
+        SeniorProfile otherSeniorProfile = mock(SeniorProfile.class);
+
+        given(memberUtil.getCurrentMember()).willReturn(guardian);
+        given(guardian.getId()).willReturn(1L);
+        given(familyMembershipRepository.findByGuardianId(1L)).willReturn(Optional.of(myMembership));
+        given(myMembership.isLeader()).willReturn(true);
+        given(myMembership.getFamily()).willReturn(family);
+        given(family.getId()).willReturn(10L);
+        given(memberRepository.findById(2L)).willReturn(Optional.of(targetMember));
+        given(targetMember.getType()).willReturn(MemberType.SENIOR);
+        given(seniorProfileRepository.findByMemberId(2L)).willReturn(Optional.of(targetSeniorProfile));
+        given(targetSeniorProfile.getFamily()).willReturn(family);
+        given(targetSeniorProfile.getId()).willReturn(200L);
+        given(seniorProfileRepository.findAllByFamilyIdWithLock(10L))
+                .willReturn(List.of(targetSeniorProfile, otherSeniorProfile));
+
+        // when
+        guardianMyPageService.deleteFamilyMember(2L);
+
+        // then
+        verify(seniorProfileRepository).delete(targetSeniorProfile);
+    }
+
+    @Test
+    @DisplayName("방장이 시니어를 삭제할 때 마지막 시니어이면 예외가 발생한다")
+    void 가족_멤버_삭제_마지막_시니어_삭제_불가() {
+        // given
+        Member guardian = mock(Member.class);
+        FamilyMembership myMembership = mock(FamilyMembership.class);
+        Family family = mock(Family.class);
+        Member targetMember = mock(Member.class);
+        SeniorProfile targetSeniorProfile = mock(SeniorProfile.class);
+
+        given(memberUtil.getCurrentMember()).willReturn(guardian);
+        given(guardian.getId()).willReturn(1L);
+        given(familyMembershipRepository.findByGuardianId(1L)).willReturn(Optional.of(myMembership));
+        given(myMembership.isLeader()).willReturn(true);
+        given(myMembership.getFamily()).willReturn(family);
+        given(family.getId()).willReturn(10L);
+        given(memberRepository.findById(2L)).willReturn(Optional.of(targetMember));
+        given(targetMember.getType()).willReturn(MemberType.SENIOR);
+        given(seniorProfileRepository.findByMemberId(2L)).willReturn(Optional.of(targetSeniorProfile));
+        given(targetSeniorProfile.getFamily()).willReturn(family);
+        given(seniorProfileRepository.findAllByFamilyIdWithLock(10L))
+                .willReturn(List.of(targetSeniorProfile));
+
+        // when & then
+        assertThatThrownBy(() -> guardianMyPageService.deleteFamilyMember(2L))
+                .isInstanceOf(BusinessException.class);
+    }
+
     // ======================== 시니어 초대코드 수정 ========================
 
     @Test


### PR DESCRIPTION
## 왜 바꾸는지

`hasParent` 여부로 보호자 회원가입 단계를 분기하고 있어, 가족 내 시니어가 0명이 되면 신규 보호자 가입 플로우가 깨집니다.
프론트에서도 처리 예정이지만, 여러 보호자가 동시에 마지막 시니어들을 삭제하는 경쟁 조건은 서버에서 막아야 합니다.

## 무엇만 바꿨는지

- `SeniorProfileRepository`: `findAllByFamilyIdWithLock` 추가 (`PESSIMISTIC_WRITE` 락)
- `GuardianMyPageService.deleteSeniorFromFamily()`: 삭제 전 가족 내 시니어 수 검증 — 1명 이하이면 `400 Bad Request`
- `GuardianMyPageServiceTest`: 정상 삭제 / 마지막 시니어 삭제 시 예외 테스트 추가

## 의도적으로 안 한 것

- 프론트 사이드 처리 (별도 진행)
- 시니어 삭제 외 다른 삭제 기능 변경 없음

## 리뷰어가 집중할 포인트

`PESSIMISTIC_WRITE` 락 범위가 적절한지 — 패밀리 단위 시니어 전체를 잠금으로써 동시 삭제를 막는 전략이 맞는지 확인 부탁드립니다.

Closes #308