### PR TITLE
fix: 초대코드 중복 허용 (#312)

### DIFF
--- a/backend/widyu-api/src/main/java/com/widyu/auth/application/senior/SeniorAuthService.java
+++ b/backend/widyu-api/src/main/java/com/widyu/auth/application/senior/SeniorAuthService.java
@@ -18,9 +18,7 @@ import com.widyu.member.repository.MemberRepository;
 import com.widyu.member.repository.SeniorProfileRepository;
 import java.security.SecureRandom;
 import java.util.ArrayList;
-import java.util.HashSet;
 import java.util.List;
-import java.util.Set;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -53,8 +51,6 @@ public class SeniorAuthService {
             throw new BusinessException(ErrorCode.ALREADY_CONNECTED_TO_FAMILY, "이미 가족에 소속되어 있습니다.");
         }
 
-        validateInviteCodesUnique(requests);
-
         Family family = createAndSaveFamily();
 
         List<Member> members = buildMembersFromRequests(requests);
@@ -77,19 +73,6 @@ public class SeniorAuthService {
         if (requests == null || requests.isEmpty()) {
             throw new BusinessException(ErrorCode.SENIOR_SIGNUP_REQUEST_EMPTY);
         }
-    }
-
-    private void validateInviteCodesUnique(List<SeniorSignUpRequest> requests) {
-        List<String> codes = requests.stream().map(SeniorSignUpRequest::inviteCode).toList();
-        Set<String> uniqueCodes = new HashSet<>(codes);
-        if (uniqueCodes.size() != codes.size()) {
-            throw new BusinessException(ErrorCode.BAD_REQUEST, "배치 내에 중복된 초대코드가 있습니다.");
-        }
-        codes.forEach(code -> {
-            if (seniorProfileRepository.existsByInviteCode(code)) {
-                throw new BusinessException(ErrorCode.BAD_REQUEST, "이미 사용 중인 초대코드입니다: " + code);
-            }
-        });
     }
 
     private Family createAndSaveFamily() {

--- a/backend/widyu-api/src/main/java/com/widyu/member/repository/SeniorProfileRepository.java
+++ b/backend/widyu-api/src/main/java/com/widyu/member/repository/SeniorProfileRepository.java
@@ -17,10 +17,6 @@ public interface SeniorProfileRepository extends JpaRepository<SeniorProfile, Lo
 
     boolean existsByMemberId(Long memberId);
 
-    boolean existsByInviteCode(String inviteCode);
-
-    boolean existsByInviteCodeAndIdNot(String inviteCode, Long id);
-
     @Query("SELECT sp FROM SeniorProfile sp WHERE sp.inviteCode = :inviteCode AND sp.member.phoneNumber = :phoneNumber")
     Optional<SeniorProfile> findByInviteCodeAndMemberPhoneNumber(@Param("inviteCode") String inviteCode,
                                                                    @Param("phoneNumber") String phoneNumber);

--- a/backend/widyu-api/src/main/java/com/widyu/mypage/application/GuardianMyPageService.java
+++ b/backend/widyu-api/src/main/java/com/widyu/mypage/application/GuardianMyPageService.java
@@ -82,9 +82,6 @@ public class GuardianMyPageService {
         if (memberRepository.findByPhoneNumber(request.phoneNumber()).isPresent()) {
             throw new BusinessException(ErrorCode.BAD_REQUEST, "이미 사용 중인 전화번호입니다.");
         }
-        if (seniorProfileRepository.existsByInviteCode(request.inviteCode())) {
-            throw new BusinessException(ErrorCode.INVITE_CODE_DUPLICATED);
-        }
 
         Member seniorMember = Member.createMember(MemberType.SENIOR, request.name(), request.phoneNumber());
         memberRepository.save(seniorMember);
@@ -193,9 +190,6 @@ public class GuardianMyPageService {
         Member guardian = MyPageProfileService.getCurrentMember(memberUtil);
         SeniorProfile seniorProfile = getSeniorProfileWithAccessCheck(memberId, guardian.getId());
         assertIsLeader(seniorProfile, guardian.getId());
-        if (seniorProfileRepository.existsByInviteCode(request.inviteCode())) {
-            throw new BusinessException(ErrorCode.BAD_REQUEST, "이미 사용 중인 초대코드입니다.");
-        }
         seniorProfile.updateInviteCode(request.inviteCode());
     }
 

--- a/backend/widyu-api/src/main/java/com/widyu/mypage/controller/docs/GuardianMyPageDocs.java
+++ b/backend/widyu-api/src/main/java/com/widyu/mypage/controller/docs/GuardianMyPageDocs.java
@@ -38,7 +38,7 @@ public interface GuardianMyPageDocs {
     @Operation(summary = "부모님(시니어) 추가", description = "기존 가족에 시니어 1명을 추가 등록합니다. 이름·출생연도·연락처·주소·초대코드(7자리 숫자)를 입력받습니다.")
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "추가 성공"),
-            @ApiResponse(responseCode = "400", description = "이미 사용 중인 전화번호 또는 초대코드"),
+            @ApiResponse(responseCode = "400", description = "이미 사용 중인 전화번호"),
             @ApiResponse(responseCode = "404", description = "연결된 가족 없음")
     })
     ApiResponseTemplate<Void> addSenior(SeniorSignUpRequest request);
@@ -135,7 +135,6 @@ public interface GuardianMyPageDocs {
     @Operation(summary = "시니어 초대코드 수정", description = "방장만 호출 가능. 시니어 로그인에 사용되는 7자리 초대코드를 수정합니다.")
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "수정 성공"),
-            @ApiResponse(responseCode = "400", description = "이미 사용 중인 초대코드"),
             @ApiResponse(responseCode = "403", description = "방장만 수정 가능")
     })
     ApiResponseTemplate<Void> updateSeniorInviteCode(

--- a/backend/widyu-api/src/test/java/com/widyu/mypage/application/GuardianMyPageServiceTest.java
+++ b/backend/widyu-api/src/test/java/com/widyu/mypage/application/GuardianMyPageServiceTest.java
@@ -212,7 +212,6 @@ class GuardianMyPageServiceTest {
         given(familyMembershipRepository.findByGuardianId(1L)).willReturn(Optional.of(membership));
         given(membership.getFamily()).willReturn(family);
         given(memberRepository.findByPhoneNumber("01011112222")).willReturn(Optional.empty());
-        given(seniorProfileRepository.existsByInviteCode("1234567")).willReturn(false);
 
         // when
         guardianMyPageService.addSenior(request);
@@ -240,30 +239,6 @@ class GuardianMyPageServiceTest {
         given(familyMembershipRepository.findByGuardianId(1L)).willReturn(Optional.of(membership));
         given(membership.getFamily()).willReturn(family);
         given(memberRepository.findByPhoneNumber("01011112222")).willReturn(Optional.of(existingMember));
-
-        // when & then
-        assertThatThrownBy(() -> guardianMyPageService.addSenior(request))
-                .isInstanceOf(BusinessException.class);
-    }
-
-    @Test
-    @DisplayName("이미 사용 중인 초대코드로 부모님을 추가하려 하면 예외가 발생한다")
-    void 부모님_추가_초대코드_중복() {
-        // given
-        Member guardian = mock(Member.class);
-        FamilyMembership membership = mock(FamilyMembership.class);
-        Family family = mock(Family.class);
-        SeniorSignUpRequest request = new SeniorSignUpRequest(
-                "오일남", LocalDate.of(1950, 1, 1), "01011112222",
-                "서울시 강남구", "101호", "1234567"
-        );
-
-        given(memberUtil.getCurrentMember()).willReturn(guardian);
-        given(guardian.getId()).willReturn(1L);
-        given(familyMembershipRepository.findByGuardianId(1L)).willReturn(Optional.of(membership));
-        given(membership.getFamily()).willReturn(family);
-        given(memberRepository.findByPhoneNumber("01011112222")).willReturn(Optional.empty());
-        given(seniorProfileRepository.existsByInviteCode("1234567")).willReturn(true);
 
         // when & then
         assertThatThrownBy(() -> guardianMyPageService.addSenior(request))
@@ -910,7 +885,6 @@ class GuardianMyPageServiceTest {
         given(seniorProfile.getId()).willReturn(100L);
         given(familyMembershipRepository.existsByGuardianIdAndSeniorProfileId(1L, 100L)).willReturn(true);
         given(familyMembershipRepository.existsByGuardianIdAndSeniorProfileIdAndIsLeaderTrue(1L, 100L)).willReturn(true);
-        given(seniorProfileRepository.existsByInviteCode("ABC1234")).willReturn(false);
 
         // when
         guardianMyPageService.updateSeniorInviteCode(10L, new UpdateInviteCodeRequest("ABC1234"));
@@ -932,26 +906,6 @@ class GuardianMyPageServiceTest {
         given(seniorProfile.getId()).willReturn(100L);
         given(familyMembershipRepository.existsByGuardianIdAndSeniorProfileId(1L, 100L)).willReturn(true);
         given(familyMembershipRepository.existsByGuardianIdAndSeniorProfileIdAndIsLeaderTrue(1L, 100L)).willReturn(false);
-
-        // when & then
-        assertThatThrownBy(() -> guardianMyPageService.updateSeniorInviteCode(10L, new UpdateInviteCodeRequest("ABC1234")))
-                .isInstanceOf(BusinessException.class);
-    }
-
-    @Test
-    @DisplayName("이미 사용 중인 초대코드로 수정하려 하면 예외가 발생한다")
-    void 시니어_초대코드_수정_중복_코드() {
-        // given
-        Member guardian = mock(Member.class);
-        SeniorProfile seniorProfile = mock(SeniorProfile.class);
-
-        given(memberUtil.getCurrentMember()).willReturn(guardian);
-        given(guardian.getId()).willReturn(1L);
-        given(seniorProfileRepository.findByMemberId(10L)).willReturn(Optional.of(seniorProfile));
-        given(seniorProfile.getId()).willReturn(100L);
-        given(familyMembershipRepository.existsByGuardianIdAndSeniorProfileId(1L, 100L)).willReturn(true);
-        given(familyMembershipRepository.existsByGuardianIdAndSeniorProfileIdAndIsLeaderTrue(1L, 100L)).willReturn(true);
-        given(seniorProfileRepository.existsByInviteCode("ABC1234")).willReturn(true);
 
         // when & then
         assertThatThrownBy(() -> guardianMyPageService.updateSeniorInviteCode(10L, new UpdateInviteCodeRequest("ABC1234")))

--- a/backend/widyu-domain/src/main/java/com/widyu/member/SeniorProfile.java
+++ b/backend/widyu-domain/src/main/java/com/widyu/member/SeniorProfile.java
@@ -40,7 +40,7 @@ public class SeniorProfile extends BaseTimeEntity {
     @Column(name = "detail_address")
     private String detailAddress;
 
-    @Column(name = "invite_code", nullable = false, unique = true, length = 7)
+    @Column(name = "invite_code", nullable = false, length = 7)
     private String inviteCode;
 
     @Column(name = "birth_date")


### PR DESCRIPTION
## #️⃣연관된 이슈

- close: #312

## 🪄작업 내용

- `SeniorProfile.inviteCode` 컬럼의 `unique = true` 제거
- `SeniorAuthService.validateInviteCodesUnique()` 메서드 및 호출 제거
- `GuardianMyPageService.addSenior()` / `updateSeniorInviteCode()` 초대코드 중복 체크 제거
- `SeniorProfileRepository.existsByInviteCode`, `existsByInviteCodeAndIdNot` 제거
- 초대코드 중복 관련 테스트 2개 제거

> ⚠️ **배포 전 수동 DB 작업 필요**
> `ddl-auto: update`는 기존 UNIQUE 인덱스를 자동으로 삭제하지 않습니다.
> ```sql
> ALTER TABLE senior_profile DROP INDEX UKl8hho4q5lchqkyq3w6hdnlj8m;
> ```

## 💖리뷰 요청사항

- 시니어 로그인은 초대코드 + 전화번호 조합으로 인증하기 때문에 초대코드 중복을 허용해도 보안상 문제없다고 판단했습니다.
- `SeniorProfileRepository.findByInviteCode(String inviteCode)` 메서드는 아직 남아 있는데, 중복 허용 이후 해당 메서드 사용처에서 결과가 여러 건이 될 수 있습니다. 사용처 확인 부탁드립니다.