### PR TITLE
refactor: widyu-domain에서 Spring Boot 플러그인 제거, 순수 java-library 모듈로 정리 (#333)

### DIFF
--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -1,9 +1,4 @@
 // 부모 모듈 - 실행되지 않음
-bootJar {
-    enabled = false
-}
-
 jar {
-    enabled = true
-    archiveClassifier = ''
+    enabled = false
 }

--- a/backend/widyu-domain/build.gradle
+++ b/backend/widyu-domain/build.gradle
@@ -1,71 +1,36 @@
 plugins {
-	id 'java-library'
-	id 'org.springframework.boot' version '3.3.5'
-	id 'io.spring.dependency-management' version '1.1.7'
+    id 'java-library'
 }
 
 group = 'widyu.com'
 version = '0.0.1-SNAPSHOT'
 description = 'widyu-domain'
 
-java {
-	toolchain {
-		languageVersion = JavaLanguageVersion.of(21)
-	}
-}
-
 configurations {
-	compileOnly {
-		extendsFrom annotationProcessor
-	}
-}
-
-repositories {
-	mavenCentral()
+    compileOnly {
+        extendsFrom annotationProcessor
+    }
 }
 
 dependencies {
-	// JPA & Database
-	api 'org.springframework.boot:spring-boot-starter-data-jpa'
-	
-	// QueryDSL
-	api 'com.querydsl:querydsl-jpa:5.0.0:jakarta'
-	annotationProcessor 'com.querydsl:querydsl-apt:5.0.0:jakarta'
-	annotationProcessor 'jakarta.annotation:jakarta.annotation-api'
-	annotationProcessor 'jakarta.persistence:jakarta.persistence-api'
-	
-	// Redis
-	api 'org.springframework.boot:spring-boot-starter-data-redis'
-	
-	// Spring Web (needed for HttpStatus)
-	api 'org.springframework.boot:spring-boot-starter-web'
-	
-	// Lombok
-	compileOnly 'org.projectlombok:lombok'
-	annotationProcessor 'org.projectlombok:lombok'
-	
-	// Test
-	testImplementation 'org.springframework.boot:spring-boot-starter-test'
-	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+    api 'org.springframework.boot:spring-boot-starter-data-jpa'
+    api 'org.springframework.boot:spring-boot-starter-data-redis'
+    api 'org.springframework.boot:spring-boot-starter-web'
+    api 'com.querydsl:querydsl-jpa:5.0.0:jakarta'
+    annotationProcessor 'com.querydsl:querydsl-apt:5.0.0:jakarta'
+    annotationProcessor 'jakarta.annotation:jakarta.annotation-api'
+    annotationProcessor 'jakarta.persistence:jakarta.persistence-api'
+    compileOnly 'org.projectlombok:lombok'
+    annotationProcessor 'org.projectlombok:lombok'
+    testImplementation 'org.springframework.boot:spring-boot-starter-test'
+    testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 }
 
 tasks.named('test') {
-	useJUnitPlatform()
+    useJUnitPlatform()
 }
 
-// bootJar를 비활성화하여 plain jar 생성
 jar {
-	enabled = true
-	archiveClassifier = ''
-}
-
-bootJar {
-	enabled = false
-}
-
-// Spring Boot 플러그인 구성 오버라이드 
-tasks.configureEach { task ->
-    if (task.name == 'bootJar') {
-        task.enabled = false
-    }
+    enabled = true
+    archiveClassifier = ''
 }

--- a/build.gradle
+++ b/build.gradle
@@ -22,28 +22,21 @@ allprojects {
 
 subprojects {
     apply plugin: 'java'
-    apply plugin: 'org.springframework.boot'
     apply plugin: 'io.spring.dependency-management'
-    
+
     group = 'widyu.com'
     version = '0.0.1-SNAPSHOT'
-    
+
     java {
         toolchain {
             languageVersion = JavaLanguageVersion.of(21)
         }
     }
-    
+
     dependencyManagement {
         imports {
+            mavenBom "org.springframework.boot:spring-boot-dependencies:3.3.5"
             mavenBom "org.springframework.cloud:spring-cloud-dependencies:2023.0.1"
         }
-    }
-}
-
-// 루트 프로젝트는 실행 가능한 JAR가 아니므로 bootJar 비활성화
-tasks.whenTaskAdded { task ->
-    if (task.name == 'bootJar') {
-        task.enabled = false
     }
 }


### PR DESCRIPTION
## #️⃣연관된 이슈

- close: #333

## 🪄작업 내용

- `build.gradle` (root): `subprojects`에서 `apply plugin: 'org.springframework.boot'` 제거, Spring Boot BOM을 `dependencyManagement`에 명시적으로 추가, `tasks.whenTaskAdded { bootJar }` 우회 코드 제거
- `backend/build.gradle`: `bootJar { enabled = false }` 제거 — Spring Boot plugin이 없으면 bootJar task 자체가 존재하지 않음, `jar { enabled = false }`만 남김
- `backend/widyu-domain/build.gradle`: Spring Boot plugin 및 `io.spring.dependency-management` 버전 선언 제거 (root subprojects에서 상속), `bootJar { enabled = false }` 제거, `java-library` 플러그인만 유지
- `widyu-api/build.gradle`은 변경 없음 — 실행 가능한 애플리케이션 모듈이므로 Spring Boot plugin 유지

## 💖리뷰 요청사항

- `widyu-domain`이 Spring Boot plugin 없이도 `spring-boot-starter-data-jpa` 등을 버전 없이 선언 가능한 이유: root `subprojects`의 `dependencyManagement`에서 `spring-boot-dependencies` BOM을 명시적으로 import해 버전 관리를 이어받기 때문입니다. 이 BOM 연결이 의도대로 동작하는지 확인 부탁드립니다!