### PR TITLE
refactor(health): MedicineScheduleService DTO 팩토리 메서드로 전환

### DIFF
--- a/backend/widyu-api/src/main/java/com/widyu/goal/medicineschedule/application/MedicineScheduleService.java
+++ b/backend/widyu-api/src/main/java/com/widyu/goal/medicineschedule/application/MedicineScheduleService.java
@@ -93,7 +93,7 @@ public class MedicineScheduleService {
 
         List<Double> monthlyGoalRates = calculateMonthlyGoalRates(targetMember.getId(), requestedMonth);
 
-        return new MedicineMonthlyResponse(lastMonthCount, currentMonthCount, monthlyGoalRates);
+        return MedicineMonthlyResponse.of(lastMonthCount, currentMonthCount, monthlyGoalRates);
     }
 
     public MedicineHomeResponse getHomeSchedules(Long memberId) {
@@ -103,21 +103,10 @@ public class MedicineScheduleService {
                 .findByMemberAndStatusWithDetails(targetMember, Status.ACTIVE);
 
         List<MedicineHomeResponse.ScheduleItem> scheduleItems = schedules.stream()
-                .map(schedule -> new MedicineHomeResponse.ScheduleItem(
-                        schedule.getId(),
-                        schedule.getTotalCount(),
-                        schedule.getAlarmTime().toString(),
-                        schedule.getCategories().stream()
-                                .flatMap(category -> category.getMedicines().stream()
-                                        .map(detail -> new MedicineHomeResponse.MedicineDetail(
-                                                detail.getMedicine().getName(),
-                                                detail.getDose()
-                                        )))
-                                .collect(Collectors.toList())
-                ))
+                .map(MedicineHomeResponse.ScheduleItem::from)
                 .collect(Collectors.toList());
 
-        return new MedicineHomeResponse(scheduleItems);
+        return MedicineHomeResponse.of(scheduleItems);
     }
 
     public MedicineScheduleDetailResponse getScheduleDetail(Long scheduleId, Long memberId) {
@@ -133,28 +122,7 @@ public class MedicineScheduleService {
                     "해당 스케줄에 접근할 권한이 없습니다.");
         }
 
-        List<MedicineScheduleDetailResponse.CategoryItem> categories = schedule.getCategories().stream()
-                .map(category -> new MedicineScheduleDetailResponse.CategoryItem(
-                        category.getId(),
-                        category.getName(),
-                        category.getCountSum().doubleValue(),
-                        category.getMedicines().stream()
-                                .map(detail -> new MedicineScheduleDetailResponse.MedicineItem(
-                                        detail.getMedicine().getId(),
-                                        detail.getMedicine().getName(),
-                                        detail.getDose().doubleValue(),
-                                        detail.getMedicine().getImageUrl(),
-                                        detail.getMedicine().getDescription()
-                                ))
-                                .collect(Collectors.toList())
-                ))
-                .collect(Collectors.toList());
-
-        return new MedicineScheduleDetailResponse(
-                schedule.getAlarmTime().toString(),
-                schedule.getTotalCount().doubleValue(),
-                categories
-        );
+        return MedicineScheduleDetailResponse.from(schedule);
     }
 
     @Transactional

--- a/backend/widyu-api/src/main/java/com/widyu/goal/medicineschedule/dto/response/MedicineHomeResponse.java
+++ b/backend/widyu-api/src/main/java/com/widyu/goal/medicineschedule/dto/response/MedicineHomeResponse.java
@@ -1,19 +1,46 @@
 package com.widyu.goal.medicineschedule.dto.response;
 
+import com.widyu.medicine.MedicineSchedule;
 import java.util.List;
+import java.util.stream.Collectors;
 
 public record MedicineHomeResponse(
         List<ScheduleItem> schedules
 ) {
+    public static MedicineHomeResponse of(List<ScheduleItem> schedules) {
+        return new MedicineHomeResponse(schedules);
+    }
+
     public record ScheduleItem(
             Long scheduleId,
             Integer medicineTotalCount,
             String alarmTime,
             List<MedicineDetail> medicineDetails
-    ) {}
+    ) {
+        public static ScheduleItem from(MedicineSchedule schedule) {
+            List<MedicineDetail> medicineDetails = schedule.getCategories().stream()
+                    .flatMap(category -> category.getMedicines().stream()
+                            .map(detail -> MedicineDetail.of(
+                                    detail.getMedicine().getName(),
+                                    detail.getDose()
+                            )))
+                    .collect(Collectors.toList());
+
+            return new ScheduleItem(
+                    schedule.getId(),
+                    schedule.getTotalCount(),
+                    schedule.getAlarmTime().toString(),
+                    medicineDetails
+            );
+        }
+    }
 
     public record MedicineDetail(
             String name,
             Integer count
-    ) {}
+    ) {
+        public static MedicineDetail of(String name, Integer count) {
+            return new MedicineDetail(name, count);
+        }
+    }
 }

--- a/backend/widyu-api/src/main/java/com/widyu/goal/medicineschedule/dto/response/MedicineMonthlyResponse.java
+++ b/backend/widyu-api/src/main/java/com/widyu/goal/medicineschedule/dto/response/MedicineMonthlyResponse.java
@@ -6,4 +6,12 @@ public record MedicineMonthlyResponse(
         Integer lastMonthAchieveCount,
         Integer currentMonthAchieveCount,
         List<Double> monthlyGoalRates
-) {}
+) {
+    public static MedicineMonthlyResponse of(
+            Integer lastMonthAchieveCount,
+            Integer currentMonthAchieveCount,
+            List<Double> monthlyGoalRates
+    ) {
+        return new MedicineMonthlyResponse(lastMonthAchieveCount, currentMonthAchieveCount, monthlyGoalRates);
+    }
+}

--- a/backend/widyu-api/src/main/java/com/widyu/goal/medicineschedule/dto/response/MedicineScheduleDetailResponse.java
+++ b/backend/widyu-api/src/main/java/com/widyu/goal/medicineschedule/dto/response/MedicineScheduleDetailResponse.java
@@ -1,18 +1,47 @@
 package com.widyu.goal.medicineschedule.dto.response;
 
+import com.widyu.medicine.MedicineCategory;
+import com.widyu.medicine.MedicineSchedule;
+import com.widyu.medicine.MedicineScheduleDetail;
 import java.util.List;
+import java.util.stream.Collectors;
 
 public record MedicineScheduleDetailResponse(
         String alarmTime,
         Double totalCount,
         List<CategoryItem> categories
 ) {
+    public static MedicineScheduleDetailResponse from(MedicineSchedule schedule) {
+        List<CategoryItem> categories = schedule.getCategories().stream()
+                .map(CategoryItem::from)
+                .collect(Collectors.toList());
+
+        return new MedicineScheduleDetailResponse(
+                schedule.getAlarmTime().toString(),
+                schedule.getTotalCount().doubleValue(),
+                categories
+        );
+    }
+
     public record CategoryItem(
             Long categoryId,
             String name,
             Double countSum,
             List<MedicineItem> medicines
-    ) {}
+    ) {
+        public static CategoryItem from(MedicineCategory category) {
+            List<MedicineItem> medicines = category.getMedicines().stream()
+                    .map(MedicineItem::from)
+                    .collect(Collectors.toList());
+
+            return new CategoryItem(
+                    category.getId(),
+                    category.getName(),
+                    category.getCountSum().doubleValue(),
+                    medicines
+            );
+        }
+    }
 
     public record MedicineItem(
             Long medicineId,
@@ -20,5 +49,15 @@ public record MedicineScheduleDetailResponse(
             Double dose,
             String imageUrl,
             String description
-    ) {}
+    ) {
+        public static MedicineItem from(MedicineScheduleDetail detail) {
+            return new MedicineItem(
+                    detail.getMedicine().getId(),
+                    detail.getMedicine().getName(),
+                    detail.getDose().doubleValue(),
+                    detail.getMedicine().getImageUrl(),
+                    detail.getMedicine().getDescription()
+            );
+        }
+    }
 }


### PR DESCRIPTION
## 개요
`MedicineScheduleService`가 응답 DTO를 서비스에서 직접 생성(`new XxxResponse(...)`)하던 부분을 DTO의 정적 팩토리(`of`/`from`)로 옮겨 코딩 규칙(서비스에서 DTO 직접 생성 금지)에 맞춥니다. #357 작업 중 Codex 검수에서 지적된 기존 기술부채로, 기능 변경과 분리한 리팩토링 PR입니다.

## 관련 문서
- LLD: N/A - 기존 코드 리팩토링 (사용자 동작 변화 없음)
- ADR: -

## 관련 이슈
Closes #361

## 변경 사항
- 변경 모듈: widyu-api (goal/medicineschedule)
- `getMonthlyStats` → `MedicineMonthlyResponse.of(...)`
- `getHomeSchedules` → `MedicineHomeResponse.of(...)` + `ScheduleItem.from(schedule)`
- `getScheduleDetail` → `MedicineScheduleDetailResponse.from(schedule)` (매핑 로직을 DTO로 이동, 서비스 22줄 → 1줄)
- 각 DTO에 정적 팩토리 메서드 추가 (`MedicineScheduleDailyResponse`와 동일한 패턴)

## 테스트
- `./gradlew :backend:widyu-api:test`: 통과했습니다.
- `validate-java-rules.sh`(MedicineScheduleService): 통과했습니다.
- 서비스 내 `new XxxResponse(` 잔여 0건 확인.

## 체크리스트
- [x] 응답 필드·값이 기존과 동일 (동작 변화 없음)
- [x] 엔티티 변경 없음
- [x] `@Async`/`@Transactional` 해당 없음
- [x] 리팩토링만 포함 (기능 추가 없음)

## Open Questions (LLD 미결정 사항)
없습니다.

## 비고
- 순수 리팩토링이라 API 계약·응답 스펙 변경이 없습니다. 클라이언트 영향 없음.
