### PR TITLE
fix: Docker JAVA_OPTS가 JVM에 적용되지 않는 문제 수정

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -35,9 +35,12 @@ COPY --from=builder /app/backend/widyu-api/build/libs/*.jar app.jar
 # Expose application port
 EXPOSE 8080
 
+# Default JVM options (overridden by JAVA_OPTS env var in compose)
+ENV JAVA_OPTS="-XX:+UseContainerSupport -XX:MaxRAMPercentage=75.0 -Djava.security.egd=file:/dev/./urandom"
+
 # Health check (exec form)
 HEALTHCHECK --interval=30s --timeout=3s --start-period=40s --retries=3 \
     CMD ["wget", "--no-verbose", "--tries=1", "--spider", "http://localhost:8080/actuator/health"]
 
-# Run the application (exec form for proper signal handling)
-ENTRYPOINT ["java", "-XX:+UseContainerSupport", "-XX:MaxRAMPercentage=75.0", "-Djava.security.egd=file:/dev/./urandom", "-jar", "app.jar"]
+# exec guarantees java becomes PID 1 → SIGTERM handled correctly
+ENTRYPOINT ["sh", "-c", "exec java $JAVA_OPTS -jar app.jar"]

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -37,11 +37,16 @@ services:
     container_name: widyu-api-dev
     environment:
       SPRING_PROFILES_ACTIVE: dev
+      # JVM Options (개발 환경) - Dockerfile ENV JAVA_OPTS 기본값을 완전히 대체
       JAVA_OPTS: >
+        -XX:+UseContainerSupport
         -Xms512m
         -Xmx1024m
         -XX:+UseG1GC
         -XX:MaxGCPauseMillis=200
+        -Dfile.encoding=UTF-8
+        -Duser.timezone=Asia/Seoul
+        -Djava.security.egd=file:/dev/./urandom
     ports:
       - "8080:8080"
     depends_on:

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -16,8 +16,9 @@ services:
       MYSQL_USERNAME: ${RDS_USERNAME}
       MYSQL_PASSWORD: ${RDS_PASSWORD}
 
-      # JVM Options (운영 환경)
+      # JVM Options (운영 환경) - Dockerfile ENV JAVA_OPTS 기본값을 완전히 대체
       JAVA_OPTS: >
+        -XX:+UseContainerSupport
         -Xms1024m
         -Xmx2048m
         -XX:+UseG1GC
@@ -26,6 +27,7 @@ services:
         -XX:HeapDumpPath=/app/logs/heap_dump.hprof
         -Dfile.encoding=UTF-8
         -Duser.timezone=Asia/Seoul
+        -Djava.security.egd=file:/dev/./urandom
 
     ports:
       - "8080:8080"


### PR DESCRIPTION
## #️⃣연관된 이슈

- close: #329

## 🪄작업 내용

`docker-compose.prod.yml`, `docker-compose.dev.yml`에 `JAVA_OPTS`로 JVM 옵션을 주입하고 있었지만, Dockerfile ENTRYPOINT가 exec-form(`["java", ...]`)이라 쉘을 거치지 않아 `$JAVA_OPTS` 치환이 발생하지 않았습니다. 운영 heap 설정, GC 튜닝, 타임존 등 compose에서 설정한 모든 JVM 옵션이 무시되고 있었습니다.

**변경 내용**

- `Dockerfile`
  - `ENV JAVA_OPTS` 기본값 추가 (`-XX:+UseContainerSupport -XX:MaxRAMPercentage=75.0 -Djava.security.egd=...`) — compose 없이 단독 실행 시에도 기본 옵션 보장
  - ENTRYPOINT를 `["sh", "-c", "exec java $JAVA_OPTS -jar app.jar"]`로 변경
  - `exec` 사용으로 java가 PID 1 유지 → SIGTERM 정상 전달

- `docker-compose.prod.yml` / `docker-compose.dev.yml`
  - compose `JAVA_OPTS`는 Dockerfile `ENV`를 완전히 대체하므로 기존에 Dockerfile에만 있던 `-XX:+UseContainerSupport`, `-Djava.security.egd=file:/dev/./urandom` 추가
  - `-Dfile.encoding=UTF-8`, `-Duser.timezone=Asia/Seoul` dev 환경에도 추가

**의도적으로 유지한 것**
- `JAVA_TOOL_OPTIONS` 대신 `JAVA_OPTS` + shell-form 유지 — 기존 compose 키 이름 그대로, 명시적으로 어떤 옵션이 들어가는지 파악 가능

## 💖리뷰 요청사항

- compose `JAVA_OPTS`가 Dockerfile `ENV JAVA_OPTS`를 완전히 덮어쓰는 구조라 두 곳에서 옵션을 관리해야 합니다. 환경별로 다른 옵션이 필요한 구조라면 현재 방식이 맞지만, 공통 옵션이 늘어나면 중복 관리가 번거로울 수 있는 트레이드오프가 있습니다.