### PR TITLE
docs(agents): 이슈와 PR 작성 규칙 보강

### DIFF
--- a/.agents/skills/issue/SKILL.md
+++ b/.agents/skills/issue/SKILL.md
@@ -9,26 +9,33 @@ WIDYU-server 작업을 시작하기 전에 GitHub Issue를 생성하고, 필요�
 
 ## 핵심 원칙
 
+- 새 작업을 시작하기 전 `develop`으로 이동한 뒤 fork(`dongkyun0713/WIDYU-server`)를 원본(`GB-able/WIDYU-server`) `develop`과 동기화하고 `git pull origin develop`로 로컬 `develop`을 최신화한다.
 - 이슈 생성 전 LLD가 있으면 LLD 링크를 본문에 포함한다.
-- 이슈 제목과 본문은 한글로 작성한다.
+- 이슈 제목과 본문은 한글 존댓말로 작성한다.
 - 작업 범위가 크면 분리안을 제안한다.
 - 미결정 사항은 `확인 필요`로 남긴다.
 - 브랜치는 사용자 요청 시 또는 바로 작업할 때만 만든다.
 
 ## 절차
 
-1. `gh issue list --state open --limit 30 --json number,title,labels`로 중복 확인.
-2. 관련 LLD가 `docs/lld/`에 있으면 이슈 본문에 링크를 건다.
-3. 아래 템플릿으로 본문 작성.
-4. `gh issue create --title "<title>" --body-file <tmpfile>`.
-5. 필요하면 `git switch -c feature/<issue-number>`.
-6. 이슈 번호, URL, 브랜치명 보고.
+1. 새 작업 브랜치를 만들기 전에 `develop`으로 이동하고 fork와 로컬 `develop`을 최신화한다.
+   - `git switch develop`
+   - `gh repo sync dongkyun0713/WIDYU-server --source GB-able/WIDYU-server --branch develop`
+   - `git pull origin develop`
+2. `gh issue list --state open --limit 30 --json number,title,labels`로 중복 확인.
+3. 관련 LLD가 `docs/lld/`에 있으면 이슈 본문에 링크를 건다.
+4. 아래 템플릿으로 본문 작성.
+5. `gh issue create --title "<title>" --body-file <tmpfile>`.
+6. 필요하면 최신화된 `develop`에서 `git switch -c feature/<issue-number>`로 브랜치를 만든다.
+7. 이슈 번호, URL, 브랜치명 보고.
 
 ## 이슈 본문 템플릿
 
+본문은 존댓말 종결형(`합니다`, `습니다`, `필요합니다`)으로 작성한다.
+
 ```markdown
 ## 배경
-<왜 필요한 작업인지>
+<왜 필요한 작업인지 존댓말로 작성합니다.>
 
 ## 관련 설계
 - LLD: docs/lld/<있으면 경로>
@@ -36,13 +43,13 @@ WIDYU-server 작업을 시작하기 전에 GitHub Issue를 생성하고, 필요�
 
 ## 작업 범위
 - 변경 모듈: widyu-api / widyu-domain
-- <구현/문서/테스트 단위>
+- <구현/문서/테스트 단위를 존댓말로 작성합니다.>
 
 ## 완료 조건
 - <LLD 인수조건 기반>
 
 ## 정책 확인 필요
-- <있으면 작성, 없으면 "없음">
+- <있으면 작성, 없으면 "없습니다.">
 ```
 
 ## 하지 말 것

--- a/.agents/skills/pr/SKILL.md
+++ b/.agents/skills/pr/SKILL.md
@@ -13,7 +13,9 @@ PR 본문은 LLD를 오라클로 삼아 작성한다. LLD에 없는 내용은 �
 - base 브랜치는 `develop`.
 - LLD가 있으면 반드시 링크하고 인수조건 기준으로 작성한다.
 - Open Questions는 LLD의 미결정 사항을 그대로 옮긴다.
+- PR 제목과 본문은 한글 존댓말로 작성한다.
 - 기본 Assignee: `dongkyun0713`.
+- 변경 성격에 맞는 label을 확인하고 가능하면 함께 지정한다.
 
 ## 사전 확인
 
@@ -27,16 +29,31 @@ PR 본문은 LLD를 오라클로 삼아 작성한다. LLD에 없는 내용은 �
 2. 관련 이슈 `gh issue view <N>` 읽기.
 3. 관련 LLD `docs/lld/LLD-XXXX.md` 읽기.
 4. `git diff develop...HEAD --stat`으로 변경 범위 파악.
-5. 아래 템플릿으로 본문 작성.
+5. 아래 템플릿으로 본문 작성. 본문은 존댓말 종결형(`합니다`, `습니다`, `확인했습니다`)을 사용한다.
 6. `gh pr create --base develop --head <branch> --title "<title>" --body-file <tmpfile> --assignee dongkyun0713`.
-7. 필요한 라벨이 정해져 있으면 `gh pr edit <PR> --add-label "<label>"`로 추가한다.
-8. `gh pr view <PR> --json assignees,labels`로 반영 확인.
+7. `gh label list --limit 50`로 사용 가능한 label을 확인한다.
+8. 변경 성격에 맞는 label이 있으면 `gh pr edit <PR> --add-label "<label>"`로 추가한다.
+9. `gh pr view <PR> --json assignees,labels`로 assignee와 label 반영을 확인한다.
+
+### Label 선택 기준
+
+| 변경 성격 | label |
+| --- | --- |
+| 문서/가이드/스킬 문서 | `Docs` |
+| 개발 환경, CI, 설정, 하네스 | `Setting` |
+| 테스트 코드/검증 보강 | `Test` |
+| 기능 구현 | `Feature` |
+| 버그 수정 | `bug` |
+| 구조 개선 | `Refactor` |
+| 배포/인프라 | `Devops` |
 
 ## PR 본문 템플릿
 
+본문은 존댓말 종결형으로 작성한다.
+
 ```markdown
 ## 개요
-<LLD 기준으로 이 PR이 해결하는 문제와 범위>
+<LLD 기준으로 이 PR이 해결하는 문제와 범위를 존댓말로 작성합니다.>
 
 ## 관련 문서
 - LLD: docs/lld/<경로> (없으면 -)
@@ -47,7 +64,7 @@ Closes #<N>
 
 ## 변경 사항
 - 변경 모듈: widyu-api / widyu-domain
-<diff 기반 사실만 bullet>
+<diff 기반 사실만 존댓말 bullet로 작성합니다.>
 
 ## 테스트
 - `./gradlew :backend:widyu-api:test`: 통과/실패
@@ -60,7 +77,7 @@ Closes #<N>
 - [ ] LLD 인수조건 전체 충족
 
 ## Open Questions (LLD 미결정 사항)
-<LLD의 Open Questions를 그대로 옮김. 없으면 "없음">
+<LLD의 Open Questions를 그대로 옮깁니다. 없으면 "없습니다.">
 
 ## 비고
 <배포 영향, 후속 작업>


### PR DESCRIPTION
## 개요

이슈와 PR을 작성할 때 협업 문서 톤이 흔들리지 않도록 `.agents` 워크플로 스킬에 존댓말 규칙을 명시합니다.
또한 새 작업 시작 전 fork sync 및 로컬 `develop` 최신화 순서와 PR label 지정 절차를 함께 보강합니다.

## 관련 문서

- LLD: 없음
- ADR: 없음

## 관련 이슈

Closes #353

## 변경 사항

- 변경 모듈: `.agents/skills`
- `issue` 스킬에 `develop` 이동 → fork sync → `git pull origin develop` → 이슈 및 브랜치 생성 순서를 추가했습니다.
- `issue` 스킬에 이슈 제목과 본문을 한글 존댓말로 작성하도록 명시했습니다.
- `pr` 스킬에 PR 제목과 본문을 한글 존댓말로 작성하도록 명시했습니다.
- `pr` 스킬에 GitHub label 목록 확인과 변경 성격별 label 추가 절차를 보강했습니다.
- `Docs`, `Setting`, `Test`, `Feature`, `bug`, `Refactor`, `Devops` label 선택 기준을 추가했습니다.

## 테스트

- `git diff --check`: 통과
- Gradle 테스트: 미실행 (`.agents` 문서성 스킬 변경만 포함합니다.)

## 체크리스트

- [x] 엔티티 변경 없음 (`./gradlew compileJava` 불필요)
- [x] MySQL ENUM 변경 없음
- [x] `@Async` 메서드 변경 없음
- [x] LLD 인수조건 해당 없음

## Open Questions (LLD 미결정 사항)

없습니다.

## 비고

- Codex 명령 허용은 `.claude/settings.local.json`과 같은 파일이 아니라 Codex rules/config 계층에서 관리합니다.
- 이번 PR은 repo 스킬 문서만 수정하며, 개인 로컬 Codex 권한 설정은 변경하지 않았습니다.
