### PR TITLE
refactor(#336): 앨범 피드 복합 인덱스 추가로 정렬 비용 제거

### DIFF
--- a/backend/widyu-domain/src/main/java/com/widyu/album/Album.java
+++ b/backend/widyu-domain/src/main/java/com/widyu/album/Album.java
@@ -14,10 +14,12 @@ import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.Index;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.OneToMany;
 import jakarta.persistence.OrderColumn;
+import jakarta.persistence.Table;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -29,6 +31,9 @@ import lombok.NoArgsConstructor;
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(indexes = {
+    @Index(name = "idx_album_status_created_id", columnList = "status, created_at DESC, album_id DESC")
+})
 public class Album extends BaseTimeEntity {
 
     @Id


### PR DESCRIPTION
## #️⃣연관된 이슈

- close: #336

## 🪄작업 내용

- `Album` 엔티티에 `(status, created_at DESC, album_id DESC)` 복합 인덱스 추가
- 앨범 피드 첫 페이지 쿼리의 Sort 단계 제거 — WHERE 구간 진입과 ORDER BY 정렬을 인덱스 하나로 처리

**성능 측정 결과 (100,000건 기준 `EXPLAIN ANALYZE`)**

| 쿼리 | 인덱스 전 | 인덱스 후 |
|---|---|---|
| 피드 첫 페이지 | Table scan + Sort / 64.4ms | Covering index lookup / 0.031ms |
| 날짜 필터 조합 | Table scan + Sort / 51.9ms | Covering index range scan / 0.054ms |

## 💖리뷰 요청사항

- 복합 인덱스 컬럼 순서 `(status, created_at DESC, album_id DESC)` 가 WHERE → ORDER BY 흐름과 맞는지 확인 부탁드립니다