### PR TITLE
fix(addressbookmark): geocoding 전용 Kakao API 키 분리

### DIFF
--- a/backend/widyu-api/src/main/java/com/widyu/goal/addressbookmark/application/GeocodingService.java
+++ b/backend/widyu-api/src/main/java/com/widyu/goal/addressbookmark/application/GeocodingService.java
@@ -15,13 +15,13 @@ public class GeocodingService {
 
     private final KakaoGeocodingClient kakaoGeocodingClient;
 
-    @Value("${oauth.kakao.client-id}")
-    private String clientId;
+    @Value("${kakao.geocoding.api-key}")
+    private String apiKey;
 
     public GeocodingResponse geocode(String address) {
         KakaoGeocodingResponse response;
         try {
-            response = kakaoGeocodingClient.geocode("KakaoAK " + clientId, address);
+            response = kakaoGeocodingClient.geocode("KakaoAK " + apiKey, address);
         } catch (Exception e) {
             throw new BusinessException(ErrorCode.BAD_REQUEST, "주소 좌표 변환 중 오류가 발생했습니다. 잠시 후 다시 시도해 주세요.");
         }

--- a/backend/widyu-api/src/main/resources/application-oauth.yml
+++ b/backend/widyu-api/src/main/resources/application-oauth.yml
@@ -25,3 +25,4 @@ oauth:
 kakao:
   geocoding:
     url: https://dapi.kakao.com
+    api-key: ${KAKAO_GEOCODING_API_KEY}

--- a/backend/widyu-api/src/main/resources/application-test.yml
+++ b/backend/widyu-api/src/main/resources/application-test.yml
@@ -51,6 +51,7 @@ juso:
 kakao:
   geocoding:
     url: https://dapi.kakao.com
+    api-key: test-kakao-geocoding-key
 
 oauth:
   kakao:

--- a/backend/widyu-api/src/test/java/com/widyu/goal/addressbookmark/application/GeocodingServiceTest.java
+++ b/backend/widyu-api/src/test/java/com/widyu/goal/addressbookmark/application/GeocodingServiceTest.java
@@ -28,7 +28,7 @@ class GeocodingServiceTest {
 
     @org.junit.jupiter.api.BeforeEach
     void setUp() {
-        ReflectionTestUtils.setField(geocodingService, "clientId", "test-client-id");
+        ReflectionTestUtils.setField(geocodingService, "apiKey", "test-client-id");
     }
 
     @Test

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -75,6 +75,9 @@ services:
       # Juso API (공통)
       JUSO_CONFM_KEY: ${JUSO_CONFM_KEY}
 
+      # Kakao Geocoding (로그인용 키와 분리)
+      KAKAO_GEOCODING_API_KEY: ${KAKAO_GEOCODING_API_KEY}
+
       # Admin (공통)
       ADMIN_EMAIL: ${ADMIN_EMAIL}
       ADMIN_PASSWORD: ${ADMIN_PASSWORD}


### PR DESCRIPTION
## 개요
개발서버에서 주소 검색 시 위·경도가 전부 `null`로 반환되던 문제를 해결합니다. geocoding이 로그인용 Kakao 키(`oauth.kakao.client-id`)를 재사용하고 있어, 해당 키(테스트앱)의 사용량 제한(`code -10, API limit has been exceeded`)에 걸리면 좌표 변환이 전부 실패했습니다. geocoding 전용 키를 분리해 로그인과 독립적으로 운영되도록 합니다.

## 관련 문서
- LLD: -
- ADR: -

## 관련 이슈
Closes #355

## 변경 사항
- 변경 모듈: widyu-api
- geocoding 전용 환경변수 `KAKAO_GEOCODING_API_KEY`를 신설했습니다.
- `GeocodingService`가 `oauth.kakao.client-id` 대신 `kakao.geocoding.api-key`를 사용하도록 변경했습니다 (필드 `clientId` → `apiKey`).
- `application-oauth.yml`, `application-test.yml`에 `kakao.geocoding.api-key` 설정을 추가했습니다.
- `docker-compose.yml`에 `KAKAO_GEOCODING_API_KEY` 환경변수 주입을 추가했습니다.
- 기존 `GeocodingServiceTest`의 필드명을 동기화했습니다.

## 테스트
- `./gradlew :backend:widyu-api:test --tests "*GeocodingServiceTest*" --tests "*AddressSearch*"`: 통과했습니다 (7건).

## 체크리스트
- [x] 엔티티 변경 없음 (compileJava 불필요)
- [x] MySQL ENUM 변경 없음
- [x] `@Async`/`@Transactional` 해당 없음
- [x] 로그인 키와 geocoding 키 분리 확인

## Open Questions (LLD 미결정 사항)
없습니다.

## 비고
- 배포 전 EC2 `/home/ec2-user/.env`에 `KAKAO_GEOCODING_API_KEY=<운영앱 REST키>`를 추가해야 합니다. CI/CD가 secrets로 `.env`를 구성한다면 GitHub Secrets에도 추가가 필요합니다.
- 후속 작업(별도 PR): 검색 시 전 건 geocoding 호출을 저장 시 1건만 변환/캐싱하도록 개선, `AddressSearchService`의 삼켜지는 예외 로깅 보강.
