### PR TITLE
fix: @Modifying 벌크 삭제 후 영속성 컨텍스트 미초기화 (#316)

### DIFF
--- a/backend/widyu-api/src/main/java/com/widyu/member/repository/PointHistoryRepository.java
+++ b/backend/widyu-api/src/main/java/com/widyu/member/repository/PointHistoryRepository.java
@@ -11,7 +11,7 @@ public interface PointHistoryRepository extends JpaRepository<PointHistory, Long
 
     List<PointHistory> findAllBySeniorProfileIdOrderByCreatedAtDesc(Long seniorProfileId);
 
-    @Modifying
+    @Modifying(clearAutomatically = true)
     @Query("DELETE FROM PointHistory p WHERE p.seniorProfile.id = :seniorProfileId")
     void deleteBySeniorProfileId(@Param("seniorProfileId") Long seniorProfileId);
 }

--- a/backend/widyu-api/src/main/java/com/widyu/member/repository/SeniorProfileRepository.java
+++ b/backend/widyu-api/src/main/java/com/widyu/member/repository/SeniorProfileRepository.java
@@ -18,7 +18,7 @@ public interface SeniorProfileRepository extends JpaRepository<SeniorProfile, Lo
 
     boolean existsByMemberId(Long memberId);
 
-    @Modifying
+    @Modifying(clearAutomatically = true)
     @Query("DELETE FROM SeniorProfile sp WHERE sp.id = :id")
     void deleteByIdDirectly(@Param("id") Long id);
 


### PR DESCRIPTION
## #️⃣연관된 이슈

- close: #316

## 🪄작업 내용

- `PointHistoryRepository.deleteBySeniorProfileId`: `@Modifying` → `@Modifying(clearAutomatically = true)`
- `SeniorProfileRepository.deleteByIdDirectly`: `@Modifying` → `@Modifying(clearAutomatically = true)`

`@Modifying @Query` 벌크 삭제는 DB를 직접 수정하지만 1차 캐시(영속성 컨텍스트)에 자동 반영되지 않는다.
`clearAutomatically = true` 추가로 벌크 삭제 직후 영속성 컨텍스트를 초기화하여 DB와 일관성 보장.

## 💖리뷰 요청사항

현재 `deleteSeniorFromFamily` 흐름상 벌크 삭제 이후 같은 트랜잭션에서 추가 조회가 없어 실질적 영향은 없으나, JPA 명세 준수 및 향후 로직 추가 시 안전성 확보를 위해 적용했습니다.