### PR TITLE
fix: 시니어 삭제 시 SeniorProfile 미삭제 버그 수정 (#314)

### DIFF
--- a/backend/widyu-api/src/main/java/com/widyu/member/repository/PointHistoryRepository.java
+++ b/backend/widyu-api/src/main/java/com/widyu/member/repository/PointHistoryRepository.java
@@ -3,10 +3,15 @@ package com.widyu.member.repository;
 import com.widyu.member.PointHistory;
 import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface PointHistoryRepository extends JpaRepository<PointHistory, Long> {
 
     List<PointHistory> findAllBySeniorProfileIdOrderByCreatedAtDesc(Long seniorProfileId);
 
-    void deleteBySeniorProfileId(Long seniorProfileId);
+    @Modifying
+    @Query("DELETE FROM PointHistory p WHERE p.seniorProfile.id = :seniorProfileId")
+    void deleteBySeniorProfileId(@Param("seniorProfileId") Long seniorProfileId);
 }

--- a/backend/widyu-api/src/main/java/com/widyu/member/repository/SeniorProfileRepository.java
+++ b/backend/widyu-api/src/main/java/com/widyu/member/repository/SeniorProfileRepository.java
@@ -6,6 +6,7 @@ import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
@@ -16,6 +17,10 @@ public interface SeniorProfileRepository extends JpaRepository<SeniorProfile, Lo
     Optional<SeniorProfile> findByMemberId(Long memberId);
 
     boolean existsByMemberId(Long memberId);
+
+    @Modifying
+    @Query("DELETE FROM SeniorProfile sp WHERE sp.id = :id")
+    void deleteByIdDirectly(@Param("id") Long id);
 
     @Query("SELECT sp FROM SeniorProfile sp WHERE sp.inviteCode = :inviteCode AND sp.member.phoneNumber = :phoneNumber")
     Optional<SeniorProfile> findByInviteCodeAndMemberPhoneNumber(@Param("inviteCode") String inviteCode,

--- a/backend/widyu-api/src/main/java/com/widyu/mypage/application/GuardianMyPageService.java
+++ b/backend/widyu-api/src/main/java/com/widyu/mypage/application/GuardianMyPageService.java
@@ -271,7 +271,7 @@ public class GuardianMyPageService {
         }
 
         pointHistoryRepository.deleteBySeniorProfileId(seniorProfile.getId());
-        seniorProfileRepository.delete(seniorProfile);
+        seniorProfileRepository.deleteByIdDirectly(seniorProfile.getId());
     }
 
     private void assertIsLeader(SeniorProfile seniorProfile, Long guardianId) {

--- a/backend/widyu-api/src/test/java/com/widyu/mypage/application/GuardianMyPageServiceTest.java
+++ b/backend/widyu-api/src/test/java/com/widyu/mypage/application/GuardianMyPageServiceTest.java
@@ -839,7 +839,7 @@ class GuardianMyPageServiceTest {
         guardianMyPageService.deleteFamilyMember(2L);
 
         // then
-        verify(seniorProfileRepository).delete(targetSeniorProfile);
+        verify(seniorProfileRepository).deleteByIdDirectly(200L);
     }
 
     @Test


### PR DESCRIPTION
## #️⃣연관된 이슈

- close: #314

## 🪄작업 내용

**버그**: 가족 멤버 삭제 API 호출 시 200이 반환되지만 시니어가 family member list에서 사라지지 않음

**원인**:
`Member` 엔티티에 `@OneToOne(cascade = CascadeType.ALL, orphanRemoval = true) SeniorProfile seniorProfile`이 선언되어 있음.
`seniorProfileRepository.delete(seniorProfile)`을 호출할 때 동일 트랜잭션의 persistence context에 `Member` 엔티티가 로드되어 있고,
flush 시점에 `CascadeType.ALL`에 포함된 `CascadeType.PERSIST`가 `member.seniorProfile` 참조를 통해 REMOVED 상태의 `SeniorProfile`을 되살림.

**수정**:
- `PointHistoryRepository.deleteBySeniorProfileId`: 파생 삭제(derived delete) → `@Modifying @Query` 벌크 삭제로 교체
  - 즉시 SQL을 실행하여 FK 순서(PointHistory 먼저) 보장
- `SeniorProfileRepository.deleteByIdDirectly`: `@Modifying @Query` 추가
  - persistence context를 우회하여 DELETE SQL을 직접 실행
- `GuardianMyPageService.deleteSeniorFromFamily`: 새 메서드 사용
- 테스트 verify 대상 업데이트

## 💖리뷰 요청사항

`@Modifying @Query` 벌크 삭제는 persistence context를 우회하기 때문에 같은 트랜잭션 내에서 이후에 해당 엔티티를 조회하면 stale 데이터가 반환될 수 있습니다.
`deleteSeniorFromFamily`는 삭제 후 추가 조회가 없으므로 문제없다고 판단했습니다.