### PR TITLE
refactor: 위도·경도 타입 String → Double 통일

### DIFF
--- a/backend/widyu-api/src/main/java/com/widyu/global/config/DevDataInitializer.java
+++ b/backend/widyu-api/src/main/java/com/widyu/global/config/DevDataInitializer.java
@@ -242,12 +242,12 @@ public class DevDataInitializer implements CommandLineRunner {
         healthScheduleRepository.save(HealthSchedule.create(
                 senior, "건강검진",
                 "서울시 강남구 테헤란로 123 강남세브란스병원",
-                "37.5013", "127.0262", now.plusWeeks(2)
+                37.5013, 127.0262, now.plusWeeks(2)
         ));
         healthScheduleRepository.save(HealthSchedule.create(
                 senior, "치과 정기검진",
                 "서울시 강남구 역삼동 456 연세치과",
-                "37.4979", "127.0276", now.plusMonths(1)
+                37.4979, 127.0276, now.plusMonths(1)
         ));
     }
 

--- a/backend/widyu-api/src/main/java/com/widyu/goal/addressbookmark/application/AddressSearchService.java
+++ b/backend/widyu-api/src/main/java/com/widyu/goal/addressbookmark/application/AddressSearchService.java
@@ -35,8 +35,8 @@ public class AddressSearchService {
         List<JusoApiResponse.JusoItem> jusoItems = response.results().juso();
         List<AddressItem> addresses = (jusoItems == null) ? List.of() : jusoItems.stream()
                 .map(item -> {
-                    String latitude = null;
-                    String longitude = null;
+                    Double latitude = null;
+                    Double longitude = null;
                     try {
                         GeocodingResponse geo = geocodingService.geocode(item.roadAddr());
                         latitude = geo.latitude();

--- a/backend/widyu-api/src/main/java/com/widyu/goal/addressbookmark/controller/docs/AddressBookmarkDocs.java
+++ b/backend/widyu-api/src/main/java/com/widyu/goal/addressbookmark/controller/docs/AddressBookmarkDocs.java
@@ -33,8 +33,8 @@ public interface AddressBookmarkDocs {
                                 "roadAddress": "서울특별시 마포구 성암로 301",
                                 "address": "서울특별시 마포구 상암동 1595",
                                 "name": "MBC",
-                                "latitude": "37.5789",
-                                "longitude": "126.8912",
+                                "latitude": 37.5789,
+                                "longitude": 126.8912,
                                 "road": "성암로 301",
                                 "jibun": "상암동 1595"
                             }

--- a/backend/widyu-api/src/main/java/com/widyu/goal/addressbookmark/controller/docs/AddressSearchDocs.java
+++ b/backend/widyu-api/src/main/java/com/widyu/goal/addressbookmark/controller/docs/AddressSearchDocs.java
@@ -36,8 +36,8 @@ public interface AddressSearchDocs {
                                             "siNm": "서울특별시",
                                             "sggNm": "마포구",
                                             "emdNm": "상암동",
-                                            "latitude": "37.5666103",
-                                            "longitude": "126.9783882"
+                                            "latitude": 37.5666103,
+                                            "longitude": 126.9783882
                                         }
                                     ],
                                     "totalCount": 1,

--- a/backend/widyu-api/src/main/java/com/widyu/goal/addressbookmark/dto/request/AddressBookmarkCreateRequest.java
+++ b/backend/widyu-api/src/main/java/com/widyu/goal/addressbookmark/dto/request/AddressBookmarkCreateRequest.java
@@ -11,8 +11,8 @@ public record AddressBookmarkCreateRequest(
         @NotBlank(message = "지번 주소는 필수입니다.")
         String address,
         String name,
-        String latitude,
-        String longitude,
+        Double latitude,
+        Double longitude,
         String road,
         String jibun
 ) {

--- a/backend/widyu-api/src/main/java/com/widyu/goal/addressbookmark/dto/response/AddressBookmarkResponse.java
+++ b/backend/widyu-api/src/main/java/com/widyu/goal/addressbookmark/dto/response/AddressBookmarkResponse.java
@@ -13,8 +13,8 @@ public class AddressBookmarkResponse {
     private String roadAddress;
     private String address;
     private String name;
-    private String latitude;
-    private String longitude;
+    private Double latitude;
+    private Double longitude;
     private String road;
     private String jibun;
 

--- a/backend/widyu-api/src/main/java/com/widyu/goal/addressbookmark/dto/response/AddressSearchResponse.java
+++ b/backend/widyu-api/src/main/java/com/widyu/goal/addressbookmark/dto/response/AddressSearchResponse.java
@@ -17,10 +17,10 @@ public record AddressSearchResponse(
             String siNm,
             String sggNm,
             String emdNm,
-            String latitude,
-            String longitude
+            Double latitude,
+            Double longitude
     ) {
-        public static AddressItem from(JusoApiResponse.JusoItem item, String latitude, String longitude) {
+        public static AddressItem from(JusoApiResponse.JusoItem item, Double latitude, Double longitude) {
             return new AddressItem(
                     item.roadAddr(),
                     item.jibunAddr(),

--- a/backend/widyu-api/src/main/java/com/widyu/goal/addressbookmark/dto/response/GeocodingResponse.java
+++ b/backend/widyu-api/src/main/java/com/widyu/goal/addressbookmark/dto/response/GeocodingResponse.java
@@ -3,10 +3,13 @@ package com.widyu.goal.addressbookmark.dto.response;
 import com.widyu.goal.addressbookmark.dto.external.KakaoGeocodingResponse;
 
 public record GeocodingResponse(
-        String latitude,
-        String longitude
+        Double latitude,
+        Double longitude
 ) {
     public static GeocodingResponse from(KakaoGeocodingResponse.Document document) {
-        return new GeocodingResponse(document.latitude(), document.longitude());
+        return new GeocodingResponse(
+                Double.parseDouble(document.latitude()),
+                Double.parseDouble(document.longitude())
+        );
     }
 }

--- a/backend/widyu-api/src/main/java/com/widyu/goal/healthschedule/controller/docs/HealthScheduleDocs.java
+++ b/backend/widyu-api/src/main/java/com/widyu/goal/healthschedule/controller/docs/HealthScheduleDocs.java
@@ -40,8 +40,8 @@ public interface HealthScheduleDocs {
                                     {
                                       "scheduleName": "정기 건강검진",
                                       "placeAddress": "서울대학교병원",
-                                      "latitude": "37.5665",
-                                      "longitude": "126.9780",
+                                      "latitude": 37.5665,
+                                      "longitude": 126.9780,
                                       "scheduledAt": "2025-11-15T14:30:00"
                                     }
                                     """
@@ -89,8 +89,8 @@ public interface HealthScheduleDocs {
                                       "memberId": 1,
                                       "scheduleName": "정기 건강검진",
                                       "placeAddress": "서울대학교병원",
-                                      "latitude": "37.5665",
-                                      "longitude": "126.9780",
+                                      "latitude": 37.5665,
+                                      "longitude": 126.9780,
                                       "scheduledAt": "2025-11-15T14:30:00"
                                     }
                                     """
@@ -140,8 +140,8 @@ public interface HealthScheduleDocs {
                                     {
                                       "scheduleName": "정기 건강검진 (수정)",
                                       "placeAddress": "강남세브란스병원",
-                                      "latitude": "37.5665",
-                                      "longitude": "126.9780",
+                                      "latitude": 37.5665,
+                                      "longitude": 126.9780,
                                       "scheduledAt": "2025-11-20T10:00:00",
                                       "progressStatus": "UPCOMING"
                                     }
@@ -392,16 +392,16 @@ public interface HealthScheduleDocs {
                                             "datetime": "2025-11-01T14:30:00",
                                             "healthScheduleId": 1,
                                             "position": {
-                                              "lat": "37.5665",
-                                              "lon": "126.9780"
+                                              "lat": 37.5665,
+                                              "lon": 126.9780
                                             }
                                           },
                                           {
                                             "datetime": "2025-11-05T10:00:00",
                                             "healthScheduleId": 2,
                                             "position": {
-                                              "lat": "37.5665",
-                                              "lon": "126.9780"
+                                              "lat": 37.5665,
+                                              "lon": 126.9780
                                             }
                                           }
                                         ]

--- a/backend/widyu-api/src/main/java/com/widyu/goal/healthschedule/dto/request/HealthScheduleCreateForSeniorRequest.java
+++ b/backend/widyu-api/src/main/java/com/widyu/goal/healthschedule/dto/request/HealthScheduleCreateForSeniorRequest.java
@@ -12,8 +12,8 @@ public record HealthScheduleCreateForSeniorRequest(
         String scheduleName,
 
         String placeAddress,
-        String latitude,
-        String longitude,
+        Double latitude,
+        Double longitude,
 
         @NotNull(message = "일정 날짜는 필수입니다.")
         LocalDateTime scheduledAt

--- a/backend/widyu-api/src/main/java/com/widyu/goal/healthschedule/dto/request/HealthScheduleCreateRequest.java
+++ b/backend/widyu-api/src/main/java/com/widyu/goal/healthschedule/dto/request/HealthScheduleCreateRequest.java
@@ -9,8 +9,8 @@ public record HealthScheduleCreateRequest(
         String scheduleName,
 
         String placeAddress,
-        String latitude,
-        String longitude,
+        Double latitude,
+        Double longitude,
 
         @NotNull(message = "일정 날짜는 필수입니다.")
         LocalDateTime scheduledAt

--- a/backend/widyu-api/src/main/java/com/widyu/goal/healthschedule/dto/request/HealthScheduleUpdateRequest.java
+++ b/backend/widyu-api/src/main/java/com/widyu/goal/healthschedule/dto/request/HealthScheduleUpdateRequest.java
@@ -6,8 +6,8 @@ import java.time.LocalDateTime;
 public record HealthScheduleUpdateRequest(
         String scheduleName,
         String placeAddress,
-        String latitude,
-        String longitude,
+        Double latitude,
+        Double longitude,
         LocalDateTime scheduledAt,
         ProgressStatus progressStatus
 ) {

--- a/backend/widyu-api/src/main/java/com/widyu/goal/healthschedule/dto/response/HealthScheduleResponse.java
+++ b/backend/widyu-api/src/main/java/com/widyu/goal/healthschedule/dto/response/HealthScheduleResponse.java
@@ -7,8 +7,8 @@ public record HealthScheduleResponse(
         String scheduleName,
         LocalDateTime scheduledAt,
         String placeAddress,
-        String latitude,
-        String longitude
+        Double latitude,
+        Double longitude
 ) {
 
     public static HealthScheduleResponse from(HealthSchedule healthSchedule) {

--- a/backend/widyu-api/src/main/java/com/widyu/goal/healthschedule/dto/response/Position.java
+++ b/backend/widyu-api/src/main/java/com/widyu/goal/healthschedule/dto/response/Position.java
@@ -1,10 +1,10 @@
 package com.widyu.goal.healthschedule.dto.response;
 
 public record Position(
-        String lat,
-        String lon
+        Double lat,
+        Double lon
 ) {
-    public static Position of(String latitude, String longitude) {
+    public static Position of(Double latitude, Double longitude) {
         return new Position(latitude, longitude);
     }
 }

--- a/backend/widyu-api/src/main/java/com/widyu/location/parentlocation/controller/docs/ParentLocationDocs.java
+++ b/backend/widyu-api/src/main/java/com/widyu/location/parentlocation/controller/docs/ParentLocationDocs.java
@@ -33,8 +33,8 @@ public interface ParentLocationDocs {
                       "memberId": 1,
                       "locationType": "HOME",
                       "placeAddress": "서울특별시 강남구 테헤란로 123",
-                      "latitude": "37.5012",
-                      "longitude": "127.0396",
+                      "latitude": 37.5012,
+                      "longitude": 127.0396,
                       "name": "우리집"
                     }
                     """
@@ -109,16 +109,16 @@ public interface ParentLocationDocs {
                               "parentLocationId": 1,
                               "locationType": "HOME",
                               "placeAddress": "서울특별시 강남구 테헤란로 123",
-                              "latitude": "37.5012",
-                              "longitude": "127.0396",
+                              "latitude": 37.5012,
+                              "longitude": 127.0396,
                               "name": "우리집"
                             },
                             {
                               "parentLocationId": 2,
                               "locationType": "OTHER",
                               "placeAddress": "서울특별시 마포구 월드컵북로 123",
-                              "latitude": "37.5665",
-                              "longitude": "126.9780",
+                              "latitude": 37.5665,
+                              "longitude": 126.9780,
                               "name": "병원"
                             }
                           ]
@@ -131,8 +131,8 @@ public interface ParentLocationDocs {
                               "parentLocationId": 3,
                               "locationType": "HOME",
                               "placeAddress": "서울특별시 송파구 올림픽로 456",
-                              "latitude": "37.5145",
-                              "longitude": "127.1059",
+                              "latitude": 37.5145,
+                              "longitude": 127.1059,
                               "name": "집"
                             }
                           ]
@@ -161,8 +161,8 @@ public interface ParentLocationDocs {
                       "memberId": 1,
                       "locationType": "HOME",
                       "placeAddress": "서울특별시 강남구 테헤란로 456",
-                      "latitude": "37.5015",
-                      "longitude": "127.0400",
+                      "latitude": 37.5015,
+                      "longitude": 127.0400,
                       "name": "새집"
                     }
                     """

--- a/backend/widyu-api/src/main/java/com/widyu/location/parentlocation/dto/request/ParentLocationCreateRequest.java
+++ b/backend/widyu-api/src/main/java/com/widyu/location/parentlocation/dto/request/ParentLocationCreateRequest.java
@@ -14,10 +14,10 @@ public record ParentLocationCreateRequest(
     LocationType locationType,
     @NotBlank(message = "장소 주소는 필수입니다.")
     String placeAddress,
-    @NotBlank(message = "위도는 필수입니다.")
-    String latitude,
-    @NotBlank(message = "경도는 필수입니다.")
-    String longitude,
+    @NotNull(message = "위도는 필수입니다.")
+    Double latitude,
+    @NotNull(message = "경도는 필수입니다.")
+    Double longitude,
     String name
 ) {
     public ParentLocation toEntity(Member seniorMember) {

--- a/backend/widyu-api/src/main/java/com/widyu/location/parentlocation/dto/request/ParentLocationUpdateRequest.java
+++ b/backend/widyu-api/src/main/java/com/widyu/location/parentlocation/dto/request/ParentLocationUpdateRequest.java
@@ -11,10 +11,10 @@ public record ParentLocationUpdateRequest(
     LocationType locationType,
     @NotBlank(message = "장소 주소는 필수입니다.")
     String placeAddress,
-    @NotBlank(message = "위도는 필수입니다.")
-    String latitude,
-    @NotBlank(message = "경도는 필수입니다.")
-    String longitude,
+    @NotNull(message = "위도는 필수입니다.")
+    Double latitude,
+    @NotNull(message = "경도는 필수입니다.")
+    Double longitude,
     String name
 ) {
 }

--- a/backend/widyu-api/src/main/java/com/widyu/location/parentlocation/dto/response/LocationInfo.java
+++ b/backend/widyu-api/src/main/java/com/widyu/location/parentlocation/dto/response/LocationInfo.java
@@ -13,8 +13,8 @@ public class LocationInfo {
     private Long parentLocationId;
     private LocationType locationType;
     private String placeAddress;
-    private String latitude;
-    private String longitude;
+    private Double latitude;
+    private Double longitude;
     private String name;
 
     public static LocationInfo of(ParentLocation parentLocation) {

--- a/backend/widyu-api/src/main/java/com/widyu/location/parentlocation/dto/response/ParentLocationResponse.java
+++ b/backend/widyu-api/src/main/java/com/widyu/location/parentlocation/dto/response/ParentLocationResponse.java
@@ -15,8 +15,8 @@ public class ParentLocationResponse {
     private String memberName;
     private LocationType locationType;
     private String placeAddress;
-    private String latitude;
-    private String longitude;
+    private Double latitude;
+    private Double longitude;
 
     public static ParentLocationResponse of(ParentLocation parentLocation) {
         return ParentLocationResponse.builder()

--- a/backend/widyu-api/src/main/java/com/widyu/location/realtime/application/RealtimeLocationService.java
+++ b/backend/widyu-api/src/main/java/com/widyu/location/realtime/application/RealtimeLocationService.java
@@ -281,8 +281,8 @@ public class RealtimeLocationService {
         List<ParentLocation> safeZones = parentLocationRepository.findAllByMember(member);
 
         for (ParentLocation safeZone : safeZones) {
-            double zoneLat = Double.parseDouble(safeZone.getLatitude());
-            double zoneLng = Double.parseDouble(safeZone.getLongitude());
+            double zoneLat = safeZone.getLatitude();
+            double zoneLng = safeZone.getLongitude();
 
             boolean isWithinSafeZone = GeoUtils.isWithinRadius(lat, lng, zoneLat, zoneLng, SAFE_ZONE_RADIUS_METERS);
 

--- a/backend/widyu-api/src/test/java/com/widyu/auth/application/senior/SeniorAuthServiceTest.java
+++ b/backend/widyu-api/src/test/java/com/widyu/auth/application/senior/SeniorAuthServiceTest.java
@@ -80,7 +80,7 @@ class SeniorAuthServiceTest {
         given(memberRepository.saveAll(anyList())).willReturn(List.of(seniorMember1, seniorMember2));
         given(seniorProfileRepository.saveAll(anyList())).willAnswer(inv -> inv.getArgument(0));
         given(familyMembershipRepository.save(any())).willAnswer(inv -> inv.getArgument(0));
-        given(geocodingService.geocode(anyString())).willReturn(new GeocodingResponse("37.55", "126.85"));
+        given(geocodingService.geocode(anyString())).willReturn(new GeocodingResponse(37.55, 126.85));
 
         // when
         seniorAuthService.seniorSignUpBulk(requests);
@@ -114,7 +114,7 @@ class SeniorAuthServiceTest {
         given(memberRepository.saveAll(anyList())).willReturn(List.of(seniorMember1, seniorMember2));
         given(seniorProfileRepository.saveAll(anyList())).willAnswer(inv -> inv.getArgument(0));
         given(familyMembershipRepository.save(any())).willAnswer(inv -> inv.getArgument(0));
-        given(geocodingService.geocode(anyString())).willReturn(new GeocodingResponse("37.55", "126.85"));
+        given(geocodingService.geocode(anyString())).willReturn(new GeocodingResponse(37.55, 126.85));
 
         // when
         seniorAuthService.seniorSignUpBulk(requests);
@@ -282,7 +282,7 @@ class SeniorAuthServiceTest {
         });
         given(seniorProfileRepository.saveAll(anyList())).willAnswer(inv -> inv.getArgument(0));
         given(familyMembershipRepository.save(any())).willAnswer(inv -> inv.getArgument(0));
-        given(geocodingService.geocode(anyString())).willReturn(new GeocodingResponse("37.55", "126.85"));
+        given(geocodingService.geocode(anyString())).willReturn(new GeocodingResponse(37.55, 126.85));
 
         // when
         seniorAuthService.seniorSignUpBulk(requests);

--- a/backend/widyu-api/src/test/java/com/widyu/goal/addressbookmark/application/GeocodingServiceTest.java
+++ b/backend/widyu-api/src/test/java/com/widyu/goal/addressbookmark/application/GeocodingServiceTest.java
@@ -44,8 +44,8 @@ class GeocodingServiceTest {
         GeocodingResponse result = geocodingService.geocode("서울특별시 마포구 성암로 301");
 
         // then
-        assertThat(result.latitude()).isEqualTo("37.5666103");
-        assertThat(result.longitude()).isEqualTo("126.9783882");
+        assertThat(result.latitude()).isEqualTo(37.5666103);
+        assertThat(result.longitude()).isEqualTo(126.9783882);
     }
 
     @Test

--- a/backend/widyu-api/src/test/java/com/widyu/mypage/application/GuardianMyPageServiceTest.java
+++ b/backend/widyu-api/src/test/java/com/widyu/mypage/application/GuardianMyPageServiceTest.java
@@ -219,7 +219,7 @@ class GuardianMyPageServiceTest {
         given(familyMembershipRepository.findByGuardianId(1L)).willReturn(Optional.of(membership));
         given(membership.getFamily()).willReturn(family);
         given(memberRepository.findByPhoneNumber("01011112222")).willReturn(Optional.empty());
-        given(geocodingService.geocode("서울시 강남구")).willReturn(new GeocodingResponse("37.55", "126.85"));
+        given(geocodingService.geocode("서울시 강남구")).willReturn(new GeocodingResponse(37.55, 126.85));
 
         // when
         guardianMyPageService.addSenior(request);
@@ -568,7 +568,7 @@ class GuardianMyPageServiceTest {
         given(familyMembershipRepository.existsByGuardianIdAndSeniorProfileId(1L, 100L)).willReturn(true);
         given(familyMembershipRepository.existsByGuardianIdAndSeniorProfileIdAndIsLeaderTrue(1L, 100L)).willReturn(true);
         given(seniorProfile.getMember()).willReturn(seniorMember);
-        given(geocodingService.geocode("서울시 강서구")).willReturn(new GeocodingResponse("37.55", "126.85"));
+        given(geocodingService.geocode("서울시 강서구")).willReturn(new GeocodingResponse(37.55, 126.85));
         given(parentLocationRepository.findByMemberAndLocationType(seniorMember, LocationType.HOME))
                 .willReturn(Optional.of(homeLocation));
 
@@ -577,7 +577,7 @@ class GuardianMyPageServiceTest {
 
         // then
         verify(seniorProfile).updateAddress("서울시 강서구");
-        verify(homeLocation).update(LocationType.HOME, "서울시 강서구", "37.55", "126.85", homeLocation.getName());
+        verify(homeLocation).update(LocationType.HOME, "서울시 강서구", 37.55, 126.85, homeLocation.getName());
     }
 
     @Test
@@ -595,7 +595,7 @@ class GuardianMyPageServiceTest {
         given(familyMembershipRepository.existsByGuardianIdAndSeniorProfileId(1L, 100L)).willReturn(true);
         given(familyMembershipRepository.existsByGuardianIdAndSeniorProfileIdAndIsLeaderTrue(1L, 100L)).willReturn(true);
         given(seniorProfile.getMember()).willReturn(seniorMember);
-        given(geocodingService.geocode("서울시 강서구")).willReturn(new GeocodingResponse("37.55", "126.85"));
+        given(geocodingService.geocode("서울시 강서구")).willReturn(new GeocodingResponse(37.55, 126.85));
         given(parentLocationRepository.findByMemberAndLocationType(seniorMember, LocationType.HOME))
                 .willReturn(Optional.empty());
 

--- a/backend/widyu-domain/src/main/java/com/widyu/addressbookmark/AddressBookmark.java
+++ b/backend/widyu-domain/src/main/java/com/widyu/addressbookmark/AddressBookmark.java
@@ -46,9 +46,9 @@ public class AddressBookmark extends BaseTimeEntity {
 
     private String name;
 
-    private String latitude;
+    private Double latitude;
 
-    private String longitude;
+    private Double longitude;
 
     private String road;
 

--- a/backend/widyu-domain/src/main/java/com/widyu/healthschedule/HealthSchedule.java
+++ b/backend/widyu-domain/src/main/java/com/widyu/healthschedule/HealthSchedule.java
@@ -44,10 +44,10 @@ public class HealthSchedule extends BaseTimeEntity {
     private String placeAddress;
 
     @Column(name = "latitude")
-    private String latitude;
+    private Double latitude;
 
     @Column(name = "longitude")
-    private String longitude;
+    private Double longitude;
 
     @Column(name = "scheduled_at", nullable = false)
     private LocalDateTime scheduledAt;
@@ -67,8 +67,8 @@ public class HealthSchedule extends BaseTimeEntity {
     private Status status = Status.ACTIVE;
 
     @Builder(access = AccessLevel.PRIVATE)
-    private HealthSchedule(Member member, String scheduleName, String placeAddress, String latitude,
-                          String longitude, LocalDateTime scheduledAt, ProgressStatus progressStatus,
+    private HealthSchedule(Member member, String scheduleName, String placeAddress, Double latitude,
+                          Double longitude, LocalDateTime scheduledAt, ProgressStatus progressStatus,
                           Integer rewardPoint, Boolean isReward, Status status) {
         this.member = member;
         this.scheduleName = scheduleName;
@@ -82,8 +82,8 @@ public class HealthSchedule extends BaseTimeEntity {
         this.status = status != null ? status : Status.ACTIVE;
     }
 
-    public static HealthSchedule create(Member member, String scheduleName, String placeAddress, String latitude,
-                                       String longitude, LocalDateTime scheduledAt) {
+    public static HealthSchedule create(Member member, String scheduleName, String placeAddress, Double latitude,
+                                       Double longitude, LocalDateTime scheduledAt) {
         return HealthSchedule.builder()
                 .member(member)
                 .scheduleName(scheduleName)
@@ -94,8 +94,8 @@ public class HealthSchedule extends BaseTimeEntity {
                 .build();
     }
 
-    public void update(String scheduleName, String placeAddress, String latitude,
-                      String longitude, LocalDateTime scheduledAt, ProgressStatus progressStatus) {
+    public void update(String scheduleName, String placeAddress, Double latitude,
+                      Double longitude, LocalDateTime scheduledAt, ProgressStatus progressStatus) {
         if (scheduleName != null) {
             this.scheduleName = scheduleName;
         }

--- a/backend/widyu-domain/src/main/java/com/widyu/parentlocation/ParentLocation.java
+++ b/backend/widyu-domain/src/main/java/com/widyu/parentlocation/ParentLocation.java
@@ -47,17 +47,17 @@ public class ParentLocation extends BaseTimeEntity {
     private String placeAddress;
 
     @Column(nullable = false)
-    private String latitude;
+    private Double latitude;
 
     @Column(nullable = false)
-    private String longitude;
+    private Double longitude;
 
     private String name;
 
     @Enumerated(EnumType.STRING)
     private Status status;
 
-    public void update(LocationType locationType, String placeAddress, String latitude, String longitude, String name) {
+    public void update(LocationType locationType, String placeAddress, Double latitude, Double longitude, String name) {
         this.locationType = locationType;
         this.placeAddress = placeAddress;
         this.latitude = latitude;


### PR DESCRIPTION
## #️⃣연관된 이슈

- close: #327

## 🪄작업 내용

카카오 지오코딩 API가 위도·경도를 문자열로 반환하기 때문에 엔티티·DTO 전반에서 `String`으로 사용되던 좌표 타입을 `Double`로 일관 변경했습니다.

- `GeocodingResponse.from()`에서 `Double.parseDouble()`로 한 번만 파싱 — 이후 레이어는 `Double` 그대로 사용
- 엔티티 (`ParentLocation`, `AddressBookmark`, `HealthSchedule`) `String → Double`
- Request DTO (`ParentLocationCreateRequest/UpdateRequest`) `@NotBlank → @NotNull`, 타입 변경
- Request DTO (`AddressBookmarkCreateRequest`, `HealthScheduleCreateRequest/UpdateRequest/CreateForSeniorRequest`) 타입 변경
- Response DTO (`LocationInfo`, `ParentLocationResponse`, `AddressBookmarkResponse`, `AddressSearchResponse`, `HealthScheduleResponse`, `Position`) 타입 변경
- `RealtimeLocationService`: 이미 `Double`이 된 필드에 남아 있던 `Double.parseDouble()` 제거
- Swagger `@ExampleObject` JSON 예시 내 좌표값 `"37.5665"` → `37.5665` (quote 제거)
- 테스트 픽스처·assertions 타입 일치 수정

**의도적으로 유지한 것**
- `KakaoGeocodingResponse.Document`: 외부 API 스펙이므로 `String` 유지
- `AddressBookmarkCreateRequest`, `HealthScheduleCreateRequest`, `HealthScheduleCreateForSeniorRequest`의 좌표 `@NotNull` 미추가 — geocoding 실패 시 null 허용, 엔티티도 nullable 컬럼
- `HealthScheduleUpdateRequest`의 좌표 `@NotNull` 미추가 — partial update이므로 null = 기존 값 유지

**DB 마이그레이션 (배포 전 수동 실행 필요)**
```sql
ALTER TABLE parent_location MODIFY COLUMN latitude DOUBLE NOT NULL, MODIFY COLUMN longitude DOUBLE NOT NULL;
ALTER TABLE address_bookmark MODIFY COLUMN latitude DOUBLE, MODIFY COLUMN longitude DOUBLE;
ALTER TABLE health_schedule MODIFY COLUMN latitude DOUBLE, MODIFY COLUMN longitude DOUBLE;
```

## 💖리뷰 요청사항

- `GeocodingResponse.from()` 한 곳에서만 파싱하는 방향이 맞는지 확인 부탁드립니다.