### PR TITLE
feature: 집주소 수정 시 HOME 타입 안심구역 자동 동기화

### DIFF
--- a/backend/widyu-api/src/main/java/com/widyu/mypage/application/GuardianMyPageService.java
+++ b/backend/widyu-api/src/main/java/com/widyu/mypage/application/GuardianMyPageService.java
@@ -19,6 +19,7 @@ import com.widyu.member.repository.FamilyMembershipRepository;
 import com.widyu.member.repository.MemberRepository;
 import com.widyu.member.repository.PointHistoryRepository;
 import com.widyu.member.repository.SeniorProfileRepository;
+import com.widyu.location.parentlocation.repository.ParentLocationRepository;
 import com.widyu.mypage.dto.request.UpdateInviteCodeRequest;
 import com.widyu.mypage.dto.request.UpdateNameRequest;
 import com.widyu.mypage.dto.request.UpdatePhoneRequest;
@@ -29,6 +30,9 @@ import com.widyu.mypage.dto.response.FamilyMemberListResponse;
 import com.widyu.mypage.dto.response.GuardianInfoResponse;
 import com.widyu.mypage.dto.response.GuardianProfileDetailResponse;
 import com.widyu.mypage.dto.response.SeniorProfileForGuardianResponse;
+import com.widyu.parentlocation.LocationType;
+import com.widyu.parentlocation.ParentLocation;
+import com.widyu.global.entity.Status;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -53,6 +57,7 @@ public class GuardianMyPageService {
     private final SeniorProfileRepository seniorProfileRepository;
     private final MemberRepository memberRepository;
     private final PointHistoryRepository pointHistoryRepository;
+    private final ParentLocationRepository parentLocationRepository;
 
     public GuardianInfoResponse getGuardianInfo() {
         Member member = MyPageProfileService.getCurrentMember(memberUtil);
@@ -167,6 +172,29 @@ public class GuardianMyPageService {
         SeniorProfile seniorProfile = getSeniorProfileWithAccessCheck(memberId, guardian.getId());
         assertIsLeader(seniorProfile, guardian.getId());
         seniorProfile.updateAddress(request.address(), request.detailAddress());
+        syncHomeParentLocation(seniorProfile.getMember(), request);
+    }
+
+    private void syncHomeParentLocation(Member seniorMember, UpdateSeniorAddressRequest request) {
+        parentLocationRepository.findByMemberAndLocationType(seniorMember, LocationType.HOME)
+                .ifPresentOrElse(
+                        location -> location.update(
+                                LocationType.HOME,
+                                request.address(),
+                                request.latitude(),
+                                request.longitude(),
+                                location.getName()
+                        ),
+                        () -> parentLocationRepository.save(ParentLocation.builder()
+                                .member(seniorMember)
+                                .locationType(LocationType.HOME)
+                                .placeAddress(request.address())
+                                .latitude(request.latitude())
+                                .longitude(request.longitude())
+                                .name("집")
+                                .status(Status.ACTIVE)
+                                .build())
+                );
     }
 
     @Transactional

--- a/backend/widyu-api/src/main/java/com/widyu/mypage/dto/request/UpdateSeniorAddressRequest.java
+++ b/backend/widyu-api/src/main/java/com/widyu/mypage/dto/request/UpdateSeniorAddressRequest.java
@@ -1,6 +1,7 @@
 package com.widyu.mypage.dto.request;
 
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
 
 public record UpdateSeniorAddressRequest(
@@ -9,5 +10,11 @@ public record UpdateSeniorAddressRequest(
         String address,
 
         @Size(max = 200, message = "상세주소는 최대 200자입니다.")
-        String detailAddress
+        String detailAddress,
+
+        @NotNull(message = "위도는 필수입니다.")
+        String latitude,
+
+        @NotNull(message = "경도는 필수입니다.")
+        String longitude
 ) {}

--- a/backend/widyu-api/src/test/java/com/widyu/mypage/application/GuardianMyPageServiceTest.java
+++ b/backend/widyu-api/src/test/java/com/widyu/mypage/application/GuardianMyPageServiceTest.java
@@ -30,6 +30,7 @@ import com.widyu.member.repository.FamilyMembershipRepository;
 import com.widyu.member.repository.MemberRepository;
 import com.widyu.member.repository.PointHistoryRepository;
 import com.widyu.member.repository.SeniorProfileRepository;
+import com.widyu.location.parentlocation.repository.ParentLocationRepository;
 import com.widyu.mypage.dto.request.UpdateInviteCodeRequest;
 import com.widyu.mypage.dto.request.UpdateNameRequest;
 import com.widyu.mypage.dto.request.UpdatePhoneRequest;
@@ -63,6 +64,7 @@ class GuardianMyPageServiceTest {
     @Mock private SeniorProfileRepository seniorProfileRepository;
     @Mock private MemberRepository memberRepository;
     @Mock private PointHistoryRepository pointHistoryRepository;
+    @Mock private ParentLocationRepository parentLocationRepository;
 
     @InjectMocks
     private GuardianMyPageService guardianMyPageService;
@@ -550,15 +552,19 @@ class GuardianMyPageServiceTest {
         Member guardian = mock(Member.class);
         SeniorProfile seniorProfile = mock(SeniorProfile.class);
 
+        Member seniorMember = mock(Member.class);
+
         given(memberUtil.getCurrentMember()).willReturn(guardian);
         given(guardian.getId()).willReturn(1L);
         given(seniorProfileRepository.findByMemberId(10L)).willReturn(Optional.of(seniorProfile));
         given(seniorProfile.getId()).willReturn(100L);
         given(familyMembershipRepository.existsByGuardianIdAndSeniorProfileId(1L, 100L)).willReturn(true);
         given(familyMembershipRepository.existsByGuardianIdAndSeniorProfileIdAndIsLeaderTrue(1L, 100L)).willReturn(true);
+        given(seniorProfile.getMember()).willReturn(seniorMember);
+        given(parentLocationRepository.findByMemberAndLocationType(any(), any())).willReturn(Optional.empty());
 
         // when
-        guardianMyPageService.updateSeniorAddress(10L, new UpdateSeniorAddressRequest("서울시 강서구", "101호"));
+        guardianMyPageService.updateSeniorAddress(10L, new UpdateSeniorAddressRequest("서울시 강서구", "101호", "37.5665", "126.9780"));
 
         // then
         verify(seniorProfile).updateAddress("서울시 강서구", "101호");


### PR DESCRIPTION
## #️⃣연관된 이슈
- close: #320

## 🪄작업 내용
- `UpdateSeniorAddressRequest`에 `latitude`, `longitude` 필드 추가
- `GuardianMyPageService.updateSeniorAddress()`에서 집주소 수정 후 HOME `ParentLocation` 자동 동기화
  - HOME 타입 위치가 이미 있으면 `update()` 호출 (upsert)
  - HOME 타입 위치가 없으면 "집" 이름으로 신규 생성
- `ParentLocationRepository.findByMemberAndLocationType()`은 기존에 이미 존재하는 메서드 사용

## 💖리뷰 요청사항
- 집 이름 기본값 "집"이 적절한지, 혹은 프론트에서 별도 전달받을지 확인
- `latitude`/`longitude`가 `@NotNull`이 맞는지 또는 `@Nullable`(optional 동기화)로 변경할지 확인