### PR TITLE
fix(#345): 주소 검색 결과에서 roadAddr 대신 roadAddrPart1 반환

### DIFF
--- a/backend/widyu-api/src/main/java/com/widyu/goal/addressbookmark/application/AddressSearchService.java
+++ b/backend/widyu-api/src/main/java/com/widyu/goal/addressbookmark/application/AddressSearchService.java
@@ -38,11 +38,11 @@ public class AddressSearchService {
                     Double latitude = null;
                     Double longitude = null;
                     try {
-                        GeocodingResponse geo = geocodingService.geocode(item.roadAddr());
+                        GeocodingResponse geo = geocodingService.geocode(item.roadAddrPart1());
                         latitude = geo.latitude();
                         longitude = geo.longitude();
                     } catch (Exception e) {
-                        log.warn("좌표 변환 실패: {}", item.roadAddr());
+                        log.warn("좌표 변환 실패: {}", item.roadAddrPart1());
                     }
                     return AddressItem.from(item, latitude, longitude);
                 })

--- a/backend/widyu-api/src/main/java/com/widyu/goal/addressbookmark/dto/response/AddressSearchResponse.java
+++ b/backend/widyu-api/src/main/java/com/widyu/goal/addressbookmark/dto/response/AddressSearchResponse.java
@@ -22,7 +22,7 @@ public record AddressSearchResponse(
     ) {
         public static AddressItem from(JusoApiResponse.JusoItem item, Double latitude, Double longitude) {
             return new AddressItem(
-                    item.roadAddr(),
+                    item.roadAddrPart1(),
                     item.jibunAddr(),
                     item.zipNo(),
                     item.bdNm(),


### PR DESCRIPTION
## #️⃣연관된 이슈

- close: #345

## 🪄작업 내용

도로명주소 검색 API 응답의 \`roadAddr\` 값을 \`roadAddrPart1\`로 변경

| | 변경 전 | 변경 후 |
|---|---|---|
| 반환값 예시 | 서울특별시 성동구 무학로 33 (하왕십리동, 텐즈힐) | 서울특별시 성동구 무학로 33 |

- \`AddressSearchResponse.AddressItem.from()\`: \`item.roadAddr()\` → \`item.roadAddrPart1()\`
- \`AddressSearchService\`: geocoding 호출도 동일하게 \`roadAddrPart1\` 사용
- 응답 JSON key(\`roadAddr\`)는 그대로 유지

## 💖리뷰 요청사항

