### PR TITLE
feat: 보호자 전화번호 변경 API 3단계로 분리

### DIFF
--- a/backend/widyu-api/src/main/java/com/widyu/auth/repository/PhoneChangeVerifiedRepository.java
+++ b/backend/widyu-api/src/main/java/com/widyu/auth/repository/PhoneChangeVerifiedRepository.java
@@ -1,0 +1,7 @@
+package com.widyu.auth.repository;
+
+import com.widyu.auth.PhoneChangeVerified;
+import org.springframework.data.repository.CrudRepository;
+
+public interface PhoneChangeVerifiedRepository extends CrudRepository<PhoneChangeVerified, String> {
+}

--- a/backend/widyu-api/src/main/java/com/widyu/mypage/application/GuardianMyPageService.java
+++ b/backend/widyu-api/src/main/java/com/widyu/mypage/application/GuardianMyPageService.java
@@ -1,8 +1,10 @@
 package com.widyu.mypage.application;
 
+import com.widyu.auth.PhoneChangeVerified;
 import com.widyu.auth.application.SmsService;
 import com.widyu.auth.dto.request.SeniorSignUpRequest;
 import com.widyu.auth.dto.request.SmsCodeRequest;
+import com.widyu.auth.repository.PhoneChangeVerifiedRepository;
 import com.widyu.auth.repository.VerificationCodeRepository;
 import com.widyu.global.error.BusinessException;
 import com.widyu.global.error.ErrorCode;
@@ -40,10 +42,13 @@ import org.springframework.web.multipart.MultipartFile;
 @Transactional(readOnly = true)
 public class GuardianMyPageService {
 
+    private static final long PHONE_CHANGE_VERIFIED_TTL_SECONDS = 300;
+
     private final MemberUtil memberUtil;
     private final S3Service s3Service;
     private final SmsService smsService;
     private final VerificationCodeRepository verificationCodeRepository;
+    private final PhoneChangeVerifiedRepository phoneChangeVerifiedRepository;
     private final FamilyMembershipRepository familyMembershipRepository;
     private final SeniorProfileRepository seniorProfileRepository;
     private final MemberRepository memberRepository;
@@ -102,7 +107,7 @@ public class GuardianMyPageService {
     }
 
     @Transactional
-    public void verifyAndUpdatePhone(SmsCodeRequest request) {
+    public void verifyPhoneChangeCode(SmsCodeRequest request) {
         String newPhone = request.phoneNumber();
 
         boolean codeMatches = verificationCodeRepository.findById(newPhone)
@@ -113,9 +118,23 @@ public class GuardianMyPageService {
             throw new BusinessException(ErrorCode.SMS_VERIFICATION_CODE_MISMATCH);
         }
 
+        verificationCodeRepository.deleteById(newPhone);
+        phoneChangeVerifiedRepository.save(PhoneChangeVerified.builder()
+                .phoneNumber(newPhone)
+                .ttl(PHONE_CHANGE_VERIFIED_TTL_SECONDS)
+                .build());
+    }
+
+    @Transactional
+    public void updatePhone(UpdatePhoneRequest request) {
+        String newPhone = request.phoneNumber();
+
+        phoneChangeVerifiedRepository.findById(newPhone)
+                .orElseThrow(() -> new BusinessException(ErrorCode.BAD_REQUEST, "전화번호 인증이 완료되지 않았습니다."));
+
         Member currentMember = MyPageProfileService.getCurrentMember(memberUtil);
         currentMember.updatePhoneNumber(newPhone);
-        verificationCodeRepository.deleteById(newPhone);
+        phoneChangeVerifiedRepository.deleteById(newPhone);
     }
 
     public ConnectedSeniorResponse getConnectedSeniors() {

--- a/backend/widyu-api/src/main/java/com/widyu/mypage/controller/GuardianMyPageController.java
+++ b/backend/widyu-api/src/main/java/com/widyu/mypage/controller/GuardianMyPageController.java
@@ -97,11 +97,21 @@ public class GuardianMyPageController implements GuardianMyPageDocs {
     }
 
     @Override
-    @PatchMapping("/phone")
-    public ApiResponseTemplate<Void> verifyAndUpdatePhone(@RequestBody @Valid SmsCodeRequest request) {
-        guardianMyPageService.verifyAndUpdatePhone(request);
+    @PostMapping("/phone/verify")
+    public ApiResponseTemplate<Void> verifyPhoneChangeCode(@RequestBody @Valid SmsCodeRequest request) {
+        guardianMyPageService.verifyPhoneChangeCode(request);
         return ApiResponseTemplate.ok()
                 .code("MYPAGE_2026")
+                .message("인증이 완료되었습니다.")
+                .build();
+    }
+
+    @Override
+    @PatchMapping("/phone")
+    public ApiResponseTemplate<Void> updatePhone(@RequestBody @Valid UpdatePhoneRequest request) {
+        guardianMyPageService.updatePhone(request);
+        return ApiResponseTemplate.ok()
+                .code("MYPAGE_2028")
                 .message("전화번호 변경이 완료되었습니다.")
                 .build();
     }

--- a/backend/widyu-api/src/main/java/com/widyu/mypage/controller/docs/GuardianMyPageDocs.java
+++ b/backend/widyu-api/src/main/java/com/widyu/mypage/controller/docs/GuardianMyPageDocs.java
@@ -54,17 +54,24 @@ public interface GuardianMyPageDocs {
     ApiResponseTemplate<Void> sendPhoneChangeSms(UpdatePhoneRequest request);
 
     @Operation(
-            summary = "보호자 전화번호 변경 - 인증코드 검증 및 변경",
-            description = """
-                    SMS 인증코드를 검증하고 전화번호를 변경합니다.
-                    인증 성공 시 즉시 전화번호가 업데이트되며 인증코드는 삭제됩니다.
-                    """
+            summary = "보호자 전화번호 변경 - 인증코드 검증",
+            description = "SMS 인증코드를 검증합니다. 성공 시 5분간 유효한 인증 완료 상태가 Redis에 저장됩니다."
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "인증 성공"),
+            @ApiResponse(responseCode = "400", description = "인증코드 불일치 또는 만료")
+    })
+    ApiResponseTemplate<Void> verifyPhoneChangeCode(SmsCodeRequest request);
+
+    @Operation(
+            summary = "보호자 전화번호 변경",
+            description = "인증이 완료된 전화번호로 변경합니다. 인증 완료 후 5분 이내에 호출해야 합니다."
     )
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "전화번호 변경 성공"),
-            @ApiResponse(responseCode = "400", description = "인증코드 불일치 또는 만료")
+            @ApiResponse(responseCode = "400", description = "인증이 완료되지 않은 번호")
     })
-    ApiResponseTemplate<Void> verifyAndUpdatePhone(SmsCodeRequest request);
+    ApiResponseTemplate<Void> updatePhone(UpdatePhoneRequest request);
 
     @Operation(summary = "보호자 프로필 이미지 수정")
     @ApiResponses({@ApiResponse(responseCode = "200", description = "수정 성공")})

--- a/backend/widyu-api/src/test/java/com/widyu/mypage/application/GuardianMyPageServiceTest.java
+++ b/backend/widyu-api/src/test/java/com/widyu/mypage/application/GuardianMyPageServiceTest.java
@@ -9,10 +9,12 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 
+import com.widyu.auth.PhoneChangeVerified;
 import com.widyu.auth.VerificationCode;
 import com.widyu.auth.application.SmsService;
 import com.widyu.auth.dto.request.SeniorSignUpRequest;
 import com.widyu.auth.dto.request.SmsCodeRequest;
+import com.widyu.auth.repository.PhoneChangeVerifiedRepository;
 import com.widyu.auth.repository.VerificationCodeRepository;
 import com.widyu.global.error.BusinessException;
 import com.widyu.global.infrastructure.s3.S3Service;
@@ -56,6 +58,7 @@ class GuardianMyPageServiceTest {
     @Mock private S3Service s3Service;
     @Mock private SmsService smsService;
     @Mock private VerificationCodeRepository verificationCodeRepository;
+    @Mock private PhoneChangeVerifiedRepository phoneChangeVerifiedRepository;
     @Mock private FamilyMembershipRepository familyMembershipRepository;
     @Mock private SeniorProfileRepository seniorProfileRepository;
     @Mock private MemberRepository memberRepository;
@@ -928,10 +931,9 @@ class GuardianMyPageServiceTest {
     // ======================== 보호자 전화번호 변경 - 인증코드 검증 ========================
 
     @Test
-    @DisplayName("올바른 인증코드로 검증하면 전화번호가 변경되고 인증코드가 삭제된다")
+    @DisplayName("올바른 인증코드로 검증하면 인증 완료 상태가 Redis에 저장된다")
     void 전화번호_변경_인증코드_검증_성공() {
         // given
-        Member currentMember = mock(Member.class);
         VerificationCode verificationCode = VerificationCode.builder()
                 .phoneNumber("01099998888")
                 .code("123456")
@@ -940,14 +942,13 @@ class GuardianMyPageServiceTest {
                 .build();
 
         given(verificationCodeRepository.findById("01099998888")).willReturn(Optional.of(verificationCode));
-        given(memberUtil.getCurrentMember()).willReturn(currentMember);
 
         // when
-        guardianMyPageService.verifyAndUpdatePhone(new SmsCodeRequest("01099998888", "123456"));
+        guardianMyPageService.verifyPhoneChangeCode(new SmsCodeRequest("01099998888", "123456"));
 
         // then
-        verify(currentMember).updatePhoneNumber("01099998888");
         verify(verificationCodeRepository).deleteById("01099998888");
+        verify(phoneChangeVerifiedRepository).save(any(PhoneChangeVerified.class));
     }
 
     @Test
@@ -964,7 +965,7 @@ class GuardianMyPageServiceTest {
         given(verificationCodeRepository.findById("01099998888")).willReturn(Optional.of(verificationCode));
 
         // when & then
-        assertThatThrownBy(() -> guardianMyPageService.verifyAndUpdatePhone(new SmsCodeRequest("01099998888", "123456")))
+        assertThatThrownBy(() -> guardianMyPageService.verifyPhoneChangeCode(new SmsCodeRequest("01099998888", "123456")))
                 .isInstanceOf(BusinessException.class);
     }
 
@@ -975,7 +976,41 @@ class GuardianMyPageServiceTest {
         given(verificationCodeRepository.findById("01099998888")).willReturn(Optional.empty());
 
         // when & then
-        assertThatThrownBy(() -> guardianMyPageService.verifyAndUpdatePhone(new SmsCodeRequest("01099998888", "123456")))
+        assertThatThrownBy(() -> guardianMyPageService.verifyPhoneChangeCode(new SmsCodeRequest("01099998888", "123456")))
+                .isInstanceOf(BusinessException.class);
+    }
+
+    // ======================== 보호자 전화번호 변경 ========================
+
+    @Test
+    @DisplayName("인증이 완료된 번호로 변경 요청하면 전화번호가 업데이트된다")
+    void 전화번호_변경() {
+        // given
+        Member currentMember = mock(Member.class);
+        PhoneChangeVerified verified = PhoneChangeVerified.builder()
+                .phoneNumber("01099998888")
+                .ttl(300)
+                .build();
+
+        given(phoneChangeVerifiedRepository.findById("01099998888")).willReturn(Optional.of(verified));
+        given(memberUtil.getCurrentMember()).willReturn(currentMember);
+
+        // when
+        guardianMyPageService.updatePhone(new UpdatePhoneRequest("01099998888"));
+
+        // then
+        verify(currentMember).updatePhoneNumber("01099998888");
+        verify(phoneChangeVerifiedRepository).deleteById("01099998888");
+    }
+
+    @Test
+    @DisplayName("인증이 완료되지 않은 번호로 변경 요청하면 예외가 발생한다")
+    void 전화번호_변경_인증_미완료() {
+        // given
+        given(phoneChangeVerifiedRepository.findById("01099998888")).willReturn(Optional.empty());
+
+        // when & then
+        assertThatThrownBy(() -> guardianMyPageService.updatePhone(new UpdatePhoneRequest("01099998888")))
                 .isInstanceOf(BusinessException.class);
     }
 }

--- a/backend/widyu-domain/src/main/java/com/widyu/auth/PhoneChangeVerified.java
+++ b/backend/widyu-domain/src/main/java/com/widyu/auth/PhoneChangeVerified.java
@@ -1,0 +1,28 @@
+package com.widyu.auth;
+
+import lombok.Builder;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.redis.core.RedisHash;
+import org.springframework.data.redis.core.TimeToLive;
+
+@Getter
+@NoArgsConstructor
+@EqualsAndHashCode(of = "phoneNumber")
+@RedisHash(value = "phoneChangeVerified")
+public class PhoneChangeVerified {
+
+    @Id
+    private String phoneNumber;
+
+    @TimeToLive
+    private long ttl;
+
+    @Builder
+    public PhoneChangeVerified(final String phoneNumber, final long ttl) {
+        this.phoneNumber = phoneNumber;
+        this.ttl = ttl;
+    }
+}


### PR DESCRIPTION
## #️⃣연관된 이슈

- close: #310

## 🪄작업 내용

- `PhoneChangeVerified` Redis 엔티티 추가 (`widyu-domain`, TTL 5분)
- `PhoneChangeVerifiedRepository` 추가
- `verifyAndUpdatePhone` → `verifyPhoneChangeCode` + `updatePhone` 으로 분리
  - `POST /phone/verify`: 인증코드 검증만 수행, 성공 시 Redis에 인증 완료 상태 저장
  - `PATCH /phone`: 인증 완료 여부 확인 후 번호 변경 (기존에는 코드+변경을 한 번에 처리)
- `GuardianMyPageServiceTest`에 `verifyPhoneChangeCode`, `updatePhone` 테스트 추가

**API 흐름**
1. `POST /phone/sms` — SMS 인증코드 발송
2. `POST /phone/verify` — 인증코드 검증, Redis에 5분 TTL로 인증 완료 마킹
3. `PATCH /phone` — 인증 완료 확인 후 전화번호 변경

## 💖리뷰 요청사항

- 인증 완료 상태를 Redis(`PhoneChangeVerified`)에 저장하는 방식이 적절한지 확인 부탁드립니다.