### PR TITLE
feat: Kakao 지오코딩 서버 통합 — 주소 검색·시니어 등록·주소 수정 시 좌표 자동 변환

### DIFF
--- a/backend/widyu-api/src/main/java/com/widyu/auth/application/senior/SeniorAuthService.java
+++ b/backend/widyu-api/src/main/java/com/widyu/auth/application/senior/SeniorAuthService.java
@@ -77,13 +77,7 @@ public class SeniorAuthService {
         for (int i = 0; i < requests.size(); i++) {
             String address = requests.get(i).address();
             Member member = members.get(i);
-            GeocodingResponse geo;
-            try {
-                geo = geocodingService.geocode(address);
-            } catch (Exception e) {
-                log.warn("HOME 안심구역 좌표 변환 실패, 추후 마이페이지에서 수정 필요: {}", address);
-                continue;
-            }
+            GeocodingResponse geo = geocodingService.geocode(address);
             parentLocationRepository.save(ParentLocation.builder()
                     .member(member)
                     .locationType(LocationType.HOME)

--- a/backend/widyu-api/src/main/java/com/widyu/auth/application/senior/SeniorAuthService.java
+++ b/backend/widyu-api/src/main/java/com/widyu/auth/application/senior/SeniorAuthService.java
@@ -77,20 +77,22 @@ public class SeniorAuthService {
         for (int i = 0; i < requests.size(); i++) {
             String address = requests.get(i).address();
             Member member = members.get(i);
+            GeocodingResponse geo;
             try {
-                GeocodingResponse geo = geocodingService.geocode(address);
-                parentLocationRepository.save(ParentLocation.builder()
-                        .member(member)
-                        .locationType(LocationType.HOME)
-                        .placeAddress(address)
-                        .latitude(geo.latitude())
-                        .longitude(geo.longitude())
-                        .name("집")
-                        .status(Status.ACTIVE)
-                        .build());
+                geo = geocodingService.geocode(address);
             } catch (Exception e) {
                 log.warn("HOME 안심구역 좌표 변환 실패, 추후 마이페이지에서 수정 필요: {}", address);
+                continue;
             }
+            parentLocationRepository.save(ParentLocation.builder()
+                    .member(member)
+                    .locationType(LocationType.HOME)
+                    .placeAddress(address)
+                    .latitude(geo.latitude())
+                    .longitude(geo.longitude())
+                    .name("집")
+                    .status(Status.ACTIVE)
+                    .build());
         }
     }
 

--- a/backend/widyu-api/src/main/java/com/widyu/auth/application/senior/SeniorAuthService.java
+++ b/backend/widyu-api/src/main/java/com/widyu/auth/application/senior/SeniorAuthService.java
@@ -3,10 +3,14 @@ package com.widyu.auth.application.senior;
 import com.widyu.auth.dto.request.SeniorSignInRequest;
 import com.widyu.auth.dto.request.SeniorSignUpRequest;
 import com.widyu.auth.dto.response.TokenPairResponse;
+import com.widyu.global.entity.Status;
 import com.widyu.global.error.BusinessException;
 import com.widyu.global.error.ErrorCode;
 import com.widyu.global.security.JwtTokenProvider;
 import com.widyu.global.util.MemberUtil;
+import com.widyu.goal.addressbookmark.application.GeocodingService;
+import com.widyu.goal.addressbookmark.dto.response.GeocodingResponse;
+import com.widyu.location.parentlocation.repository.ParentLocationRepository;
 import com.widyu.member.Family;
 import com.widyu.member.FamilyMembership;
 import com.widyu.member.Member;
@@ -16,6 +20,8 @@ import com.widyu.member.repository.FamilyMembershipRepository;
 import com.widyu.member.repository.FamilyRepository;
 import com.widyu.member.repository.MemberRepository;
 import com.widyu.member.repository.SeniorProfileRepository;
+import com.widyu.parentlocation.LocationType;
+import com.widyu.parentlocation.ParentLocation;
 import java.security.SecureRandom;
 import java.util.ArrayList;
 import java.util.List;
@@ -38,6 +44,8 @@ public class SeniorAuthService {
     private final SeniorProfileRepository seniorProfileRepository;
     private final FamilyRepository familyRepository;
     private final FamilyMembershipRepository familyMembershipRepository;
+    private final ParentLocationRepository parentLocationRepository;
+    private final GeocodingService geocodingService;
     private final JwtTokenProvider jwtTokenProvider;
     private final MemberUtil memberUtil;
 
@@ -61,6 +69,29 @@ public class SeniorAuthService {
 
         FamilyMembership leaderMembership = FamilyMembership.createLeaderMembership(family, guardian);
         familyMembershipRepository.save(leaderMembership);
+
+        saveHomeParentLocations(requests, members);
+    }
+
+    private void saveHomeParentLocations(List<SeniorSignUpRequest> requests, List<Member> members) {
+        for (int i = 0; i < requests.size(); i++) {
+            String address = requests.get(i).address();
+            Member member = members.get(i);
+            try {
+                GeocodingResponse geo = geocodingService.geocode(address);
+                parentLocationRepository.save(ParentLocation.builder()
+                        .member(member)
+                        .locationType(LocationType.HOME)
+                        .placeAddress(address)
+                        .latitude(geo.latitude())
+                        .longitude(geo.longitude())
+                        .name("집")
+                        .status(Status.ACTIVE)
+                        .build());
+            } catch (Exception e) {
+                log.warn("HOME 안심구역 좌표 변환 실패, 추후 마이페이지에서 수정 필요: {}", address);
+            }
+        }
     }
 
     @Transactional

--- a/backend/widyu-api/src/main/java/com/widyu/auth/controller/docs/SeniorAuthDocs.java
+++ b/backend/widyu-api/src/main/java/com/widyu/auth/controller/docs/SeniorAuthDocs.java
@@ -5,6 +5,8 @@ import com.widyu.auth.dto.request.SeniorSignUpRequest;
 import com.widyu.auth.dto.response.TokenPairResponse;
 import com.widyu.global.response.ApiResponseTemplate;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -17,11 +19,29 @@ public interface SeniorAuthDocs {
 
     @Operation(
             summary = "시니어 일괄 회원가입",
-            description = "보호자가 시니어를 일괄 등록합니다. 각 시니어는 이름, 생년월일, 전화번호, 주소, 초대코드를 저장하고 초대코드로 로그인할 수 있습니다."
+            description = "보호자가 시니어를 일괄 등록합니다. 각 시니어는 이름, 생년월일, 전화번호, 주소, 초대코드를 저장하고 초대코드로 로그인할 수 있습니다.\n\n" +
+                    "- 주소는 도로명주소 검색 API(`GET /api/v1/goals/address-search`)로 조회한 값을 사용하세요.\n" +
+                    "- 초대코드는 7자리 숫자로 구성되며, 시니어 로그인 시 사용됩니다.\n" +
+                    "- 지오코딩 실패(유효하지 않은 주소) 시 400 오류가 반환됩니다.",
+            requestBody = @io.swagger.v3.oas.annotations.parameters.RequestBody(
+                    content = @Content(
+                            examples = @ExampleObject(value = """
+                                    [
+                                      {
+                                        "name": "김부모",
+                                        "birthDate": "1955-03-15",
+                                        "phoneNumber": "01012345678",
+                                        "address": "서울특별시 마포구 성암로 301",
+                                        "inviteCode": "1234567"
+                                      }
+                                    ]
+                                    """)
+                    )
+            )
     )
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "시니어 일괄 회원가입 성공"),
-            @ApiResponse(responseCode = "400", description = "잘못된 요청 (빈 리스트 등)"),
+            @ApiResponse(responseCode = "400", description = "잘못된 요청 (빈 리스트, 유효하지 않은 주소 등)"),
             @ApiResponse(responseCode = "401", description = "인증 실패")
     })
     ApiResponseTemplate<Void> seniorSignUpBulk(@RequestBody @Valid List<SeniorSignUpRequest> requests);

--- a/backend/widyu-api/src/main/java/com/widyu/auth/dto/request/SeniorSignUpRequest.java
+++ b/backend/widyu-api/src/main/java/com/widyu/auth/dto/request/SeniorSignUpRequest.java
@@ -1,6 +1,7 @@
 package com.widyu.auth.dto.request;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Past;
 import jakarta.validation.constraints.NotBlank;
@@ -9,15 +10,18 @@ import jakarta.validation.constraints.Size;
 import java.time.LocalDate;
 
 public record SeniorSignUpRequest(
+        @Schema(example = "김부모")
         @NotBlank(message = "이름은 필수입니다.")
         @Size(max = 50, message = "이름은 최대 50자입니다.")
         String name,
 
+        @Schema(example = "1955-03-15")
         @NotNull(message = "생년월일은 필수입니다.")
         @Past(message = "생년월일은 오늘 이전 날짜여야 합니다.")
         @JsonFormat(pattern = "yyyy-MM-dd")
         LocalDate birthDate,
 
+        @Schema(example = "01012345678")
         @NotBlank(message = "전화번호는 필수입니다.")
         @Pattern(
                 regexp = "^01[016789][0-9]{7,8}$",
@@ -25,10 +29,12 @@ public record SeniorSignUpRequest(
         )
         String phoneNumber,
 
+        @Schema(example = "서울특별시 마포구 성암로 301")
         @NotBlank(message = "주소는 필수입니다.")
         @Size(max = 200, message = "주소는 최대 200자입니다.")
         String address,
 
+        @Schema(example = "1234567")
         @NotBlank(message = "초대코드는 필수입니다.")
         @Pattern(regexp = "^\\d{7}$", message = "초대코드는 숫자만 7자리로 입력해주세요.")
         String inviteCode

--- a/backend/widyu-api/src/main/java/com/widyu/global/error/GlobalExceptionHandler.java
+++ b/backend/widyu-api/src/main/java/com/widyu/global/error/GlobalExceptionHandler.java
@@ -6,6 +6,7 @@ import com.widyu.global.response.ApiResponseTemplate;
 import jakarta.servlet.http.HttpServletRequest;
 import java.time.OffsetDateTime;
 import java.util.Arrays;
+import java.util.Objects;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -17,6 +18,7 @@ import org.springframework.validation.FieldError;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.method.annotation.HandlerMethodValidationException;
 
 @Slf4j
 @RestControllerAdvice
@@ -55,6 +57,22 @@ public class GlobalExceptionHandler {
         final String message = String.format("%s (%s)", trimTrailingPeriod(defaultMsg), field);
 
         log.error("Validation error for field {}: {}", field, defaultMsg);
+
+        return toResponse(HttpStatus.BAD_REQUEST, ErrorCode.BAD_REQUEST.getCode(), message);
+    }
+
+    @ExceptionHandler(HandlerMethodValidationException.class)
+    protected ResponseEntity<ApiResponseTemplate<Void>> handleHandlerMethodValidationException(
+            final HandlerMethodValidationException e
+    ) {
+        String message = e.getAllValidationResults().stream()
+                .flatMap(result -> result.getResolvableErrors().stream())
+                .map(error -> error.getDefaultMessage())
+                .filter(Objects::nonNull)
+                .findFirst()
+                .orElse("요청 값이 유효하지 않습니다");
+
+        log.error("Validation error: {}", message);
 
         return toResponse(HttpStatus.BAD_REQUEST, ErrorCode.BAD_REQUEST.getCode(), message);
     }

--- a/backend/widyu-api/src/main/java/com/widyu/goal/addressbookmark/application/GeocodingService.java
+++ b/backend/widyu-api/src/main/java/com/widyu/goal/addressbookmark/application/GeocodingService.java
@@ -19,10 +19,16 @@ public class GeocodingService {
     private String clientId;
 
     public GeocodingResponse geocode(String address) {
-        KakaoGeocodingResponse response = kakaoGeocodingClient.geocode("KakaoAK " + clientId, address);
+        KakaoGeocodingResponse response;
+        try {
+            response = kakaoGeocodingClient.geocode("KakaoAK " + clientId, address);
+        } catch (Exception e) {
+            throw new BusinessException(ErrorCode.BAD_REQUEST, "주소 좌표 변환 중 오류가 발생했습니다. 잠시 후 다시 시도해 주세요.");
+        }
 
         if (response.documents() == null || response.documents().isEmpty()) {
-            throw new BusinessException(ErrorCode.BAD_REQUEST, "좌표를 찾을 수 없는 주소입니다.");
+            throw new BusinessException(ErrorCode.BAD_REQUEST,
+                    "입력한 주소의 좌표를 찾을 수 없습니다. 정확한 도로명주소를 입력해 주세요.");
         }
 
         return GeocodingResponse.from(response.documents().get(0));

--- a/backend/widyu-api/src/main/java/com/widyu/mypage/application/GuardianMyPageService.java
+++ b/backend/widyu-api/src/main/java/com/widyu/mypage/application/GuardianMyPageService.java
@@ -104,20 +104,22 @@ public class GuardianMyPageService {
     }
 
     private void saveHomeParentLocation(Member seniorMember, String address) {
+        GeocodingResponse geo;
         try {
-            GeocodingResponse geo = geocodingService.geocode(address);
-            parentLocationRepository.save(ParentLocation.builder()
-                    .member(seniorMember)
-                    .locationType(LocationType.HOME)
-                    .placeAddress(address)
-                    .latitude(geo.latitude())
-                    .longitude(geo.longitude())
-                    .name("집")
-                    .status(Status.ACTIVE)
-                    .build());
+            geo = geocodingService.geocode(address);
         } catch (Exception e) {
             log.warn("HOME 안심구역 좌표 변환 실패, 추후 마이페이지에서 수정 필요: {}", address);
+            return;
         }
+        parentLocationRepository.save(ParentLocation.builder()
+                .member(seniorMember)
+                .locationType(LocationType.HOME)
+                .placeAddress(address)
+                .latitude(geo.latitude())
+                .longitude(geo.longitude())
+                .name("집")
+                .status(Status.ACTIVE)
+                .build());
     }
 
     @Transactional

--- a/backend/widyu-api/src/main/java/com/widyu/mypage/application/GuardianMyPageService.java
+++ b/backend/widyu-api/src/main/java/com/widyu/mypage/application/GuardianMyPageService.java
@@ -104,13 +104,7 @@ public class GuardianMyPageService {
     }
 
     private void saveHomeParentLocation(Member seniorMember, String address) {
-        GeocodingResponse geo;
-        try {
-            geo = geocodingService.geocode(address);
-        } catch (Exception e) {
-            log.warn("HOME 안심구역 좌표 변환 실패, 추후 마이페이지에서 수정 필요: {}", address);
-            return;
-        }
+        GeocodingResponse geo = geocodingService.geocode(address);
         parentLocationRepository.save(ParentLocation.builder()
                 .member(seniorMember)
                 .locationType(LocationType.HOME)

--- a/backend/widyu-api/src/main/java/com/widyu/mypage/application/GuardianMyPageService.java
+++ b/backend/widyu-api/src/main/java/com/widyu/mypage/application/GuardianMyPageService.java
@@ -10,15 +10,21 @@ import com.widyu.global.error.BusinessException;
 import com.widyu.global.error.ErrorCode;
 import com.widyu.global.infrastructure.s3.S3Service;
 import com.widyu.global.util.MemberUtil;
+import com.widyu.goal.addressbookmark.application.GeocodingService;
+import com.widyu.goal.addressbookmark.dto.response.GeocodingResponse;
+import com.widyu.location.parentlocation.repository.ParentLocationRepository;
 import com.widyu.member.Family;
 import com.widyu.member.FamilyMembership;
 import com.widyu.member.Member;
 import com.widyu.member.MemberType;
 import com.widyu.member.SeniorProfile;
+import com.widyu.global.entity.Status;
 import com.widyu.member.repository.FamilyMembershipRepository;
 import com.widyu.member.repository.MemberRepository;
 import com.widyu.member.repository.PointHistoryRepository;
 import com.widyu.member.repository.SeniorProfileRepository;
+import com.widyu.parentlocation.LocationType;
+import com.widyu.parentlocation.ParentLocation;
 import com.widyu.mypage.dto.request.UpdateInviteCodeRequest;
 import com.widyu.mypage.dto.request.UpdateNameRequest;
 import com.widyu.mypage.dto.request.UpdatePhoneRequest;
@@ -53,6 +59,8 @@ public class GuardianMyPageService {
     private final SeniorProfileRepository seniorProfileRepository;
     private final MemberRepository memberRepository;
     private final PointHistoryRepository pointHistoryRepository;
+    private final ParentLocationRepository parentLocationRepository;
+    private final GeocodingService geocodingService;
 
     public GuardianInfoResponse getGuardianInfo() {
         Member member = MyPageProfileService.getCurrentMember(memberUtil);
@@ -92,6 +100,24 @@ public class GuardianMyPageService {
                 request.inviteCode(), request.birthDate()
         );
         seniorProfileRepository.save(profile);
+        saveHomeParentLocation(seniorMember, request.address());
+    }
+
+    private void saveHomeParentLocation(Member seniorMember, String address) {
+        try {
+            GeocodingResponse geo = geocodingService.geocode(address);
+            parentLocationRepository.save(ParentLocation.builder()
+                    .member(seniorMember)
+                    .locationType(LocationType.HOME)
+                    .placeAddress(address)
+                    .latitude(geo.latitude())
+                    .longitude(geo.longitude())
+                    .name("집")
+                    .status(Status.ACTIVE)
+                    .build());
+        } catch (Exception e) {
+            log.warn("HOME 안심구역 좌표 변환 실패, 추후 마이페이지에서 수정 필요: {}", address);
+        }
     }
 
     @Transactional
@@ -166,7 +192,25 @@ public class GuardianMyPageService {
         Member guardian = MyPageProfileService.getCurrentMember(memberUtil);
         SeniorProfile seniorProfile = getSeniorProfileWithAccessCheck(memberId, guardian.getId());
         assertIsLeader(seniorProfile, guardian.getId());
+        Member seniorMember = seniorProfile.getMember();
         seniorProfile.updateAddress(request.address());
+        GeocodingResponse geo = geocodingService.geocode(request.address());
+        parentLocationRepository.findByMemberAndLocationType(seniorMember, LocationType.HOME)
+                .ifPresentOrElse(
+                        location -> location.update(
+                                LocationType.HOME, request.address(),
+                                geo.latitude(), geo.longitude(), location.getName()
+                        ),
+                        () -> parentLocationRepository.save(ParentLocation.builder()
+                                .member(seniorMember)
+                                .locationType(LocationType.HOME)
+                                .placeAddress(request.address())
+                                .latitude(geo.latitude())
+                                .longitude(geo.longitude())
+                                .name("집")
+                                .status(Status.ACTIVE)
+                                .build())
+                );
     }
 
     @Transactional

--- a/backend/widyu-api/src/main/java/com/widyu/mypage/dto/request/UpdateSeniorAddressRequest.java
+++ b/backend/widyu-api/src/main/java/com/widyu/mypage/dto/request/UpdateSeniorAddressRequest.java
@@ -1,9 +1,11 @@
 package com.widyu.mypage.dto.request;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Size;
 
 public record UpdateSeniorAddressRequest(
+        @Schema(example = "서울특별시 마포구 성암로 301")
         @NotBlank(message = "주소는 필수입니다.")
         @Size(max = 200, message = "주소는 최대 200자입니다.")
         String address

--- a/backend/widyu-api/src/test/java/com/widyu/auth/application/senior/SeniorAuthServiceTest.java
+++ b/backend/widyu-api/src/test/java/com/widyu/auth/application/senior/SeniorAuthServiceTest.java
@@ -124,8 +124,8 @@ class SeniorAuthServiceTest {
     }
 
     @Test
-    @DisplayName("시니어 일괄 등록 시 지오코딩 실패해도 가입은 성공하고 HOME 저장은 건너뛴다")
-    void 시니어_일괄_등록_시_지오코딩_실패해도_가입은_성공한다() {
+    @DisplayName("시니어 일괄 등록 시 지오코딩 실패하면 가입도 실패한다")
+    void 시니어_일괄_등록_시_지오코딩_실패하면_가입도_실패한다() {
         // given
         Member guardian = Member.createMember(MemberType.GUARDIAN, "보호자", "01099999999");
         ReflectionTestUtils.setField(guardian, "id", 1L);
@@ -144,13 +144,12 @@ class SeniorAuthServiceTest {
         given(memberRepository.saveAll(anyList())).willReturn(List.of(seniorMember));
         given(seniorProfileRepository.saveAll(anyList())).willAnswer(inv -> inv.getArgument(0));
         given(familyMembershipRepository.save(any())).willAnswer(inv -> inv.getArgument(0));
-        given(geocodingService.geocode(anyString())).willThrow(new BusinessException(ErrorCode.BAD_REQUEST, "좌표 없음"));
+        given(geocodingService.geocode(anyString()))
+                .willThrow(new BusinessException(ErrorCode.BAD_REQUEST, "입력한 주소의 좌표를 찾을 수 없습니다. 정확한 도로명주소를 입력해 주세요."));
 
-        // when
-        seniorAuthService.seniorSignUpBulk(requests);
-
-        // then
-        verify(memberRepository).saveAll(anyList());
+        // when & then
+        assertThatThrownBy(() -> seniorAuthService.seniorSignUpBulk(requests))
+                .isInstanceOf(BusinessException.class);
         verify(parentLocationRepository, org.mockito.Mockito.never()).save(any());
     }
 

--- a/backend/widyu-api/src/test/java/com/widyu/auth/application/senior/SeniorAuthServiceTest.java
+++ b/backend/widyu-api/src/test/java/com/widyu/auth/application/senior/SeniorAuthServiceTest.java
@@ -16,6 +16,9 @@ import com.widyu.global.error.BusinessException;
 import com.widyu.global.error.ErrorCode;
 import com.widyu.global.security.JwtTokenProvider;
 import com.widyu.global.util.MemberUtil;
+import com.widyu.goal.addressbookmark.application.GeocodingService;
+import com.widyu.goal.addressbookmark.dto.response.GeocodingResponse;
+import com.widyu.location.parentlocation.repository.ParentLocationRepository;
 import com.widyu.member.Family;
 import com.widyu.member.FamilyMembership;
 import com.widyu.member.Member;
@@ -25,6 +28,7 @@ import com.widyu.member.repository.FamilyMembershipRepository;
 import com.widyu.member.repository.FamilyRepository;
 import com.widyu.member.repository.MemberRepository;
 import com.widyu.member.repository.SeniorProfileRepository;
+import com.widyu.parentlocation.ParentLocation;
 import java.time.LocalDate;
 import java.util.List;
 import java.util.Optional;
@@ -44,6 +48,8 @@ class SeniorAuthServiceTest {
     @Mock private SeniorProfileRepository seniorProfileRepository;
     @Mock private FamilyRepository familyRepository;
     @Mock private FamilyMembershipRepository familyMembershipRepository;
+    @Mock private ParentLocationRepository parentLocationRepository;
+    @Mock private GeocodingService geocodingService;
     @Mock private JwtTokenProvider jwtTokenProvider;
     @Mock private MemberUtil memberUtil;
 
@@ -74,6 +80,7 @@ class SeniorAuthServiceTest {
         given(memberRepository.saveAll(anyList())).willReturn(List.of(seniorMember1, seniorMember2));
         given(seniorProfileRepository.saveAll(anyList())).willAnswer(inv -> inv.getArgument(0));
         given(familyMembershipRepository.save(any())).willAnswer(inv -> inv.getArgument(0));
+        given(geocodingService.geocode(anyString())).willReturn(new GeocodingResponse("37.55", "126.85"));
 
         // when
         seniorAuthService.seniorSignUpBulk(requests);
@@ -82,6 +89,69 @@ class SeniorAuthServiceTest {
         verify(memberRepository).saveAll(anyList());
         verify(seniorProfileRepository).saveAll(anyList());
         verify(familyMembershipRepository).save(any());
+    }
+
+    @Test
+    @DisplayName("시니어 일괄 등록 시 각 시니어의 HOME 안심구역이 생성된다")
+    void 시니어_일괄_등록_시_HOME_안심구역이_생성된다() {
+        // given
+        Member guardian = Member.createMember(MemberType.GUARDIAN, "보호자", "01099999999");
+        ReflectionTestUtils.setField(guardian, "id", 1L);
+
+        Member seniorMember1 = Member.createMember(MemberType.SENIOR, "부모님", "01011112222");
+        Member seniorMember2 = Member.createMember(MemberType.SENIOR, "할머니", "01033334444");
+        Family family = Family.createFamily("ABC123");
+        ReflectionTestUtils.setField(family, "id", 1L);
+
+        List<SeniorSignUpRequest> requests = List.of(
+                new SeniorSignUpRequest("부모님", LocalDate.of(1950, 1, 1), "01011112222", "서울시 강남구", "1234567"),
+                new SeniorSignUpRequest("할머니", LocalDate.of(1948, 2, 2), "01033334444", "서울시 서초구", "7654321")
+        );
+
+        given(memberUtil.getCurrentMember()).willReturn(guardian);
+        given(familyRepository.existsByFamilyCode(anyString())).willReturn(false);
+        given(familyRepository.save(any(Family.class))).willReturn(family);
+        given(memberRepository.saveAll(anyList())).willReturn(List.of(seniorMember1, seniorMember2));
+        given(seniorProfileRepository.saveAll(anyList())).willAnswer(inv -> inv.getArgument(0));
+        given(familyMembershipRepository.save(any())).willAnswer(inv -> inv.getArgument(0));
+        given(geocodingService.geocode(anyString())).willReturn(new GeocodingResponse("37.55", "126.85"));
+
+        // when
+        seniorAuthService.seniorSignUpBulk(requests);
+
+        // then
+        verify(parentLocationRepository, org.mockito.Mockito.times(2)).save(any(ParentLocation.class));
+    }
+
+    @Test
+    @DisplayName("시니어 일괄 등록 시 지오코딩 실패해도 가입은 성공하고 HOME 저장은 건너뛴다")
+    void 시니어_일괄_등록_시_지오코딩_실패해도_가입은_성공한다() {
+        // given
+        Member guardian = Member.createMember(MemberType.GUARDIAN, "보호자", "01099999999");
+        ReflectionTestUtils.setField(guardian, "id", 1L);
+
+        Member seniorMember = Member.createMember(MemberType.SENIOR, "부모님", "01011112222");
+        Family family = Family.createFamily("ABC123");
+        ReflectionTestUtils.setField(family, "id", 1L);
+
+        List<SeniorSignUpRequest> requests = List.of(
+                new SeniorSignUpRequest("부모님", LocalDate.of(1950, 1, 1), "01011112222", "서울시 강남구", "1234567")
+        );
+
+        given(memberUtil.getCurrentMember()).willReturn(guardian);
+        given(familyRepository.existsByFamilyCode(anyString())).willReturn(false);
+        given(familyRepository.save(any(Family.class))).willReturn(family);
+        given(memberRepository.saveAll(anyList())).willReturn(List.of(seniorMember));
+        given(seniorProfileRepository.saveAll(anyList())).willAnswer(inv -> inv.getArgument(0));
+        given(familyMembershipRepository.save(any())).willAnswer(inv -> inv.getArgument(0));
+        given(geocodingService.geocode(anyString())).willThrow(new BusinessException(ErrorCode.BAD_REQUEST, "좌표 없음"));
+
+        // when
+        seniorAuthService.seniorSignUpBulk(requests);
+
+        // then
+        verify(memberRepository).saveAll(anyList());
+        verify(parentLocationRepository, org.mockito.Mockito.never()).save(any());
     }
 
     @Test
@@ -213,6 +283,7 @@ class SeniorAuthServiceTest {
         });
         given(seniorProfileRepository.saveAll(anyList())).willAnswer(inv -> inv.getArgument(0));
         given(familyMembershipRepository.save(any())).willAnswer(inv -> inv.getArgument(0));
+        given(geocodingService.geocode(anyString())).willReturn(new GeocodingResponse("37.55", "126.85"));
 
         // when
         seniorAuthService.seniorSignUpBulk(requests);

--- a/backend/widyu-api/src/test/java/com/widyu/mypage/application/GuardianMyPageServiceTest.java
+++ b/backend/widyu-api/src/test/java/com/widyu/mypage/application/GuardianMyPageServiceTest.java
@@ -219,6 +219,7 @@ class GuardianMyPageServiceTest {
         given(familyMembershipRepository.findByGuardianId(1L)).willReturn(Optional.of(membership));
         given(membership.getFamily()).willReturn(family);
         given(memberRepository.findByPhoneNumber("01011112222")).willReturn(Optional.empty());
+        given(geocodingService.geocode("서울시 강남구")).willReturn(new GeocodingResponse("37.55", "126.85"));
 
         // when
         guardianMyPageService.addSenior(request);
@@ -226,6 +227,7 @@ class GuardianMyPageServiceTest {
         // then
         verify(memberRepository).save(any(Member.class));
         verify(seniorProfileRepository).save(any(SeniorProfile.class));
+        verify(parentLocationRepository).save(any(com.widyu.parentlocation.ParentLocation.class));
     }
 
     @Test

--- a/backend/widyu-api/src/test/java/com/widyu/mypage/application/GuardianMyPageServiceTest.java
+++ b/backend/widyu-api/src/test/java/com/widyu/mypage/application/GuardianMyPageServiceTest.java
@@ -19,6 +19,9 @@ import com.widyu.auth.repository.VerificationCodeRepository;
 import com.widyu.global.error.BusinessException;
 import com.widyu.global.infrastructure.s3.S3Service;
 import com.widyu.global.util.MemberUtil;
+import com.widyu.goal.addressbookmark.application.GeocodingService;
+import com.widyu.goal.addressbookmark.dto.response.GeocodingResponse;
+import com.widyu.location.parentlocation.repository.ParentLocationRepository;
 import com.widyu.member.Family;
 import com.widyu.member.FamilyMembership;
 import com.widyu.member.LocalAccount;
@@ -34,6 +37,8 @@ import com.widyu.mypage.dto.request.UpdateInviteCodeRequest;
 import com.widyu.mypage.dto.request.UpdateNameRequest;
 import com.widyu.mypage.dto.request.UpdatePhoneRequest;
 import com.widyu.mypage.dto.request.UpdateSeniorAddressRequest;
+import com.widyu.parentlocation.LocationType;
+import com.widyu.parentlocation.ParentLocation;
 import com.widyu.mypage.dto.response.ConnectedSeniorResponse;
 import com.widyu.mypage.dto.response.FamilyCodeResponse;
 import com.widyu.mypage.dto.response.FamilyMemberListResponse;
@@ -63,6 +68,8 @@ class GuardianMyPageServiceTest {
     @Mock private SeniorProfileRepository seniorProfileRepository;
     @Mock private MemberRepository memberRepository;
     @Mock private PointHistoryRepository pointHistoryRepository;
+    @Mock private ParentLocationRepository parentLocationRepository;
+    @Mock private GeocodingService geocodingService;
 
     @InjectMocks
     private GuardianMyPageService guardianMyPageService;
@@ -544,10 +551,39 @@ class GuardianMyPageServiceTest {
     // ======================== 시니어 주소 수정 ========================
 
     @Test
-    @DisplayName("시니어 주소를 수정하면 시니어 프로필의 주소가 변경된다")
+    @DisplayName("시니어 주소를 수정하면 시니어 프로필 주소와 HOME 안심구역 좌표가 갱신된다")
     void 시니어_주소_수정() {
         // given
         Member guardian = mock(Member.class);
+        Member seniorMember = mock(Member.class);
+        SeniorProfile seniorProfile = mock(SeniorProfile.class);
+        ParentLocation homeLocation = mock(ParentLocation.class);
+
+        given(memberUtil.getCurrentMember()).willReturn(guardian);
+        given(guardian.getId()).willReturn(1L);
+        given(seniorProfileRepository.findByMemberId(10L)).willReturn(Optional.of(seniorProfile));
+        given(seniorProfile.getId()).willReturn(100L);
+        given(familyMembershipRepository.existsByGuardianIdAndSeniorProfileId(1L, 100L)).willReturn(true);
+        given(familyMembershipRepository.existsByGuardianIdAndSeniorProfileIdAndIsLeaderTrue(1L, 100L)).willReturn(true);
+        given(seniorProfile.getMember()).willReturn(seniorMember);
+        given(geocodingService.geocode("서울시 강서구")).willReturn(new GeocodingResponse("37.55", "126.85"));
+        given(parentLocationRepository.findByMemberAndLocationType(seniorMember, LocationType.HOME))
+                .willReturn(Optional.of(homeLocation));
+
+        // when
+        guardianMyPageService.updateSeniorAddress(10L, new UpdateSeniorAddressRequest("서울시 강서구"));
+
+        // then
+        verify(seniorProfile).updateAddress("서울시 강서구");
+        verify(homeLocation).update(LocationType.HOME, "서울시 강서구", "37.55", "126.85", homeLocation.getName());
+    }
+
+    @Test
+    @DisplayName("시니어 주소를 수정할 때 HOME 안심구역이 없으면 새로 생성된다")
+    void 시니어_주소_수정_HOME_최초_생성() {
+        // given
+        Member guardian = mock(Member.class);
+        Member seniorMember = mock(Member.class);
         SeniorProfile seniorProfile = mock(SeniorProfile.class);
 
         given(memberUtil.getCurrentMember()).willReturn(guardian);
@@ -556,12 +592,16 @@ class GuardianMyPageServiceTest {
         given(seniorProfile.getId()).willReturn(100L);
         given(familyMembershipRepository.existsByGuardianIdAndSeniorProfileId(1L, 100L)).willReturn(true);
         given(familyMembershipRepository.existsByGuardianIdAndSeniorProfileIdAndIsLeaderTrue(1L, 100L)).willReturn(true);
+        given(seniorProfile.getMember()).willReturn(seniorMember);
+        given(geocodingService.geocode("서울시 강서구")).willReturn(new GeocodingResponse("37.55", "126.85"));
+        given(parentLocationRepository.findByMemberAndLocationType(seniorMember, LocationType.HOME))
+                .willReturn(Optional.empty());
 
         // when
         guardianMyPageService.updateSeniorAddress(10L, new UpdateSeniorAddressRequest("서울시 강서구"));
 
         // then
-        verify(seniorProfile).updateAddress("서울시 강서구");
+        verify(parentLocationRepository).save(any(ParentLocation.class));
     }
 
     // ======================== 가족 멤버 목록 조회 ========================


### PR DESCRIPTION
## #️⃣연관된 이슈

- close: #324

## 🪄작업 내용

- `KakaoGeocodingClient` (Feign) + `GeocodingService` 추가 — Kakao Local API로 주소 → 위도·경도 변환 (`oauth.kakao.client-id` 재사용, 별도 키 불필요)
- `AddressSearchResponse.AddressItem`에 `latitude`, `longitude` 추가 — 주소 검색 결과마다 좌표 포함 (변환 실패 항목은 null)
- `SeniorAuthService.seniorSignUpBulk` — 회원가입 시 시니어별 HOME `ParentLocation` 자동 생성, 지오코딩 실패 시 가입 실패
- `GuardianMyPageService.addSenior` — 가족 추가 시 HOME `ParentLocation` 자동 생성, 지오코딩 실패 시 추가 실패
- `GuardianMyPageService.updateSeniorAddress` — 주소 수정 시 지오코딩 후 HOME upsert, 지오코딩 실패 시 수정 실패
- `UpdateSeniorAddressRequest`에서 `latitude`/`longitude` 제거 — 좌표는 서버에서 직접 변환
- 지오코딩 예외 메시지 구체화 (Feign 오류 / 주소 미매칭 2종 분리)

## 💖리뷰 요청사항

- 주소 검색 시 결과 건수(최대 10건)만큼 Kakao API를 순차 호출합니다. 병렬 처리 없이 이 방식이 허용 가능한지 봐주세요.
- 쓰기 경로(등록·수정)는 지오코딩 실패 시 전체 실패로 처리했고, 읽기(검색)는 부분 null로 다르게 처리했습니다. 이 판단이 적절한지 확인 부탁드립니다.

