### PR TITLE
refactor: PaymentProperties 위치를 pay/config로 이동

### DIFF
--- a/backend/widyu-api/src/main/java/com/widyu/pay/config/PaymentAuthInterceptor.java
+++ b/backend/widyu-api/src/main/java/com/widyu/pay/config/PaymentAuthInterceptor.java
@@ -1,6 +1,6 @@
 package com.widyu.pay.config;
 
-import com.widyu.pay.dto.request.PaymentProperties;
+import com.widyu.pay.config.PaymentProperties;
 import feign.RequestInterceptor;
 import feign.RequestTemplate;
 import java.nio.charset.StandardCharsets;

--- a/backend/widyu-api/src/main/java/com/widyu/pay/config/PaymentFeignConfig.java
+++ b/backend/widyu-api/src/main/java/com/widyu/pay/config/PaymentFeignConfig.java
@@ -1,6 +1,6 @@
 package com.widyu.pay.config;
 
-import com.widyu.pay.dto.request.PaymentProperties;
+import com.widyu.pay.config.PaymentProperties;
 import feign.Request;
 import java.util.concurrent.TimeUnit;
 import org.springframework.context.annotation.Bean;

--- a/backend/widyu-api/src/main/java/com/widyu/pay/config/PaymentProperties.java
+++ b/backend/widyu-api/src/main/java/com/widyu/pay/config/PaymentProperties.java
@@ -1,4 +1,4 @@
-package com.widyu.pay.dto.request;
+package com.widyu.pay.config;
 
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.context.annotation.Configuration;


### PR DESCRIPTION
## #️⃣연관된 이슈

- close: #331

## 🪄작업 내용

`@ConfigurationProperties`로 YAML 설정을 바인딩하는 `PaymentProperties`가 `pay/dto/request/`에 위치해 패키지 의도와 맞지 않는 문제를 수정했습니다.

- `PaymentProperties` 파일을 `pay/dto/request/` → `pay/config/`로 이동, 패키지 선언 수정
- 참조 중인 `PaymentFeignConfig`, `PaymentAuthInterceptor`의 import 경로 수정

## 💖리뷰 요청사항

