### PR TITLE
fix(#339): 앨범 피드 커서를 createdAt + id 복합 커서로 변경

### DIFF
--- a/backend/widyu-api/src/main/java/com/widyu/album/application/AlbumFacade.java
+++ b/backend/widyu-api/src/main/java/com/widyu/album/application/AlbumFacade.java
@@ -25,12 +25,12 @@ public interface AlbumFacade {
     /**
      * 앨범 피드 조회 (무한 스크롤)
      */
-    CursorPage<AlbumFeedResponse> getAlbumFeed(Long lastAlbumId, String date);
+    CursorPage<AlbumFeedResponse> getAlbumFeed(String cursor, String date);
     
     /**
      * 미디어 피드 조회 (무한 스크롤)
      */
-    CursorPage<AlbumMediaResponse> getMediaFeed(Long lastPostId);
+    CursorPage<AlbumMediaResponse> getMediaFeed(String cursor);
     
     /**
      * 앨범 상세 조회

--- a/backend/widyu-api/src/main/java/com/widyu/album/application/AlbumFacadeImpl.java
+++ b/backend/widyu-api/src/main/java/com/widyu/album/application/AlbumFacadeImpl.java
@@ -59,14 +59,15 @@ public class AlbumFacadeImpl implements AlbumFacade {
     }
 
     @Override
-    public CursorPage<AlbumFeedResponse> getAlbumFeed(Long lastAlbumId, String date) {
-        AlbumFeedRequest request = AlbumFeedRequest.from(lastAlbumId, date);
+    public CursorPage<AlbumFeedResponse> getAlbumFeed(String cursor, String date) {
+        AlbumFeedRequest request = AlbumFeedRequest.from(cursor, date);
         return albumFeedService.getAlbumFeed(request);
     }
     
     @Override
-    public CursorPage<AlbumMediaResponse> getMediaFeed(Long lastPostId) {
-        return albumFeedService.getMediaFeed(lastPostId);
+    public CursorPage<AlbumMediaResponse> getMediaFeed(String cursor) {
+        AlbumFeedRequest parsed = AlbumFeedRequest.from(cursor, null);
+        return albumFeedService.getMediaFeed(parsed.lastCreatedAt(), parsed.lastAlbumId());
     }
 
     @Override

--- a/backend/widyu-api/src/main/java/com/widyu/album/application/AlbumFeedService.java
+++ b/backend/widyu-api/src/main/java/com/widyu/album/application/AlbumFeedService.java
@@ -45,7 +45,11 @@ public class AlbumFeedService {
 
         // 1) 앨범 ID 커서 페이지 조회 (size+1 로 hasNext 판단)
         Pageable pageable = pagePlusOne(ALBUM_FEED_SIZE);
-        Slice<Long> idSlice = findAlbumIdSlice(request.hasCursor() ? request.lastAlbumId() : null, request.hasDate() ? LocalDate.parse(request.date()) : null, pageable);
+        Slice<Long> idSlice = findAlbumIdSlice(
+                request.hasCursor() ? request.lastCreatedAt() : null,
+                request.hasCursor() ? request.lastAlbumId() : null,
+                request.hasDate() ? LocalDate.parse(request.date()) : null,
+                pageable);
 
         // 2) 상세 조회 (ID 순서 보존)
         List<Long> albumIds = idSlice.getContent();
@@ -59,17 +63,17 @@ public class AlbumFeedService {
         if (feed.size() > ALBUM_FEED_SIZE) {
             feed = feed.subList(0, ALBUM_FEED_SIZE);
         }
-        String nextCursor = lastAlbumIdOrNull(feed);
+        String nextCursor = lastCursorOrNull(feed);
 
         return new CursorPage<>(feed, nextCursor, hasNext);
     }
 
     @Transactional(readOnly = true)
-    public CursorPage<AlbumMediaResponse> getMediaFeed(Long lastPostId) {
+    public CursorPage<AlbumMediaResponse> getMediaFeed(LocalDateTime lastCreatedAt, Long lastPostId) {
         Pageable pageable = pagePlusOne(MEDIA_FEED_SIZE);
 
         // 1) 앨범 ID 커서 페이지
-        Slice<Long> idSlice = findAlbumIdSlice(lastPostId, null, pageable);
+        Slice<Long> idSlice = findAlbumIdSlice(lastCreatedAt, lastPostId, null, pageable);
 
         // 2) 상세 조회 (ID 순서 보존)
         List<Long> albumIds = idSlice.getContent();
@@ -81,11 +85,11 @@ public class AlbumFeedService {
             albumMediaResponses.addAll(AlbumMediaResponse.fromAlbum(album));
         }
 
-        // 4) 커서는 마지막 미디어의 postId(=albumId)
+        // 4) 커서는 마지막 앨범의 (createdAt, albumId)
         boolean hasNext = idSlice.hasNext();
         String nextCursor = albumMediaResponses.isEmpty()
                 ? null
-                : String.valueOf(albumMediaResponses.getLast().postId());
+                : buildCursor(albumMediaResponses.getLast().createdAt(), albumMediaResponses.getLast().postId());
 
         return new CursorPage<>(albumMediaResponses, nextCursor, hasNext);
     }
@@ -94,18 +98,22 @@ public class AlbumFeedService {
         return PageRequest.of(0, size + 1);
     }
 
-    private Slice<Long> findAlbumIdSlice(Long lastPostId, LocalDate date, Pageable pageable) {
+    private Slice<Long> findAlbumIdSlice(LocalDateTime lastCreatedAt, Long lastPostId, LocalDate date, Pageable pageable) {
         if (date != null) {
             LocalDateTime startOfDay = date.atStartOfDay();
             LocalDateTime startOfNextDay = date.plusDays(1).atStartOfDay();
-            return (lastPostId != null)
-                    ? albumRepository.findAlbumIdsAfterPostIdByDate(lastPostId, startOfDay, startOfNextDay, pageable)
+            return (lastCreatedAt != null)
+                    ? albumRepository.findAlbumIdsAfterPostIdByDate(lastCreatedAt, lastPostId, startOfDay, startOfNextDay, pageable)
                     : albumRepository.findLatestAlbumIdsByDate(startOfDay, startOfNextDay, pageable);
         } else {
-            return (lastPostId != null)
-                    ? albumRepository.findAlbumIdsAfterPostId(lastPostId, pageable)
+            return (lastCreatedAt != null)
+                    ? albumRepository.findAlbumIdsAfterPostId(lastCreatedAt, lastPostId, pageable)
                     : albumRepository.findLatestAlbumIds(pageable);
         }
+    }
+
+    private String buildCursor(LocalDateTime createdAt, Long albumId) {
+        return createdAt.toString() + "|" + albumId;
     }
 
     private List<Album> findAlbumsOrderedByIds(List<Long> albumIds) {
@@ -122,10 +130,10 @@ public class AlbumFeedService {
         return fetched;
     }
 
-    private String lastAlbumIdOrNull(List<AlbumFeedResponse> feed) {
+    private String lastCursorOrNull(List<AlbumFeedResponse> feed) {
         if (feed == null || feed.isEmpty()) return null;
         AlbumFeedResponse last = feed.getLast();
-        return String.valueOf(last.albumId());
+        return buildCursor(last.createdAt(), last.albumId());
     }
 
     private List<AlbumFeedResponse> convertToFeedResponsesBulk(List<Album> albums, Member currentMember) {

--- a/backend/widyu-api/src/main/java/com/widyu/album/controller/AlbumController.java
+++ b/backend/widyu-api/src/main/java/com/widyu/album/controller/AlbumController.java
@@ -53,7 +53,7 @@ public class AlbumController implements AlbumDocs {
     @Override
     @GetMapping("/feed")
     public ApiResponseTemplate<CursorPage<AlbumFeedResponse>> getAlbumFeed(
-            @RequestParam(value = "cursor", required = false) Long cursor,
+            @RequestParam(value = "cursor", required = false) String cursor,
             @RequestParam(value = "date", required = false) String date
     ) {
         CursorPage<AlbumFeedResponse> response = albumFacade.getAlbumFeed(cursor, date);
@@ -67,7 +67,7 @@ public class AlbumController implements AlbumDocs {
     @Override
     @GetMapping("/media")
     public ApiResponseTemplate<CursorPage<AlbumMediaResponse>> getMediaFeed(
-            @RequestParam(value = "cursor", required = false) Long cursor
+            @RequestParam(value = "cursor", required = false) String cursor
     ) {
         CursorPage<AlbumMediaResponse> response = albumFacade.getMediaFeed(cursor);
         

--- a/backend/widyu-api/src/main/java/com/widyu/album/controller/docs/AlbumDocs.java
+++ b/backend/widyu-api/src/main/java/com/widyu/album/controller/docs/AlbumDocs.java
@@ -199,7 +199,7 @@ public interface AlbumDocs {
     })
     ApiResponseTemplate<CursorPage<AlbumFeedResponse>> getAlbumFeed(
             @Parameter(description = "마지막으로 조회한 앨범 ID (무한 스크롤용)", example = "123")
-            @RequestParam(value = "cursor", required = false) Long cursor,
+            @RequestParam(value = "cursor", required = false) String cursor,
             @Parameter(description = "캘린더용 날짜 파라미터 (yyyy-MM-dd 형식)", example = "2024-12-21")
             @RequestParam(value = "date", required = false) String date
     );
@@ -264,7 +264,7 @@ public interface AlbumDocs {
     })
     ApiResponseTemplate<CursorPage<AlbumMediaResponse>> getMediaFeed(
             @Parameter(description = "마지막으로 조회한 postId (무한 스크롤용)", example = "123")
-            @RequestParam(value = "lastPostId", required = false) Long lastPostId
+            @RequestParam(value = "cursor", required = false) String cursor
     );
 
     // ========== 앨범 수정 ==========

--- a/backend/widyu-api/src/main/java/com/widyu/album/dto/request/AlbumFeedRequest.java
+++ b/backend/widyu-api/src/main/java/com/widyu/album/dto/request/AlbumFeedRequest.java
@@ -1,18 +1,27 @@
 package com.widyu.album.dto.request;
 
+import java.time.LocalDateTime;
+
 public record AlbumFeedRequest(
+        LocalDateTime lastCreatedAt,
         Long lastAlbumId,
         String date
 ) {
     public boolean hasCursor() {
-        return lastAlbumId != null;
+        return lastCreatedAt != null && lastAlbumId != null;
     }
 
-    public static AlbumFeedRequest from(Long lastAlbumId, String date) {
-        return new AlbumFeedRequest(lastAlbumId, date);
-    }
-    
     public boolean hasDate() {
         return date != null && !date.trim().isEmpty();
+    }
+
+    public static AlbumFeedRequest from(String cursor, String date) {
+        if (cursor == null) {
+            return new AlbumFeedRequest(null, null, date);
+        }
+        String[] parts = cursor.split("\\|");
+        LocalDateTime lastCreatedAt = LocalDateTime.parse(parts[0]);
+        Long lastAlbumId = Long.parseLong(parts[1]);
+        return new AlbumFeedRequest(lastCreatedAt, lastAlbumId, date);
     }
 }

--- a/backend/widyu-api/src/main/java/com/widyu/album/repository/AlbumRepository.java
+++ b/backend/widyu-api/src/main/java/com/widyu/album/repository/AlbumRepository.java
@@ -27,9 +27,16 @@ public interface AlbumRepository extends JpaRepository<Album, Long> {
     @Query("SELECT DISTINCT a FROM Album a LEFT JOIN FETCH a.mediaUrls LEFT JOIN FETCH a.thumbnailUrls LEFT JOIN FETCH a.durations WHERE a.id IN :albumIds ORDER BY a.createdAt DESC, a.id DESC")
     List<Album> findAlbumsWithCollectionsByIds(@Param("albumIds") List<Long> albumIds);
 
-    @Query("SELECT a.id FROM Album a WHERE a.status = 'ACTIVE' AND a.id < :lastPostId ORDER BY a.id DESC")
+    @Query("""
+            SELECT a.id FROM Album a
+            WHERE a.status = 'ACTIVE'
+              AND (a.createdAt < :lastCreatedAt
+                   OR (a.createdAt = :lastCreatedAt AND a.id < :lastId))
+            ORDER BY a.createdAt DESC, a.id DESC
+            """)
     org.springframework.data.domain.Slice<Long> findAlbumIdsAfterPostId(
-            @Param("lastPostId") Long lastPostId,
+            @Param("lastCreatedAt") LocalDateTime lastCreatedAt,
+            @Param("lastId") Long lastId,
             Pageable pageable
     );
 
@@ -57,9 +64,18 @@ public interface AlbumRepository extends JpaRepository<Album, Long> {
     @Query("SELECT a.id FROM Album a WHERE a.status = 'ACTIVE' AND a.createdAt >= :startOfDay AND a.createdAt < :startOfNextDay ORDER BY a.createdAt DESC, a.id DESC")
     org.springframework.data.domain.Slice<Long> findLatestAlbumIdsByDate(@Param("startOfDay") LocalDateTime startOfDay, @Param("startOfNextDay") LocalDateTime startOfNextDay, Pageable pageable);
 
-    @Query("SELECT a.id FROM Album a WHERE a.status = 'ACTIVE' AND a.createdAt >= :startOfDay AND a.createdAt < :startOfNextDay AND a.id < :lastPostId ORDER BY a.id DESC")
+    @Query("""
+            SELECT a.id FROM Album a
+            WHERE a.status = 'ACTIVE'
+              AND a.createdAt >= :startOfDay
+              AND a.createdAt < :startOfNextDay
+              AND (a.createdAt < :lastCreatedAt
+                   OR (a.createdAt = :lastCreatedAt AND a.id < :lastId))
+            ORDER BY a.createdAt DESC, a.id DESC
+            """)
     org.springframework.data.domain.Slice<Long> findAlbumIdsAfterPostIdByDate(
-            @Param("lastPostId") Long lastPostId,
+            @Param("lastCreatedAt") LocalDateTime lastCreatedAt,
+            @Param("lastId") Long lastId,
             @Param("startOfDay") LocalDateTime startOfDay,
             @Param("startOfNextDay") LocalDateTime startOfNextDay,
             Pageable pageable


### PR DESCRIPTION
## #️⃣연관된 이슈

- close: #339

## 🪄작업 내용

- 앨범 피드 커서를 `Long albumId` 단일값에서 `"{createdAt}|{albumId}"` 복합 문자열로 변경
- `findAlbumIdsAfterPostId`, `findAlbumIdsAfterPostIdByDate` 쿼리를 `(createdAt, id)` 기반 커서 조건으로 수정
- 첫 페이지(`ORDER BY createdAt DESC, id DESC`)와 커서 이후 페이지의 정렬 기준 통일
- 앨범 피드 / 미디어 피드 모두 동일하게 적용

**변경 전**
```
첫 페이지:      ORDER BY createdAt DESC, id DESC
커서 이후 페이지: WHERE id < :lastPostId ORDER BY id DESC
```

**변경 후**
```
첫 페이지:      ORDER BY createdAt DESC, id DESC
커서 이후 페이지: WHERE (createdAt < :lastCreatedAt OR (createdAt = :lastCreatedAt AND id < :lastId))
                ORDER BY createdAt DESC, id DESC
```

## 💖리뷰 요청사항