### PR TITLE
fix(#341): SeniorProfile birth_date NOT NULL 제약 추가

### DIFF
--- a/backend/widyu-domain/src/main/java/com/widyu/member/SeniorProfile.java
+++ b/backend/widyu-domain/src/main/java/com/widyu/member/SeniorProfile.java
@@ -40,7 +40,7 @@ public class SeniorProfile extends BaseTimeEntity {
     @Column(name = "invite_code", nullable = false, length = 7)
     private String inviteCode;
 
-    @Column(name = "birth_date")
+    @Column(name = "birth_date", nullable = false)
     private LocalDate birthDate;
 
     @Column(nullable = false)


### PR DESCRIPTION
## #️⃣연관된 이슈

- close: #341

## 🪄작업 내용

- `SeniorProfile.birthDate` 컬럼에 `nullable = false` 추가
- 가입 플로우에서 항상 필수로 수집되는 값이므로 DB 레벨에서도 null 차단

## 💖리뷰 요청사항

- 기존 운영 DB에 `birth_date` null인 행이 있다면 배포 전 확인이 필요합니다