### PR TITLE
fix(#347): X-Frame-Options를 SockJS iframe 경로에만 SAMEORIGIN, 나머지 DENY로 제한

### DIFF
--- a/backend/widyu-api/src/main/java/com/widyu/global/config/SecurityConfig.java
+++ b/backend/widyu-api/src/main/java/com/widyu/global/config/SecurityConfig.java
@@ -13,6 +13,10 @@ import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+import org.springframework.security.web.header.writers.DelegatingRequestMatcherHeaderWriter;
+import org.springframework.security.web.header.writers.frameoptions.XFrameOptionsHeaderWriter;
+import org.springframework.security.web.util.matcher.AntPathRequestMatcher;
+import org.springframework.security.web.util.matcher.NegatedRequestMatcher;
 
 @Configuration
 @EnableWebSecurity
@@ -30,8 +34,19 @@ public class SecurityConfig {
                 .sessionManagement(
                         session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS));
 
-        // SockJS의 iframe fallback을 위한 frameOptions 설정
-        http.headers(headers -> headers.frameOptions(frame -> frame.disable())); // [수정] sameOrigin 대신 disable로 변경
+        // SockJS iframe fallback 경로에만 SAMEORIGIN, 그 외 전체 DENY
+        AntPathRequestMatcher sockJsIframe = new AntPathRequestMatcher("/ws/location/iframe.html");
+        http.headers(headers -> headers
+                .frameOptions(frame -> frame.disable())
+                .addHeaderWriter(new DelegatingRequestMatcherHeaderWriter(
+                        sockJsIframe,
+                        new XFrameOptionsHeaderWriter(XFrameOptionsHeaderWriter.XFrameOptionsMode.SAMEORIGIN)
+                ))
+                .addHeaderWriter(new DelegatingRequestMatcherHeaderWriter(
+                        new NegatedRequestMatcher(sockJsIframe),
+                        new XFrameOptionsHeaderWriter(XFrameOptionsHeaderWriter.XFrameOptionsMode.DENY)
+                ))
+        );
 
         // 요청 경로에 대한 인가 설정
         http.authorizeHttpRequests(


### PR DESCRIPTION
## #️⃣연관된 이슈

- close: #347

## 🪄작업 내용

전역 \`sameOrigin()\` 설정을 경로별로 분리

| 경로 | 변경 전 | 변경 후 |
|---|---|---|
| \`/ws/location/iframe.html\` (SockJS fallback) | SAMEORIGIN | SAMEORIGIN |
| 그 외 전체 | SAMEORIGIN | **DENY** |

\`DelegatingRequestMatcherHeaderWriter\`로 두 경우를 분기 처리:
- \`frame.disable()\`로 전역 헤더를 비활성화한 뒤
- SockJS iframe 경로 → SAMEORIGIN 헤더 추가
- 나머지 경로(NegatedRequestMatcher) → DENY 헤더 추가

## 💖리뷰 요청사항

SockJS iframe 경로(\`/ws/location/iframe.html\`)가 실제로 해당 헤더를 요구하는지 확인 부탁드립니다