### PR TITLE
fix(#343): 핵심 엔티티 필드 NOT NULL 제약 추가

### DIFF
--- a/backend/widyu-domain/src/main/java/com/widyu/member/FamilyMembership.java
+++ b/backend/widyu-domain/src/main/java/com/widyu/member/FamilyMembership.java
@@ -34,7 +34,7 @@ public class FamilyMembership extends BaseTimeEntity {
     @JoinColumn(name = "guardian_id", nullable = false, unique = true)
     private Member guardian;
 
-    @Column(name = "connected_at")
+    @Column(name = "connected_at", nullable = false)
     private LocalDateTime connectedAt;
 
     private String nickname;

--- a/backend/widyu-domain/src/main/java/com/widyu/member/LocalAccount.java
+++ b/backend/widyu-domain/src/main/java/com/widyu/member/LocalAccount.java
@@ -36,8 +36,10 @@ public class LocalAccount {
     @JoinColumn(name = "member_id", nullable = false)
     private Member member;
 
+    @Column(nullable = false)
     private String email;
 
+    @Column(nullable = false)
     private String password;
 
     @Column(name = "is_first")

--- a/backend/widyu-domain/src/main/java/com/widyu/member/Member.java
+++ b/backend/widyu-domain/src/main/java/com/widyu/member/Member.java
@@ -36,11 +36,14 @@ public class Member extends BaseTimeEntity {
     private Long id;
 
     @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
     private MemberRole role;
 
     @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
     private MemberType type;
 
+    @Column(nullable = false)
     private String name;
 
     private String phoneNumber;
@@ -67,6 +70,7 @@ public class Member extends BaseTimeEntity {
     private List<AddressBookmark> addressBookmarks = new ArrayList<>();
 
     @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
     private Status status;
 
     @Builder(access = AccessLevel.PRIVATE)

--- a/backend/widyu-domain/src/main/java/com/widyu/member/SocialAccount.java
+++ b/backend/widyu-domain/src/main/java/com/widyu/member/SocialAccount.java
@@ -29,8 +29,10 @@ public class SocialAccount {
 
     private String email;
 
+    @Column(nullable = false)
     private String provider;
 
+    @Column(nullable = false)
     private String oauthId;
 
     @Column(name = "refresh_token", length = 1000)

--- a/backend/widyu-domain/src/main/java/com/widyu/pay/Payment.java
+++ b/backend/widyu-domain/src/main/java/com/widyu/pay/Payment.java
@@ -38,6 +38,7 @@ public class Payment {
     @Column(unique = true, nullable = false)
     private String paymentKey;
 
+    @Column(nullable = false)
     private String orderId;
     private String orderName;
     private int amount;
@@ -45,6 +46,7 @@ public class Payment {
     private int canceledPointAmount;
 
     @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
     private PaymentStatus status;
 
     private ZonedDateTime requestedAt;


### PR DESCRIPTION
## #️⃣연관된 이슈

- close: #343

## 🪄작업 내용

Java 코드 레벨에서는 항상 값이 들어오지만 DB 제약이 없던 핵심 필드에 `nullable = false` 추가

| 엔티티 | 필드 |
|---|---|
| Member | role, type, name, status |
| LocalAccount | email, password |
| SocialAccount | provider, oauthId |
| FamilyMembership | connectedAt |
| Payment | orderId, status |

**의도적으로 nullable 유지한 필드**
- `Member.phoneNumber` — 탈퇴 시 `maskPersonalInfo()`에서 null 처리
- `FamilyMembership.nickname` — 선택 입력
- `SocialAccount.refreshToken / email` — 일부 OAuth 프로바이더 미제공

## 💖리뷰 요청사항

기존 운영 DB에 해당 컬럼에 null이 있다면 배포 전 데이터 정합성 확인이 필요합니다