### PR TITLE
refactor: 상세주소(detailAddress) 필드 전면 제거

### DIFF
--- a/backend/widyu-api/src/main/java/com/widyu/auth/application/senior/SeniorAuthService.java
+++ b/backend/widyu-api/src/main/java/com/widyu/auth/application/senior/SeniorAuthService.java
@@ -105,7 +105,6 @@ public class SeniorAuthService {
                     member,
                     family,
                     req.address(),
-                    req.detailAddress(),
                     req.inviteCode(),
                     req.birthDate()
             );

--- a/backend/widyu-api/src/main/java/com/widyu/auth/dto/request/ParentSignUpRequest.java
+++ b/backend/widyu-api/src/main/java/com/widyu/auth/dto/request/ParentSignUpRequest.java
@@ -20,9 +20,6 @@ public record ParentSignUpRequest(
         @Size(max = 200, message = "주소는 최대 200자입니다.")
         String address,
 
-        @Size(max = 200, message = "상세주소는 최대 200자입니다.")
-        String detailAddress,
-
         @NotBlank(message = "초대코드는 필수입니다.")
         @Pattern(regexp = "^\\d{7}$", message = "초대코드는 숫자만 7자리로 입력해주세요.")
         String inviteCode

--- a/backend/widyu-api/src/main/java/com/widyu/auth/dto/request/SeniorSignUpRequest.java
+++ b/backend/widyu-api/src/main/java/com/widyu/auth/dto/request/SeniorSignUpRequest.java
@@ -29,9 +29,6 @@ public record SeniorSignUpRequest(
         @Size(max = 200, message = "주소는 최대 200자입니다.")
         String address,
 
-        @Size(max = 200, message = "상세주소는 최대 200자입니다.")
-        String detailAddress,
-
         @NotBlank(message = "초대코드는 필수입니다.")
         @Pattern(regexp = "^\\d{7}$", message = "초대코드는 숫자만 7자리로 입력해주세요.")
         String inviteCode

--- a/backend/widyu-api/src/main/java/com/widyu/global/config/DevDataInitializer.java
+++ b/backend/widyu-api/src/main/java/com/widyu/global/config/DevDataInitializer.java
@@ -157,9 +157,9 @@ public class DevDataInitializer implements CommandLineRunner {
         familyMembershipRepository.save(FamilyMembership.createMembership(family, g2));
 
         seniorProfileRepository.save(SeniorProfile.createSeniorProfile(
-                s1, family, "서울시 강남구", "101호", "1110001", LocalDate.of(1948, 3, 12)));
+                s1, family, "서울시 강남구", "1110001", LocalDate.of(1948, 3, 12)));
         seniorProfileRepository.save(SeniorProfile.createSeniorProfile(
-                s2, family, "서울시 강남구", "202호", "1110002", LocalDate.of(1952, 11, 5)));
+                s2, family, "서울시 강남구", "1110002", LocalDate.of(1952, 11, 5)));
 
         return List.of(s1, s2);
     }
@@ -181,7 +181,7 @@ public class DevDataInitializer implements CommandLineRunner {
         familyMembershipRepository.save(FamilyMembership.createMembership(family, g2));
 
         seniorProfileRepository.save(SeniorProfile.createSeniorProfile(
-                s1, family, "부산시 해운대구", "303호", "2220001", LocalDate.of(1945, 7, 21)));
+                s1, family, "부산시 해운대구", "2220001", LocalDate.of(1945, 7, 21)));
 
         return List.of(s1);
     }

--- a/backend/widyu-api/src/main/java/com/widyu/member/dto/response/SeniorProfileResponse.java
+++ b/backend/widyu-api/src/main/java/com/widyu/member/dto/response/SeniorProfileResponse.java
@@ -11,7 +11,6 @@ public record SeniorProfileResponse(
         String name,
         String profileImage,
         String address,
-        String detailAddress,
         String inviteCode,
         Long points,
         List<GuardianInfo> guardians
@@ -44,7 +43,6 @@ public record SeniorProfileResponse(
                 seniorProfile.getMember().getName(),
                 seniorProfile.getMember().getProfileImage(),
                 seniorProfile.getAddress(),
-                seniorProfile.getDetailAddress(),
                 seniorProfile.getInviteCode(),
                 seniorProfile.getPoints(),
                 guardianInfos

--- a/backend/widyu-api/src/main/java/com/widyu/mypage/application/GuardianMyPageService.java
+++ b/backend/widyu-api/src/main/java/com/widyu/mypage/application/GuardianMyPageService.java
@@ -88,7 +88,7 @@ public class GuardianMyPageService {
 
         SeniorProfile profile = SeniorProfile.createSeniorProfile(
                 seniorMember, family,
-                request.address(), request.detailAddress(),
+                request.address(),
                 request.inviteCode(), request.birthDate()
         );
         seniorProfileRepository.save(profile);
@@ -166,7 +166,7 @@ public class GuardianMyPageService {
         Member guardian = MyPageProfileService.getCurrentMember(memberUtil);
         SeniorProfile seniorProfile = getSeniorProfileWithAccessCheck(memberId, guardian.getId());
         assertIsLeader(seniorProfile, guardian.getId());
-        seniorProfile.updateAddress(request.address(), request.detailAddress());
+        seniorProfile.updateAddress(request.address());
     }
 
     @Transactional

--- a/backend/widyu-api/src/main/java/com/widyu/mypage/dto/request/UpdateSeniorAddressRequest.java
+++ b/backend/widyu-api/src/main/java/com/widyu/mypage/dto/request/UpdateSeniorAddressRequest.java
@@ -6,8 +6,5 @@ import jakarta.validation.constraints.Size;
 public record UpdateSeniorAddressRequest(
         @NotBlank(message = "주소는 필수입니다.")
         @Size(max = 200, message = "주소는 최대 200자입니다.")
-        String address,
-
-        @Size(max = 200, message = "상세주소는 최대 200자입니다.")
-        String detailAddress
+        String address
 ) {}

--- a/backend/widyu-api/src/main/java/com/widyu/mypage/dto/response/SeniorProfileDetailResponse.java
+++ b/backend/widyu-api/src/main/java/com/widyu/mypage/dto/response/SeniorProfileDetailResponse.java
@@ -10,7 +10,6 @@ public record SeniorProfileDetailResponse(
         LocalDate birthDate,
         String phoneNumber,
         String address,
-        String detailAddress,
         String inviteCode
 ) {
     public static SeniorProfileDetailResponse of(Member member, SeniorProfile seniorProfile) {
@@ -20,7 +19,6 @@ public record SeniorProfileDetailResponse(
                 seniorProfile.getBirthDate(),
                 member.getPhoneNumber(),
                 seniorProfile.getAddress(),
-                seniorProfile.getDetailAddress(),
                 seniorProfile.getInviteCode()
         );
     }

--- a/backend/widyu-api/src/main/java/com/widyu/mypage/dto/response/SeniorProfileForGuardianResponse.java
+++ b/backend/widyu-api/src/main/java/com/widyu/mypage/dto/response/SeniorProfileForGuardianResponse.java
@@ -11,7 +11,6 @@ public record SeniorProfileForGuardianResponse(
         LocalDate birthDate,
         String phoneNumber,
         String address,
-        String detailAddress,
         String inviteCode
 ) {
     public static SeniorProfileForGuardianResponse of(Member seniorMember, SeniorProfile seniorProfile) {
@@ -22,7 +21,6 @@ public record SeniorProfileForGuardianResponse(
                 seniorProfile.getBirthDate(),
                 seniorMember.getPhoneNumber(),
                 seniorProfile.getAddress(),
-                seniorProfile.getDetailAddress(),
                 seniorProfile.getInviteCode()
         );
     }

--- a/backend/widyu-api/src/test/java/com/widyu/auth/application/senior/SeniorAuthServiceTest.java
+++ b/backend/widyu-api/src/test/java/com/widyu/auth/application/senior/SeniorAuthServiceTest.java
@@ -58,8 +58,8 @@ class SeniorAuthServiceTest {
         ReflectionTestUtils.setField(guardian, "id", 1L);
 
         List<SeniorSignUpRequest> requests = List.of(
-                new SeniorSignUpRequest("부모님", LocalDate.of(1950, 1, 1), "01011112222", "서울시 강남구", "101호", "1234567"),
-                new SeniorSignUpRequest("할머니", LocalDate.of(1948, 2, 2), "01033334444", "서울시 서초구", "202호", "7654321")
+                new SeniorSignUpRequest("부모님", LocalDate.of(1950, 1, 1), "01011112222", "서울시 강남구", "1234567"),
+                new SeniorSignUpRequest("할머니", LocalDate.of(1948, 2, 2), "01033334444", "서울시 서초구", "7654321")
         );
 
         Member seniorMember1 = Member.createMember(MemberType.SENIOR, "부모님", "01011112222");
@@ -94,7 +94,7 @@ class SeniorAuthServiceTest {
         given(familyMembershipRepository.findByGuardianId(1L)).willReturn(Optional.of(mock(FamilyMembership.class)));
 
         List<SeniorSignUpRequest> requests = List.of(
-                new SeniorSignUpRequest("부모님", LocalDate.of(1950, 1, 1), "01011112222", "서울", "101호", "1234567")
+                new SeniorSignUpRequest("부모님", LocalDate.of(1950, 1, 1), "01011112222", "서울", "1234567")
         );
 
         // when & then
@@ -142,7 +142,7 @@ class SeniorAuthServiceTest {
         ReflectionTestUtils.setField(family, "id", 1L);
 
         SeniorProfile seniorProfile = SeniorProfile.createSeniorProfile(
-                seniorMember, family, "서울", "101호", inviteCode, LocalDate.of(1950, 1, 1)
+                seniorMember, family, "서울", inviteCode, LocalDate.of(1950, 1, 1)
         );
         TokenPairResponse expectedToken = TokenPairResponse.of(2L, "access", "refresh");
 
@@ -180,7 +180,7 @@ class SeniorAuthServiceTest {
         given(familyRepository.existsByFamilyCode(anyString())).willReturn(true);
 
         List<SeniorSignUpRequest> requests = List.of(
-                new SeniorSignUpRequest("부모님", LocalDate.of(1950, 1, 1), "01011112222", "서울", "101호", "1234567")
+                new SeniorSignUpRequest("부모님", LocalDate.of(1950, 1, 1), "01011112222", "서울", "1234567")
         );
 
         // when & then
@@ -202,8 +202,8 @@ class SeniorAuthServiceTest {
         given(familyRepository.save(any(Family.class))).willReturn(family);
 
         List<SeniorSignUpRequest> requests = List.of(
-                new SeniorSignUpRequest("부모님", LocalDate.of(1950, 1, 1), "01011112222", "서울", "101호", "1234567"),
-                new SeniorSignUpRequest("할머니", LocalDate.of(1948, 2, 2), "01033334444", "부산", "202호", "7654321")
+                new SeniorSignUpRequest("부모님", LocalDate.of(1950, 1, 1), "01011112222", "서울", "1234567"),
+                new SeniorSignUpRequest("할머니", LocalDate.of(1948, 2, 2), "01033334444", "부산", "7654321")
         );
 
         given(memberRepository.saveAll(anyList())).willAnswer(inv -> {

--- a/backend/widyu-api/src/test/java/com/widyu/home/GuardianHomeServiceTest.java
+++ b/backend/widyu-api/src/test/java/com/widyu/home/GuardianHomeServiceTest.java
@@ -74,7 +74,7 @@ class GuardianHomeServiceTest {
         Member otherSenior = Member.createMember(MemberType.SENIOR, "다른가족부모님", "01055556666");
         Family otherFamily = Family.createFamily("OTHER1");
         SeniorProfile otherProfile = SeniorProfile.createSeniorProfile(
-                otherSenior, otherFamily, "서울시", null, "9990001", null);
+                otherSenior, otherFamily, "서울시", "9990001", null);
 
         given(memberUtil.getCurrentMember()).willReturn(guardian);
         given(memberRepository.findById(42L)).willReturn(Optional.of(otherSenior));
@@ -95,7 +95,7 @@ class GuardianHomeServiceTest {
         Family family = Family.createFamily("FAMA01");
         FamilyMembership membership = FamilyMembership.createLeaderMembership(family, guardian);
         SeniorProfile seniorProfile = SeniorProfile.createSeniorProfile(
-                senior, family, "서울시", null, "1110001", null);
+                senior, family, "서울시", "1110001", null);
 
         given(memberUtil.getCurrentMember()).willReturn(guardian);
         given(familyMembershipRepository.findByGuardianId(any())).willReturn(Optional.of(membership));
@@ -122,7 +122,7 @@ class GuardianHomeServiceTest {
         Family family = Family.createFamily("FAMA01");
         FamilyMembership membership = FamilyMembership.createLeaderMembership(family, guardian);
         SeniorProfile seniorProfile = SeniorProfile.createSeniorProfile(
-                senior, family, "서울시", null, "1110001", null);
+                senior, family, "서울시", "1110001", null);
 
         given(memberUtil.getCurrentMember()).willReturn(guardian);
         given(familyMembershipRepository.findByGuardianId(any())).willReturn(Optional.of(membership));
@@ -149,7 +149,7 @@ class GuardianHomeServiceTest {
         Family family = Family.createFamily("FAMA01");
         FamilyMembership membership = FamilyMembership.createLeaderMembership(family, guardian);
         SeniorProfile seniorProfile = SeniorProfile.createSeniorProfile(
-                senior, family, "서울시", null, "1110001", null);
+                senior, family, "서울시", "1110001", null);
 
         given(memberUtil.getCurrentMember()).willReturn(guardian);
         given(familyMembershipRepository.findByGuardianId(any())).willReturn(Optional.of(membership));
@@ -176,7 +176,7 @@ class GuardianHomeServiceTest {
         Family family = Family.createFamily("FAMA01");
         FamilyMembership membership = FamilyMembership.createLeaderMembership(family, guardian);
         SeniorProfile seniorProfile = SeniorProfile.createSeniorProfile(
-                senior, family, "서울시", null, "1110001", null);
+                senior, family, "서울시", "1110001", null);
 
         MedicineSchedule schedule1 = mock(MedicineSchedule.class);
         MedicineSchedule schedule2 = mock(MedicineSchedule.class);

--- a/backend/widyu-api/src/test/java/com/widyu/mypage/application/GuardianMyPageServiceTest.java
+++ b/backend/widyu-api/src/test/java/com/widyu/mypage/application/GuardianMyPageServiceTest.java
@@ -204,7 +204,7 @@ class GuardianMyPageServiceTest {
         Family family = mock(Family.class);
         SeniorSignUpRequest request = new SeniorSignUpRequest(
                 "오일남", LocalDate.of(1950, 1, 1), "01011112222",
-                "서울시 강남구", "101호", "1234567"
+                "서울시 강남구", "1234567"
         );
 
         given(memberUtil.getCurrentMember()).willReturn(guardian);
@@ -231,7 +231,7 @@ class GuardianMyPageServiceTest {
         Member existingMember = mock(Member.class);
         SeniorSignUpRequest request = new SeniorSignUpRequest(
                 "오일남", LocalDate.of(1950, 1, 1), "01011112222",
-                "서울시 강남구", "101호", "1234567"
+                "서울시 강남구", "1234567"
         );
 
         given(memberUtil.getCurrentMember()).willReturn(guardian);
@@ -252,7 +252,7 @@ class GuardianMyPageServiceTest {
         Member guardian = mock(Member.class);
         SeniorSignUpRequest request = new SeniorSignUpRequest(
                 "오일남", LocalDate.of(1950, 1, 1), "01011112222",
-                "서울시 강남구", "101호", "1234567"
+                "서울시 강남구", "1234567"
         );
 
         given(memberUtil.getCurrentMember()).willReturn(guardian);
@@ -558,10 +558,10 @@ class GuardianMyPageServiceTest {
         given(familyMembershipRepository.existsByGuardianIdAndSeniorProfileIdAndIsLeaderTrue(1L, 100L)).willReturn(true);
 
         // when
-        guardianMyPageService.updateSeniorAddress(10L, new UpdateSeniorAddressRequest("서울시 강서구", "101호"));
+        guardianMyPageService.updateSeniorAddress(10L, new UpdateSeniorAddressRequest("서울시 강서구"));
 
         // then
-        verify(seniorProfile).updateAddress("서울시 강서구", "101호");
+        verify(seniorProfile).updateAddress("서울시 강서구");
     }
 
     // ======================== 가족 멤버 목록 조회 ========================

--- a/backend/widyu-api/src/test/java/com/widyu/mypage/application/SeniorMyPageServiceTest.java
+++ b/backend/widyu-api/src/test/java/com/widyu/mypage/application/SeniorMyPageServiceTest.java
@@ -112,7 +112,6 @@ class SeniorMyPageServiceTest {
         given(member.getProfileImage()).willReturn("image.png");
         given(seniorProfile.getBirthDate()).willReturn(LocalDate.of(1950, 1, 1));
         given(seniorProfile.getAddress()).willReturn("서울시 강서구");
-        given(seniorProfile.getDetailAddress()).willReturn("101호");
         given(seniorProfile.getInviteCode()).willReturn("1234567");
 
         // when

--- a/backend/widyu-api/src/test/java/com/widyu/pay/integration/PaymentIntegrationTest.java
+++ b/backend/widyu-api/src/test/java/com/widyu/pay/integration/PaymentIntegrationTest.java
@@ -177,7 +177,6 @@ class PaymentIntegrationTest {
                         member,
                         family,
                         "서울시 강남구",
-                        "101호",
                         inviteCode,
                         LocalDate.of(1950, 1, 1)
                 )

--- a/backend/widyu-domain/src/main/java/com/widyu/member/SeniorProfile.java
+++ b/backend/widyu-domain/src/main/java/com/widyu/member/SeniorProfile.java
@@ -37,9 +37,6 @@ public class SeniorProfile extends BaseTimeEntity {
 
     private String address;
 
-    @Column(name = "detail_address")
-    private String detailAddress;
-
     @Column(name = "invite_code", nullable = false, length = 7)
     private String inviteCode;
 
@@ -53,12 +50,11 @@ public class SeniorProfile extends BaseTimeEntity {
     private Integer defaultWalkGoal;
 
     @Builder(access = AccessLevel.PRIVATE)
-    private SeniorProfile(Member member, Family family, String address, String detailAddress,
+    private SeniorProfile(Member member, Family family, String address,
                           String inviteCode, LocalDate birthDate, Long points, Integer defaultWalkGoal) {
         this.member = member;
         this.family = family;
         this.address = address;
-        this.detailAddress = detailAddress;
         this.inviteCode = inviteCode;
         this.birthDate = birthDate;
         this.points = points;
@@ -66,12 +62,11 @@ public class SeniorProfile extends BaseTimeEntity {
     }
 
     public static SeniorProfile createSeniorProfile(Member member, Family family, String address,
-                                                    String detailAddress, String inviteCode, LocalDate birthDate) {
+                                                    String inviteCode, LocalDate birthDate) {
         return SeniorProfile.builder()
                 .member(member)
                 .family(family)
                 .address(address)
-                .detailAddress(detailAddress)
                 .inviteCode(inviteCode)
                 .birthDate(birthDate)
                 .points(100L)
@@ -103,9 +98,8 @@ public class SeniorProfile extends BaseTimeEntity {
         return this.defaultWalkGoal != null;
     }
 
-    public void updateAddress(String address, String detailAddress) {
+    public void updateAddress(String address) {
         this.address = address;
-        this.detailAddress = detailAddress;
     }
 
     public void updateInviteCode(String inviteCode) {


### PR DESCRIPTION
## #️⃣연관된 이슈
- close: #318

## 🪄작업 내용
- `SeniorProfile` 엔티티에서 `detailAddress` 필드 및 관련 Builder/메서드 제거
- `SeniorSignUpRequest`, `ParentSignUpRequest`에서 `detailAddress` 제거
- `UpdateSeniorAddressRequest`에서 `detailAddress` 제거
- `SeniorProfileResponse`, `SeniorProfileDetailResponse`, `SeniorProfileForGuardianResponse` 응답 DTO에서 `detailAddress` 제거
- `SeniorAuthService.buildProfilesFromRequests()` 호출부 수정
- `GuardianMyPageService.updateSeniorAddress()` 및 `addSenior()` 호출부 수정
- `DevDataInitializer` 시드 데이터 수정

> DB 마이그레이션 필요: `ALTER TABLE senior_profile DROP COLUMN detail_address;`

## 💖리뷰 요청사항
- 제거 누락된 `detailAddress` 참조가 있는지 확인