### PR TITLE
fix(ci): Codex 자동 검수 판정 파서 오탐(REQUEST_CHANGES 고정) 수정

### DIFF
--- a/scripts/harness/codex-review.sh
+++ b/scripts/harness/codex-review.sh
@@ -73,11 +73,16 @@ fi
 
 cat "$REPORT_FILE"
 
-# 판정 파싱: REQUEST_CHANGES 우선, 없으면 APPROVE, 둘 다 없으면 보수적으로 통과(fail-open)
-if grep -qE 'VERDICT:[[:space:]]*REQUEST_CHANGES|\bREQUEST_CHANGES\b' "$REPORT_FILE"; then
-  rm -f "$REPORT_FILE"
+# 판정 파싱: codex exec는 입력 프롬프트를 출력에 에코하고, 그 프롬프트에는
+# "VERDICT: APPROVE"/"VERDICT: REQUEST_CHANGES" 안내 문구가 들어있다.
+# 출력 전체를 grep하면 실제 판정과 무관하게 프롬프트 문구에 매칭되므로,
+# codex가 마지막 줄에 단독 출력하는 마지막 VERDICT 줄만 실제 판정으로 본다.
+# VERDICT 줄이 없으면 보수적으로 통과(fail-open).
+FINAL_VERDICT=$(grep -oE 'VERDICT:[[:space:]]*(APPROVE|REQUEST_CHANGES)' "$REPORT_FILE" | tail -n 1)
+rm -f "$REPORT_FILE"
+
+if printf '%s' "$FINAL_VERDICT" | grep -q 'REQUEST_CHANGES'; then
   exit 1
 fi
 
-rm -f "$REPORT_FILE"
 exit 0


### PR DESCRIPTION
## 개요
Stop 훅의 Codex 자동 검수가 실제 판정과 무관하게 항상 `REQUEST_CHANGES`로 처리되던 버그를 수정합니다.

`codex exec`는 입력 프롬프트를 출력에 그대로 에코하고, 그 프롬프트에는 `VERDICT: REQUEST_CHANGES` 안내 문구가 포함됩니다. 기존 파서는 출력 **전체**를 grep해서 이 프롬프트 문구에 매칭되어, 실제 판정이 `APPROVE`여도 항상 exit 1이 되었습니다. 사실상 어떤 변경도 APPROVE로 통과시키지 못했습니다.

## 관련 문서
- LLD: N/A - 하네스 스크립트 버그 수정
- ADR: -

## 관련 이슈
Closes #359

## 변경 사항
- 변경 파일: `scripts/harness/codex-review.sh`
- 출력 전체 grep 대신 **마지막 `VERDICT:` 줄**만 실제 판정으로 사용하도록 수정했습니다. codex가 지침대로 마지막 줄에 단독 VERDICT를 출력하므로, 마지막 매칭이 실제 판정입니다.
- VERDICT 줄이 없으면 기존과 동일하게 보수적으로 통과(fail-open)합니다.

## 테스트
- 로컬 시뮬레이션(3케이스) 검증:
  - 프롬프트 에코 + 실제 APPROVE → exit 0
  - 프롬프트 에코 + 실제 REQUEST_CHANGES → exit 1
  - VERDICT 줄 없음 → exit 0 (fail-open)
- `bash -n scripts/harness/codex-review.sh` 문법 검사 통과

## 체크리스트
- [x] Java 코드 변경 없음 (하네스 스크립트만 변경)
- [x] fail-open 동작 유지
- [x] on-stop.sh의 exit code 계약(0=APPROVE, 1=REQUEST_CHANGES) 유지

## Open Questions (LLD 미결정 사항)
없습니다.

## 비고
- 이 버그로 그동안 Codex 검수가 실제 APPROVE를 표시하지 못했습니다. 수정 후에는 실제 판정이 반영됩니다.
