### PR TITLE
Swagger 문서와 앨범 커서 파서 정합성을 보강합니다

### DIFF
--- a/backend/widyu-api/src/main/java/com/widyu/album/controller/docs/AlbumDocs.java
+++ b/backend/widyu-api/src/main/java/com/widyu/album/controller/docs/AlbumDocs.java
@@ -405,7 +405,7 @@ public interface AlbumDocs {
                                     value = """
                                             {
                                               "code": "AUTH_4030",
-                                              "message": "본인의 앨범만 삭제할 수 있습니다.",
+                                              "message": "접근 권한이 없습니다. - 본인의 앨범만 삭제할 수 있습니다.",
                                               "data": null
                                             }
                                             """

--- a/backend/widyu-api/src/main/java/com/widyu/album/controller/docs/AlbumDocs.java
+++ b/backend/widyu-api/src/main/java/com/widyu/album/controller/docs/AlbumDocs.java
@@ -53,28 +53,18 @@ public interface AlbumDocs {
     )
     @ApiResponses({
             @ApiResponse(
-                    responseCode = "200",
-                    description = "앨범 업로드 성공",
+                    responseCode = "202",
+                    description = "앨범 업로드 요청 접수",
                     content = @Content(
-                            schema = @Schema(implementation = AlbumUploadResponse.class),
+                            schema = @Schema(implementation = AlbumUploadAcceptedResponse.class),
                             examples = @ExampleObject(
                                     name = "성공 응답",
                                     value = """
                                             {
                                               "code": "ALBM_2001",
-                                              "message": "앨범 업로드가 완료되었습니다.",
+                                              "message": "앨범 업로드 요청이 접수되었습니다.",
                                               "data": {
-                                                "albumId": 123,
-                                                "content": "가족 여행 사진입니다!",
-                                                "mediaUrls": [
-                                                  "https://s3.bucket.com/albums/photos/1/20241221_143000_abcd1234.jpg",
-                                                  "https://s3.bucket.com/albums/videos/1/20241221_143001_efgh5678.mp4"
-                                                ],
-                                                "mediaCount": 2,
-                                                "photoCount": 1,
-                                                "videoCount": 1,
-                                                "authorName": "홍길동",
-                                                "createdAt": "2024-12-21T14:30:00"
+                                                "albumId": 123
                                               }
                                             }
                                             """
@@ -189,7 +179,7 @@ public interface AlbumDocs {
                                                   }
                                                 ],
                                                 "hasNext": true,
-                                                "nextCursor": "122"
+                                                "nextCursor": "2024-12-21T14:30:00|123"
                                               }
                                             }
                                             """
@@ -198,7 +188,7 @@ public interface AlbumDocs {
             )
     })
     ApiResponseTemplate<CursorPage<AlbumFeedResponse>> getAlbumFeed(
-            @Parameter(description = "마지막으로 조회한 앨범 ID (무한 스크롤용)", example = "123")
+            @Parameter(description = "응답의 nextCursor 값 (createdAt|albumId 형식)", example = "2024-12-21T14:30:00|123")
             @RequestParam(value = "cursor", required = false) String cursor,
             @Parameter(description = "캘린더용 날짜 파라미터 (yyyy-MM-dd 형식)", example = "2024-12-21")
             @RequestParam(value = "date", required = false) String date
@@ -218,8 +208,8 @@ public interface AlbumDocs {
                     - 페이지 크기: 10개 고정
                     
                     **무한 스크롤 사용법:**
-                    1. 첫 번째 요청: lastPostId 없이 호출
-                    2. 다음 요청: 응답의 nextCursor를 lastPostId로 사용
+                    1. 첫 번째 요청: cursor 없이 호출
+                    2. 다음 요청: 응답의 nextCursor를 cursor로 사용
                     """
     )
     @ApiResponses({
@@ -254,7 +244,7 @@ public interface AlbumDocs {
                                                   }
                                                 ],
                                                 "hasNext": true,
-                                                "nextCursor": "119"
+                                                "nextCursor": "2024-12-21T14:25:00|119"
                                               }
                                             }
                                             """
@@ -263,7 +253,7 @@ public interface AlbumDocs {
             )
     })
     ApiResponseTemplate<CursorPage<AlbumMediaResponse>> getMediaFeed(
-            @Parameter(description = "마지막으로 조회한 postId (무한 스크롤용)", example = "123")
+            @Parameter(description = "응답의 nextCursor 값 (createdAt|albumId 형식)", example = "2024-12-21T14:25:00|119")
             @RequestParam(value = "cursor", required = false) String cursor
     );
 

--- a/backend/widyu-api/src/main/java/com/widyu/album/controller/docs/AlbumDocs.java
+++ b/backend/widyu-api/src/main/java/com/widyu/album/controller/docs/AlbumDocs.java
@@ -81,7 +81,7 @@ public interface AlbumDocs {
                                             value = """
                                                     {
                                                       "code": "REQ_4000",
-                                                      "message": "전체 최대 8개, 사진 최대 8개, 동영상 최대 3개까지 업로드 가능합니다.",
+                                                      "message": "잘못된 요청입니다. - 전체 최대 8개, 사진 최대 8개, 동영상 최대 3개까지 업로드 가능합니다.",
                                                       "data": null
                                                     }
                                                     """
@@ -329,7 +329,7 @@ public interface AlbumDocs {
                                     value = """
                                             {
                                               "code": "AUTH_4030",
-                                              "message": "본인의 앨범만 수정할 수 있습니다.",
+                                              "message": "접근 권한이 없습니다. - 본인의 앨범만 수정할 수 있습니다.",
                                               "data": null
                                             }
                                             """

--- a/backend/widyu-api/src/main/java/com/widyu/album/controller/docs/AlbumDocs.java
+++ b/backend/widyu-api/src/main/java/com/widyu/album/controller/docs/AlbumDocs.java
@@ -686,8 +686,7 @@ public interface AlbumDocs {
                                                           "name": "홍길동",
                                                           "profileImage": null
                                                         },
-                                                        "canEdit": true,
-                                                        "replies": []
+                                                        "canEdit": true
                                                       }
                                                     ]
                                                   }
@@ -789,9 +788,11 @@ public interface AlbumDocs {
                                               "code": "ALBM_2008",
                                               "message": "앨범 해금이 완료되었습니다.",
                                               "data": {
+                                                "unlockId": 1,
                                                 "albumId": 123,
-                                                "unlockPrice": 50,
-                                                "remainingPoints": 450
+                                                "albumTitle": "오늘 소풍 다녀왔어요!",
+                                                "unlockedAt": "2025-09-13T12:00:00",
+                                                "message": "앨범이 해금되었습니다."
                                               }
                                             }
                                             """

--- a/backend/widyu-api/src/main/java/com/widyu/album/dto/request/AlbumFeedRequest.java
+++ b/backend/widyu-api/src/main/java/com/widyu/album/dto/request/AlbumFeedRequest.java
@@ -1,6 +1,9 @@
 package com.widyu.album.dto.request;
 
+import com.widyu.global.error.BusinessException;
+import com.widyu.global.error.ErrorCode;
 import java.time.LocalDateTime;
+import java.time.format.DateTimeParseException;
 
 public record AlbumFeedRequest(
         LocalDateTime lastCreatedAt,
@@ -16,12 +19,37 @@ public record AlbumFeedRequest(
     }
 
     public static AlbumFeedRequest from(String cursor, String date) {
-        if (cursor == null) {
+        if (cursor == null || cursor.isBlank()) {
             return new AlbumFeedRequest(null, null, date);
         }
-        String[] parts = cursor.split("\\|");
-        LocalDateTime lastCreatedAt = LocalDateTime.parse(parts[0]);
-        Long lastAlbumId = Long.parseLong(parts[1]);
+
+        String[] parts = cursor.split("\\|", -1);
+        if (parts.length != 2 || parts[0].isBlank() || parts[1].isBlank()) {
+            throw invalidCursorException();
+        }
+
+        LocalDateTime lastCreatedAt = parseCreatedAt(parts[0]);
+        Long lastAlbumId = parseAlbumId(parts[1]);
         return new AlbumFeedRequest(lastCreatedAt, lastAlbumId, date);
+    }
+
+    private static LocalDateTime parseCreatedAt(String value) {
+        try {
+            return LocalDateTime.parse(value);
+        } catch (DateTimeParseException e) {
+            throw invalidCursorException();
+        }
+    }
+
+    private static Long parseAlbumId(String value) {
+        try {
+            return Long.parseLong(value);
+        } catch (NumberFormatException e) {
+            throw invalidCursorException();
+        }
+    }
+
+    private static BusinessException invalidCursorException() {
+        return new BusinessException(ErrorCode.BAD_REQUEST, "커서 형식은 createdAt|albumId 이어야 합니다.");
     }
 }

--- a/backend/widyu-api/src/main/java/com/widyu/auth/controller/docs/GuardianAuthDocs.java
+++ b/backend/widyu-api/src/main/java/com/widyu/auth/controller/docs/GuardianAuthDocs.java
@@ -95,12 +95,7 @@ public interface GuardianAuthDocs {
                                         "profile": {
                                           "name": "홍길동",
                                           "phoneNumber": "010-1234-5678",
-                                          "email": "user@example.com",
-                                          "providers": ["LOCAL"]
-                                        },
-                                        "accountInfo": {
-                                          "email": "user@example.com",
-                                          "accountType": "LOCAL"
+                                          "email": "user@example.com"
                                         }
                                       }
                                     }
@@ -230,19 +225,13 @@ public interface GuardianAuthDocs {
                                       "message": "소셜 로그인 성공",
                                       "data": {
                                         "isFirst": false,
-                                        "accessToken": null,
-                                        "refreshToken": null,
                                         "profile": {
                                           "name": "홍길동",
                                           "phoneNumber": "010-1234-5678",
                                           "email": "existing@example.com",
                                           "providers": ["kakao"]
                                         },
-                                        "newSocialAccount": {
-                                          "provider": "naver",
-                                          "email": "newuser@naver.com",
-                                          "name": "홍길동"
-                                        }
+                                        "socialTemporaryToken": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9..."
                                       }
                                     }
                                     """
@@ -258,7 +247,7 @@ public interface GuardianAuthDocs {
                             name = "토큰 오류",
                             value = """
                                     {
-                                      "code": "AUTH_4001",
+                                      "code": "AUTH_4018",
                                       "message": "유효하지 않은 액세스 토큰입니다.",
                                       "data": null
                                     }
@@ -348,6 +337,7 @@ public interface GuardianAuthDocs {
                                       "code": "AUTH_2006",
                                       "message": "휴대폰 번호로 회원 조회 성공",
                                       "data": {
+                                        "memberId": 1,
                                         "name": "홍길동",
                                         "phoneNumber": "01012345678",
                                         "email": "user@example.com"
@@ -409,7 +399,7 @@ public interface GuardianAuthDocs {
                             name = "토큰 만료",
                             value = """
                                     {
-                                      "code": "AUTH_4011",
+                                      "code": "AUTH_4014",
                                       "message": "임시 토큰이 만료되었습니다.",
                                       "data": null
                                     }
@@ -428,8 +418,7 @@ public interface GuardianAuthDocs {
                                     name = "요청 예시",
                                     value = """
                                             {
-                                              "password": "NewPass@1234",
-                                              "confirmPassword": "NewPass@1234"
+                                              "password": "NewPass@1234"
                                             }
                                             """
                             )
@@ -471,7 +460,7 @@ public interface GuardianAuthDocs {
                             name = "토큰 오류",
                             value = """
                                     {
-                                      "code": "AUTH_4001",
+                                      "code": "AUTH_4018",
                                       "message": "유효하지 않은 액세스 토큰입니다.",
                                       "data": null
                                     }
@@ -537,7 +526,7 @@ public interface GuardianAuthDocs {
                             name = "토큰 만료",
                             value = """
                                     {
-                                      "code": "AUTH_4011",
+                                      "code": "AUTH_4014",
                                       "message": "임시 토큰이 만료되었습니다.",
                                       "data": null
                                     }

--- a/backend/widyu-api/src/main/java/com/widyu/auth/controller/docs/GuardianAuthDocs.java
+++ b/backend/widyu-api/src/main/java/com/widyu/auth/controller/docs/GuardianAuthDocs.java
@@ -578,7 +578,7 @@ public interface GuardianAuthDocs {
                                     name = "이미 연동된 제공자",
                                     value = """
                                             {
-                                              "code": "AUTH_4010",
+                                              "code": "AUTH_4019",
                                               "message": "이미 연동된 소셜 로그인 제공자입니다.",
                                               "data": null
                                             }

--- a/backend/widyu-api/src/main/java/com/widyu/auth/controller/docs/SmsDocs.java
+++ b/backend/widyu-api/src/main/java/com/widyu/auth/controller/docs/SmsDocs.java
@@ -134,7 +134,7 @@ public interface SmsDocs {
                             value = """
                                     {
                                       "code": "MEMBER_4041",
-                                      "message": "해당 정보와 일치하는 회원을 찾을 수 없습니다.",
+                                      "message": "회원을 찾을 수 없습니다.",
                                       "data": null
                                     }
                                     """

--- a/backend/widyu-api/src/main/java/com/widyu/auth/controller/docs/UnifiedAuthDocs.java
+++ b/backend/widyu-api/src/main/java/com/widyu/auth/controller/docs/UnifiedAuthDocs.java
@@ -34,6 +34,7 @@ public interface UnifiedAuthDocs {
                                       "code": "AUTH_2009",
                                       "message": "토큰 재발급에 성공했습니다.",
                                       "data": {
+                                        "memberId": 1,
                                         "accessToken": "Bearer eyJhbGciOiJIUzI1NiIs...",
                                         "refreshToken": "eyJhbGciOiJIUzI1NiIs..."
                                       }

--- a/backend/widyu-api/src/main/java/com/widyu/fcm/controller/FcmController.java
+++ b/backend/widyu-api/src/main/java/com/widyu/fcm/controller/FcmController.java
@@ -45,7 +45,7 @@ public class FcmController implements FcmDocs {
     public ApiResponseTemplate<List<FcmCategoryResponse>> getNotificationCategories() {
         return ApiResponseTemplate.ok()
                 .code("FCM_2005")
-                .message("OK")
+                .message("알림 카테고리 조회 성공")
                 .body(fcmService.getNotificationCategories());
     }
 

--- a/backend/widyu-api/src/main/java/com/widyu/fcm/controller/docs/NotificationSettingDocs.java
+++ b/backend/widyu-api/src/main/java/com/widyu/fcm/controller/docs/NotificationSettingDocs.java
@@ -92,7 +92,7 @@ public interface NotificationSettingDocs {
                             value = """
                                     {
                                       "code": "FCM_4001",
-                                      "message": "유효하지 않은 알림 그룹입니다.",
+                                      "message": "유효하지 않은 알림 카테고리입니다.",
                                       "data": null
                                     }
                                     """

--- a/backend/widyu-api/src/main/java/com/widyu/goal/healthschedule/controller/docs/HealthScheduleDocs.java
+++ b/backend/widyu-api/src/main/java/com/widyu/goal/healthschedule/controller/docs/HealthScheduleDocs.java
@@ -59,13 +59,11 @@ public interface HealthScheduleDocs {
                                       "code": "HLTH_2001",
                                       "message": "건강 일정이 생성되었습니다.",
                                       "data": {
-                                        "healthScheduleId": 1,
                                         "scheduleName": "정기 건강검진",
-                                        "placeAddress": "서울대학교병원",
-                                        "latitude": "37.5665",
-                                        "longitude": "126.9780",
                                         "scheduledAt": "2025-11-15T14:30:00",
-                                        "progressStatus": "UPCOMING"
+                                        "placeAddress": "서울대학교병원",
+                                        "latitude": 37.5665,
+                                        "longitude": 126.9780
                                       }
                                     }
                                     """
@@ -108,13 +106,11 @@ public interface HealthScheduleDocs {
                                       "code": "HLTH_2001",
                                       "message": "건강 일정이 생성되었습니다.",
                                       "data": {
-                                        "healthScheduleId": 1,
                                         "scheduleName": "정기 건강검진",
-                                        "placeAddress": "서울대학교병원",
-                                        "latitude": "37.5665",
-                                        "longitude": "126.9780",
                                         "scheduledAt": "2025-11-15T14:30:00",
-                                        "progressStatus": "UPCOMING"
+                                        "placeAddress": "서울대학교병원",
+                                        "latitude": 37.5665,
+                                        "longitude": 126.9780
                                       }
                                     }
                                     """
@@ -160,13 +156,11 @@ public interface HealthScheduleDocs {
                                       "code": "HLTH_2002",
                                       "message": "건강 일정이 수정되었습니다.",
                                       "data": {
-                                        "healthScheduleId": 1,
                                         "scheduleName": "정기 건강검진 (수정)",
-                                        "placeAddress": "강남세브란스병원",
-                                        "latitude": "37.5665",
-                                        "longitude": "126.9780",
                                         "scheduledAt": "2025-11-20T10:00:00",
-                                        "progressStatus": "UPCOMING"
+                                        "placeAddress": "강남세브란스병원",
+                                        "latitude": 37.5665,
+                                        "longitude": 126.9780
                                       }
                                     }
                                     """

--- a/backend/widyu-api/src/main/java/com/widyu/goal/healthschedule/controller/docs/HealthScheduleDocs.java
+++ b/backend/widyu-api/src/main/java/com/widyu/goal/healthschedule/controller/docs/HealthScheduleDocs.java
@@ -186,7 +186,8 @@ public interface HealthScheduleDocs {
                             value = """
                                     {
                                       "code": "HLTH_2003",
-                                      "message": "건강 일정이 삭제되었습니다."
+                                      "message": "건강 일정이 삭제되었습니다.",
+                                      "data": null
                                     }
                                     """
                     )
@@ -358,7 +359,8 @@ public interface HealthScheduleDocs {
                             value = """
                                     {
                                       "code": "HLTH_2006",
-                                      "message": "건강 일정 포인트 적립이 완료되었습니다."
+                                      "message": "건강 일정 포인트 적립이 완료되었습니다.",
+                                      "data": null
                                     }
                                     """
                     )
@@ -434,7 +436,8 @@ public interface HealthScheduleDocs {
                             value = """
                                     {
                                       "code": "HLTH_2008",
-                                      "message": "건강 일정이 완료 처리되었습니다."
+                                      "message": "건강 일정이 완료 처리되었습니다.",
+                                      "data": null
                                     }
                                     """
                     )

--- a/backend/widyu-api/src/main/java/com/widyu/goal/home/controller/docs/GoalHomeDocs.java
+++ b/backend/widyu-api/src/main/java/com/widyu/goal/home/controller/docs/GoalHomeDocs.java
@@ -8,6 +8,9 @@ import com.widyu.goal.home.dto.response.SeniorGoalHomeResponse;
 import com.widyu.goal.home.dto.response.SeniorWeeklyGoalStatusResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -32,12 +35,33 @@ public interface GoalHomeDocs {
                     - 시니어 ID (memberId)
                     - 시니어 이름 (name)
                     - 시니어 프로필 이미지 (profileImage)
-                    - 보호자가 설정한 닉네임 (nickname)
-                    - 연결된 날짜 (connectedAt)
                     """
     )
     @ApiResponses({
-            @ApiResponse(responseCode = "200", description = "조회 성공"),
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "조회 성공",
+                    content = @Content(
+                            schema = @Schema(implementation = ApiResponseTemplate.class),
+                            examples = @ExampleObject(
+                                    value = """
+                                            {
+                                              "code": "GOAL_HOME_2001",
+                                              "message": "가족 목록 조회 성공",
+                                              "data": {
+                                                "families": [
+                                                  {
+                                                    "memberId": 1,
+                                                    "name": "김부모",
+                                                    "profileImage": "https://www.widyu.shop/profile/senior.png"
+                                                  }
+                                                ]
+                                              }
+                                            }
+                                            """
+                            )
+                    )
+            ),
             @ApiResponse(responseCode = "401", description = "인증 실패")
     })
     ApiResponseTemplate<FamilyListResponse> getFamilyList();
@@ -48,16 +72,50 @@ public interface GoalHomeDocs {
                     시니어 사용자의 목표 홈 화면 정보를 조회합니다.
 
                     **반환 정보:**
-                    - **약 스케줄**: 오늘 복용 현황, 다음 알람 시간(HH:mm 형식) 및 복용 개수
-                    - **걸음 수**: 오늘 걸음 수 및 목표
-                    - **병원 일정**: 가장 가까운 병원 일정 (D-day, 일시, 병원명, 주소)
+                    - **약 스케줄**: 다음 복용 스케줄 ID, 오늘 복용/예정 횟수, 다음 복용 예정 개수, 다음 알람 시간
+                    - **걸음 수**: 오늘 걸음 수 및 목표 걸음 수
+                    - **병원 일정**: 가장 가까운 병원 일정 ID, D-day, 일시, 일정명, 주소
 
                     **권한:**
                     - 시니어 본인만 가능
                     """
     )
     @ApiResponses({
-            @ApiResponse(responseCode = "200", description = "조회 성공"),
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "조회 성공",
+                    content = @Content(
+                            schema = @Schema(implementation = ApiResponseTemplate.class),
+                            examples = @ExampleObject(
+                                    value = """
+                                            {
+                                              "code": "GOAL_HOME_2002",
+                                              "message": "시니어 목표 홈 조회 성공",
+                                              "data": {
+                                                "medicine": {
+                                                  "medicineScheduleId": 1,
+                                                  "todayTakenCount": 2,
+                                                  "todayTotalCount": 3,
+                                                  "nextDoseCount": 4,
+                                                  "nextAlarmTime": "17:00"
+                                                },
+                                                "steps": {
+                                                  "steps": 9829,
+                                                  "goal": 10000
+                                                },
+                                                "hospital": {
+                                                  "hospitalScheduleId": 1,
+                                                  "dday": 14,
+                                                  "datetime": "2025-08-26T17:00:00",
+                                                  "name": "고려대학교 의과대학 부속병원",
+                                                  "address": "서울특별시 성북구 고려대로 73"
+                                                }
+                                              }
+                                            }
+                                            """
+                            )
+                    )
+            ),
             @ApiResponse(responseCode = "401", description = "인증 실패")
     })
     ApiResponseTemplate<SeniorGoalHomeResponse> getSeniorGoalHome();
@@ -84,7 +142,32 @@ public interface GoalHomeDocs {
                     """
     )
     @ApiResponses({
-            @ApiResponse(responseCode = "200", description = "조회 성공"),
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "조회 성공",
+                    content = @Content(
+                            schema = @Schema(implementation = ApiResponseTemplate.class),
+                            examples = @ExampleObject(
+                                    value = """
+                                            {
+                                              "code": "GOAL_HOME_2003",
+                                              "message": "시니어 주간 목표 달성률 조회 성공",
+                                              "data": {
+                                                "thisWeekGoalRates": [
+                                                  "NOT_STARTED",
+                                                  "IN_PROGRESS",
+                                                  "COMPLETED",
+                                                  "FAILED",
+                                                  "NOT_STARTED",
+                                                  "NOT_STARTED",
+                                                  "NOT_STARTED"
+                                                ]
+                                              }
+                                            }
+                                            """
+                            )
+                    )
+            ),
             @ApiResponse(responseCode = "401", description = "인증 실패")
     })
     ApiResponseTemplate<SeniorWeeklyGoalStatusResponse> getSeniorWeeklyGoalStatus();
@@ -109,7 +192,26 @@ public interface GoalHomeDocs {
                     """
     )
     @ApiResponses({
-            @ApiResponse(responseCode = "200", description = "조회 성공"),
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "조회 성공",
+                    content = @Content(
+                            schema = @Schema(implementation = ApiResponseTemplate.class),
+                            examples = @ExampleObject(
+                                    value = """
+                                            {
+                                              "code": "GOAL_HOME_2004",
+                                              "message": "보호자 목표 현황 조회 성공",
+                                              "data": {
+                                                "lastWeekGoalRate": 0.8,
+                                                "thisWeekGoalRate": 0.65,
+                                                "thisWeekGoalRates": [0.6, 0.24, 0.53, 0.75, 0.85, 0.9, 1.0]
+                                              }
+                                            }
+                                            """
+                            )
+                    )
+            ),
             @ApiResponse(responseCode = "400", description = "연결된 부모님이 없음"),
             @ApiResponse(responseCode = "401", description = "인증 실패")
     })
@@ -140,7 +242,52 @@ public interface GoalHomeDocs {
                     """
     )
     @ApiResponses({
-            @ApiResponse(responseCode = "200", description = "조회 성공"),
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "조회 성공",
+                    content = @Content(
+                            schema = @Schema(implementation = ApiResponseTemplate.class),
+                            examples = @ExampleObject(
+                                    value = """
+                                            {
+                                              "code": "GOAL_HOME_2005",
+                                              "message": "보호자 목표 홈 조회 성공",
+                                              "data": {
+                                                "medicine": {
+                                                  "totalCount": 6,
+                                                  "takenCount": 1,
+                                                  "schedules": [
+                                                    {
+                                                      "medicineScheduleId": 101,
+                                                      "alarmTime": "19:00",
+                                                      "status": "taken",
+                                                      "proofImageUrl": "https://www.widyu.shop/img",
+                                                      "medicines": [
+                                                        {
+                                                          "name": "위염약",
+                                                          "count": 5
+                                                        }
+                                                      ]
+                                                    }
+                                                  ]
+                                                },
+                                                "steps": {
+                                                  "steps": 9829,
+                                                  "goal": 10000
+                                                },
+                                                "hospital": {
+                                                  "hospitalScheduleId": 1,
+                                                  "dday": 14,
+                                                  "datetime": "2025-08-26T17:00:00",
+                                                  "name": "고려대학교 의과대학 부속병원",
+                                                  "address": "서울특별시 성북구 고려대로 73"
+                                                }
+                                              }
+                                            }
+                                            """
+                            )
+                    )
+            ),
             @ApiResponse(responseCode = "400", description = "연결된 부모님이 없음"),
             @ApiResponse(responseCode = "401", description = "인증 실패")
     })

--- a/backend/widyu-api/src/main/java/com/widyu/goal/medicineschedule/controller/docs/MedicineScheduleDocs.java
+++ b/backend/widyu-api/src/main/java/com/widyu/goal/medicineschedule/controller/docs/MedicineScheduleDocs.java
@@ -60,10 +60,9 @@ public interface MedicineScheduleDocs {
                             examples = @ExampleObject(
                                     value = """
                                             {
-                                              "isSuccess": true,
-                                              "code": "200",
-                                              "message": "요청에 성공하였습니다.",
-                                              "result": {
+                                              "code": "MEDICINE_2001",
+                                              "message": "일자별 약 복용 현황 조회 성공",
+                                              "data": {
                                                 "medicineSchedule": [
                                                   {
                                                     "medicineScheduleId": 1,
@@ -134,12 +133,11 @@ public interface MedicineScheduleDocs {
                             examples = @ExampleObject(
                                     value = """
                                             {
-                                              "isSuccess": true,
-                                              "code": "200",
-                                              "message": "요청에 성공하였습니다.",
-                                              "result": {
-                                                "lastMonthCount": 25,
-                                                "currentMonthCount": 18,
+                                              "code": "MEDICINE_2002",
+                                              "message": "날짜별 약 조회 성공",
+                                              "data": {
+                                                "lastMonthAchieveCount": 25,
+                                                "currentMonthAchieveCount": 18,
                                                 "monthlyGoalRates": [
                                                   1.0, 1.0, 0.5, 1.0, 1.0, 0.0, 1.0,
                                                   1.0, 1.0, 1.0, 0.5, 1.0, 1.0, 1.0,
@@ -189,34 +187,33 @@ public interface MedicineScheduleDocs {
                             examples = @ExampleObject(
                                     value = """
                                             {
-                                              "isSuccess": true,
-                                              "code": "200",
-                                              "message": "요청에 성공하였습니다.",
-                                              "result": {
+                                              "code": "MEDICINE_2003",
+                                              "message": "시니어 약복용 홈 조회 성공",
+                                              "data": {
                                                 "schedules": [
                                                   {
                                                     "scheduleId": 1,
-                                                    "totalCount": 3,
+                                                    "medicineTotalCount": 3,
                                                     "alarmTime": "08:00",
-                                                    "medicines": [
+                                                    "medicineDetails": [
                                                       {
-                                                        "itemName": "타이레놀",
-                                                        "dose": 1
+                                                        "name": "타이레놀",
+                                                        "count": 1
                                                       },
                                                       {
-                                                        "itemName": "비타민C",
-                                                        "dose": 2
+                                                        "name": "비타민C",
+                                                        "count": 2
                                                       }
                                                     ]
                                                   },
                                                   {
                                                     "scheduleId": 2,
-                                                    "totalCount": 1,
+                                                    "medicineTotalCount": 1,
                                                     "alarmTime": "20:00",
-                                                    "medicines": [
+                                                    "medicineDetails": [
                                                       {
-                                                        "itemName": "오메가3",
-                                                        "dose": 1
+                                                        "name": "오메가3",
+                                                        "count": 1
                                                       }
                                                     ]
                                                   }
@@ -257,30 +254,29 @@ public interface MedicineScheduleDocs {
                             examples = @ExampleObject(
                                     value = """
                                             {
-                                              "isSuccess": true,
-                                              "code": "200",
-                                              "message": "요청에 성공하였습니다.",
-                                              "result": {
+                                              "code": "MEDICINE_2004",
+                                              "message": "약 복용 상세 조회 성공",
+                                              "data": {
                                                 "alarmTime": "08:00",
                                                 "totalCount": 3.0,
                                                 "categories": [
                                                   {
                                                     "categoryId": 1,
-                                                    "categoryName": "아침 식후",
+                                                    "name": "아침 식후",
                                                     "countSum": 3.0,
                                                     "medicines": [
                                                       {
                                                         "medicineId": 1,
-                                                        "itemName": "타이레놀",
+                                                        "medicineName": "타이레놀",
                                                         "dose": 1.0,
-                                                        "itemImage": "https://example.com/tylenol.jpg",
+                                                        "imageUrl": "https://example.com/tylenol.jpg",
                                                         "description": "해열, 진통제"
                                                       },
                                                       {
                                                         "medicineId": 2,
-                                                        "itemName": "비타민C",
+                                                        "medicineName": "비타민C",
                                                         "dose": 2.0,
-                                                        "itemImage": "https://example.com/vitaminc.jpg",
+                                                        "imageUrl": "https://example.com/vitaminc.jpg",
                                                         "description": "면역력 강화"
                                                       }
                                                     ]
@@ -355,10 +351,9 @@ public interface MedicineScheduleDocs {
                             examples = @ExampleObject(
                                     value = """
                                             {
-                                              "isSuccess": true,
-                                              "code": "200",
-                                              "message": "요청에 성공하였습니다.",
-                                              "result": {
+                                              "code": "MEDICINE_2005",
+                                              "message": "약 복용 스케줄 생성 성공",
+                                              "data": {
                                                 "scheduleId": 1
                                               }
                                             }
@@ -505,10 +500,9 @@ public interface MedicineScheduleDocs {
                             examples = @ExampleObject(
                                     value = """
                                             {
-                                              "isSuccess": true,
-                                              "code": "200",
-                                              "message": "요청에 성공하였습니다.",
-                                              "result": {
+                                              "code": "MEDICINE_2009",
+                                              "message": "약품 검색 성공",
+                                              "data": {
                                                 "medicines": [
                                                   {
                                                     "medicineId": 1,

--- a/backend/widyu-api/src/main/java/com/widyu/goal/medicineschedule/controller/docs/MedicineScheduleDocs.java
+++ b/backend/widyu-api/src/main/java/com/widyu/goal/medicineschedule/controller/docs/MedicineScheduleDocs.java
@@ -354,7 +354,7 @@ public interface MedicineScheduleDocs {
                                               "code": "MEDICINE_2005",
                                               "message": "약 복용 스케줄 생성 성공",
                                               "data": {
-                                                "scheduleId": 1
+                                                "medicineScheduleId": 1
                                               }
                                             }
                                             """

--- a/backend/widyu-api/src/main/java/com/widyu/heart/controller/docs/HeartRateDocs.java
+++ b/backend/widyu-api/src/main/java/com/widyu/heart/controller/docs/HeartRateDocs.java
@@ -91,7 +91,7 @@ public interface HeartRateDocs {
                     examples = @ExampleObject(
                             value = """
                                     {
-                                      "code": "FORBIDDEN",
+                                      "code": "AUTH_4030",
                                       "message": "해당 회원의 정보를 조회할 권한이 없습니다.",
                                       "data": null
                                     }

--- a/backend/widyu-api/src/main/java/com/widyu/heart/controller/docs/HeartRateDocs.java
+++ b/backend/widyu-api/src/main/java/com/widyu/heart/controller/docs/HeartRateDocs.java
@@ -92,7 +92,7 @@ public interface HeartRateDocs {
                             value = """
                                     {
                                       "code": "AUTH_4030",
-                                      "message": "해당 회원의 정보를 조회할 권한이 없습니다.",
+                                      "message": "접근 권한이 없습니다. - 가족으로 연결된 시니어만 접근할 수 있습니다.",
                                       "data": null
                                     }
                                     """

--- a/backend/widyu-api/src/main/java/com/widyu/location/realtime/controller/docs/RealtimeLocationDocs.java
+++ b/backend/widyu-api/src/main/java/com/widyu/location/realtime/controller/docs/RealtimeLocationDocs.java
@@ -105,7 +105,7 @@ public interface RealtimeLocationDocs {
                             value = """
                     {
                       "code": "AUTH_4030",
-                      "message": "해당 시니어의 위치를 조회할 권한이 없습니다.",
+                      "message": "접근 권한이 없습니다. - 해당 시니어의 위치를 조회할 권한이 없습니다.",
                       "data": null
                     }
                     """
@@ -120,7 +120,7 @@ public interface RealtimeLocationDocs {
                             value = """
                     {
                       "code": "SRV_4040",
-                      "message": "최근 위치 정보가 없습니다.",
+                      "message": "찾을 수 없습니다 - 최근 위치 정보가 없습니다.",
                       "data": null
                     }
                     """
@@ -187,7 +187,7 @@ public interface RealtimeLocationDocs {
                             value = """
                     {
                       "code": "AUTH_4030",
-                      "message": "해당 시니어의 위치를 조회할 권한이 없습니다.",
+                      "message": "접근 권한이 없습니다. - 해당 시니어의 위치를 조회할 권한이 없습니다.",
                       "data": null
                     }
                     """

--- a/backend/widyu-api/src/main/java/com/widyu/location/realtime/controller/docs/RealtimeLocationDocs.java
+++ b/backend/widyu-api/src/main/java/com/widyu/location/realtime/controller/docs/RealtimeLocationDocs.java
@@ -104,7 +104,7 @@ public interface RealtimeLocationDocs {
                     examples = @ExampleObject(
                             value = """
                     {
-                      "code": "FORBIDDEN",
+                      "code": "AUTH_4030",
                       "message": "해당 시니어의 위치를 조회할 권한이 없습니다.",
                       "data": null
                     }
@@ -119,7 +119,7 @@ public interface RealtimeLocationDocs {
                     examples = @ExampleObject(
                             value = """
                     {
-                      "code": "NOT_FOUND",
+                      "code": "SRV_4040",
                       "message": "최근 위치 정보가 없습니다.",
                       "data": null
                     }
@@ -186,7 +186,7 @@ public interface RealtimeLocationDocs {
                     examples = @ExampleObject(
                             value = """
                     {
-                      "code": "FORBIDDEN",
+                      "code": "AUTH_4030",
                       "message": "해당 시니어의 위치를 조회할 권한이 없습니다.",
                       "data": null
                     }

--- a/backend/widyu-api/src/main/java/com/widyu/pay/controller/docs/PaymentDocs.java
+++ b/backend/widyu-api/src/main/java/com/widyu/pay/controller/docs/PaymentDocs.java
@@ -24,14 +24,67 @@ public interface PaymentDocs {
             summary = "결제 패키지 목록 조회",
             description = "서버가 제공하는 포인트 충전 패키지 목록을 조회합니다."
     )
-    @ApiResponse(responseCode = "200", description = "패키지 조회 성공")
+    @ApiResponse(
+            responseCode = "200",
+            description = "패키지 조회 성공",
+            content = @Content(
+                    schema = @Schema(implementation = ApiResponseTemplate.class),
+                    examples = @ExampleObject(
+                            name = "응답 예시",
+                            value = """
+                                    {
+                                      "code": "PAY_1999",
+                                      "message": "결제 패키지 조회 성공",
+                                      "data": [
+                                        {
+                                          "packageId": "POINT_10000",
+                                          "orderName": "포인트 10,000P 충전",
+                                          "amount": 10000,
+                                          "pointAmount": 10000
+                                        },
+                                        {
+                                          "packageId": "POINT_30000",
+                                          "orderName": "포인트 30,000P 충전",
+                                          "amount": 30000,
+                                          "pointAmount": 33000
+                                        }
+                                      ]
+                                    }
+                                    """
+                    )
+            )
+    )
     ApiResponseTemplate<java.util.List<PaymentPackageResponse>> getPackages();
 
     @Operation(
             summary = "결제 주문 생성",
             description = "결제 승인 전에 서버에 선행 주문을 생성하고 주문 ID, 금액, 만료 시각을 반환합니다."
     )
-    @ApiResponse(responseCode = "200", description = "주문 생성 성공")
+    @ApiResponse(
+            responseCode = "200",
+            description = "주문 생성 성공",
+            content = @Content(
+                    schema = @Schema(implementation = ApiResponseTemplate.class),
+                    examples = @ExampleObject(
+                            name = "응답 예시",
+                            value = """
+                                    {
+                                      "code": "PAY_2000",
+                                      "message": "주문 생성 성공",
+                                      "data": {
+                                        "orderId": "order_123456",
+                                        "packageId": "POINT_10000",
+                                        "orderName": "포인트 10,000P 충전",
+                                        "amount": 10000,
+                                        "pointAmount": 10000,
+                                        "status": "CREATED",
+                                        "expiresAt": "2026-07-06T12:10:00+09:00"
+                                      }
+                                    }
+                                    """
+                    )
+            )
+    )
     ApiResponseTemplate<PaymentOrderResponse> createOrder(
             @RequestBody(
                     required = true,

--- a/backend/widyu-api/src/main/java/com/widyu/pay/controller/docs/PaymentDocs.java
+++ b/backend/widyu-api/src/main/java/com/widyu/pay/controller/docs/PaymentDocs.java
@@ -66,9 +66,34 @@ public interface PaymentDocs {
                                       "code": "PAY_2001",
                                       "message": "결제 승인 성공",
                                       "data": {
-                                        "paymentKey": "string",
+                                        "mId": null,
+                                        "lastTransactionKey": null,
+                                        "paymentKey": "pay_abc123",
                                         "orderId": "order_123456",
-                                        "status": "DONE"
+                                        "orderName": "포인트 충전 5,000P",
+                                        "amount": 5000,
+                                        "taxExemptionAmount": 0,
+                                        "status": "DONE",
+                                        "requestedAt": "2026-07-06T12:00:00+09:00",
+                                        "approvedAt": "2026-07-06T12:00:05+09:00",
+                                        "canceledAmount": 0,
+                                        "canceledPointAmount": 0,
+                                        "remainingAmount": 5000,
+                                        "useEscrow": false,
+                                        "cultureExpense": false,
+                                        "cancellations": [],
+                                        "card": {
+                                          "issuerCode": "3K",
+                                          "acquirerCode": "3K",
+                                          "number": "43301234****000*",
+                                          "installmentPlanMonths": 0,
+                                          "interestFree": false,
+                                          "approveNo": "00000000",
+                                          "cardType": "신용"
+                                        },
+                                        "easyPay": null,
+                                        "transfer": null,
+                                        "virtualAccount": null
                                       }
                                     }
                                     """
@@ -110,9 +135,34 @@ public interface PaymentDocs {
                                       "code": "PAY_2002",
                                       "message": "결제 취소 성공",
                                       "data": {
-                                        "paymentKey": "string",
+                                        "mId": null,
+                                        "lastTransactionKey": null,
+                                        "paymentKey": "pay_abc123",
                                         "orderId": "order_123456",
-                                        "status": "CANCELED"
+                                        "orderName": "포인트 충전 5,000P",
+                                        "amount": 5000,
+                                        "taxExemptionAmount": 0,
+                                        "status": "CANCELED",
+                                        "requestedAt": "2026-07-06T12:00:00+09:00",
+                                        "approvedAt": "2026-07-06T12:00:05+09:00",
+                                        "canceledAmount": 5000,
+                                        "canceledPointAmount": 0,
+                                        "remainingAmount": 0,
+                                        "useEscrow": false,
+                                        "cultureExpense": false,
+                                        "cancellations": [
+                                          {
+                                            "cancelAmount": 5000,
+                                            "cancelPointAmount": 0,
+                                            "cancelReason": "사용자 요청",
+                                            "requestedByMemberId": 1,
+                                            "canceledAt": "2026-07-06T13:00:00+09:00"
+                                          }
+                                        ],
+                                        "card": null,
+                                        "easyPay": null,
+                                        "transfer": null,
+                                        "virtualAccount": null
                                       }
                                     }
                                     """
@@ -163,14 +213,56 @@ public interface PaymentDocs {
                                       "data": {
                                         "payments": [
                                           {
+                                            "mId": null,
+                                            "lastTransactionKey": null,
                                             "paymentKey": "pay_abc123",
                                             "orderId": "order_123456",
-                                            "status": "DONE"
+                                            "orderName": "포인트 충전 5,000P",
+                                            "amount": 5000,
+                                            "taxExemptionAmount": 0,
+                                            "status": "DONE",
+                                            "requestedAt": "2026-07-06T12:00:00+09:00",
+                                            "approvedAt": "2026-07-06T12:00:05+09:00",
+                                            "canceledAmount": 0,
+                                            "canceledPointAmount": 0,
+                                            "remainingAmount": 5000,
+                                            "useEscrow": false,
+                                            "cultureExpense": false,
+                                            "cancellations": [],
+                                            "card": null,
+                                            "easyPay": null,
+                                            "transfer": null,
+                                            "virtualAccount": null
                                           },
                                           {
+                                            "mId": null,
+                                            "lastTransactionKey": null,
                                             "paymentKey": "pay_xyz789",
                                             "orderId": "order_789123",
-                                            "status": "PARTIAL_CANCELED"
+                                            "orderName": "포인트 충전 10,000P",
+                                            "amount": 10000,
+                                            "taxExemptionAmount": 0,
+                                            "status": "PARTIAL_CANCELED",
+                                            "requestedAt": "2026-07-05T09:30:00+09:00",
+                                            "approvedAt": "2026-07-05T09:30:04+09:00",
+                                            "canceledAmount": 3000,
+                                            "canceledPointAmount": 0,
+                                            "remainingAmount": 7000,
+                                            "useEscrow": false,
+                                            "cultureExpense": false,
+                                            "cancellations": [
+                                              {
+                                                "cancelAmount": 3000,
+                                                "cancelPointAmount": 0,
+                                                "cancelReason": "부분 취소 요청",
+                                                "requestedByMemberId": 1,
+                                                "canceledAt": "2026-07-05T15:00:00+09:00"
+                                              }
+                                            ],
+                                            "card": null,
+                                            "easyPay": null,
+                                            "transfer": null,
+                                            "virtualAccount": null
                                           }
                                         ]
                                       }

--- a/backend/widyu-api/src/test/java/com/widyu/album/dto/request/AlbumFeedRequestTest.java
+++ b/backend/widyu-api/src/test/java/com/widyu/album/dto/request/AlbumFeedRequestTest.java
@@ -1,0 +1,76 @@
+package com.widyu.album.dto.request;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.widyu.global.error.BusinessException;
+import com.widyu.global.error.ErrorCode;
+import java.time.LocalDateTime;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+@DisplayName("AlbumFeedRequest 커서 파서 단위 테스트")
+class AlbumFeedRequestTest {
+
+    @Test
+    @DisplayName("복합 커서를 전달하면 createdAt과 albumId를 파싱한다")
+    void 복합_커서를_전달하면_createdAt과_albumId를_파싱한다() {
+        // given
+        String cursor = "2024-12-21T14:30:00|123";
+        String date = "2024-12-21";
+
+        // when
+        AlbumFeedRequest request = AlbumFeedRequest.from(cursor, date);
+
+        // then
+        assertThat(request.lastCreatedAt()).isEqualTo(LocalDateTime.of(2024, 12, 21, 14, 30));
+        assertThat(request.lastAlbumId()).isEqualTo(123L);
+        assertThat(request.date()).isEqualTo(date);
+        assertThat(request.hasCursor()).isTrue();
+    }
+
+    @Test
+    @DisplayName("커서가 없으면 첫 페이지 요청으로 파싱한다")
+    void 커서가_없으면_첫_페이지_요청으로_파싱한다() {
+        // given
+        String date = "2024-12-21";
+
+        // when
+        AlbumFeedRequest nullCursorRequest = AlbumFeedRequest.from(null, date);
+        AlbumFeedRequest blankCursorRequest = AlbumFeedRequest.from(" ", date);
+
+        // then
+        assertThat(nullCursorRequest.hasCursor()).isFalse();
+        assertThat(blankCursorRequest.hasCursor()).isFalse();
+        assertThat(nullCursorRequest.date()).isEqualTo(date);
+        assertThat(blankCursorRequest.date()).isEqualTo(date);
+    }
+
+    @Test
+    @DisplayName("커서 형식이 잘못되면 BAD_REQUEST 예외를 던진다")
+    void 커서_형식이_잘못되면_BAD_REQUEST_예외를_던진다() {
+        // given
+        String cursor = "123";
+
+        // when & then
+        assertThatThrownBy(() -> AlbumFeedRequest.from(cursor, null))
+                .isInstanceOf(BusinessException.class)
+                .extracting("errorCode")
+                .isEqualTo(ErrorCode.BAD_REQUEST);
+    }
+
+    @Test
+    @DisplayName("커서 날짜나 앨범 ID를 파싱할 수 없으면 BAD_REQUEST 예외를 던진다")
+    void 커서_날짜나_앨범_ID를_파싱할_수_없으면_BAD_REQUEST_예외를_던진다() {
+        // when & then
+        assertThatThrownBy(() -> AlbumFeedRequest.from("invalid-date|123", null))
+                .isInstanceOf(BusinessException.class)
+                .extracting("errorCode")
+                .isEqualTo(ErrorCode.BAD_REQUEST);
+
+        assertThatThrownBy(() -> AlbumFeedRequest.from("2024-12-21T14:30:00|abc", null))
+                .isInstanceOf(BusinessException.class)
+                .extracting("errorCode")
+                .isEqualTo(ErrorCode.BAD_REQUEST);
+    }
+}

--- a/backend/widyu-domain/src/main/java/com/widyu/global/error/ErrorCode.java
+++ b/backend/widyu-domain/src/main/java/com/widyu/global/error/ErrorCode.java
@@ -28,7 +28,7 @@ public enum ErrorCode {
     SOCIAL_NAME_NOT_PROVIDED(HttpStatus.BAD_REQUEST, "AUTH_4007", "소셜 로그인 제공자가 이름을 제공하지 않습니다."),
     SOCIAL_ACCOUNT_ALREADY_LINKED(HttpStatus.BAD_REQUEST, "AUTH_4008", "이미 연동된 소셜 계정입니다."),
     SOCIAL_ACCOUNT_ALREADY_LINKED_TO_CURRENT_USER(HttpStatus.BAD_REQUEST, "AUTH_4009", "현재 사용자에게 이미 연동된 소셜 계정입니다."),
-    SOCIAL_PROVIDER_ALREADY_LINKED(HttpStatus.BAD_REQUEST, "AUTH_4010", "이미 연동된 소셜 로그인 제공자입니다."),
+    SOCIAL_PROVIDER_ALREADY_LINKED(HttpStatus.BAD_REQUEST, "AUTH_4019", "이미 연동된 소셜 로그인 제공자입니다."),
 
     // 부모 인증 관련
     INVITE_CODE_DUPLICATED(HttpStatus.BAD_REQUEST, "PARENT_4001", "이미 존재하는 초대코드입니다."),


### PR DESCRIPTION
## 개요
Swagger 문서의 성공 응답 예시와 실제 컨트롤러 응답이 맞지 않는 부분을 정리합니다.
앨범 피드 커서는 ADR-0005의 복합 커서 기준에 맞게 `createdAt|albumId` 형식으로 검증합니다.

## 관련 문서
- LLD: -
- ADR: docs/adr/ADR-0005-cursor-pagination.md

## 관련 이슈
Closes #363

## 변경 사항
- 변경 모듈: widyu-api
- 앨범 업로드 Swagger 문서를 실제 `202 Accepted` 응답과 `AlbumUploadAcceptedResponse` 구조에 맞췄습니다.
- 앨범 피드와 미디어 피드 Swagger 커서 예시를 `createdAt|albumId` 형식으로 정리했습니다.
- 앨범 복합 커서 파서에서 잘못된 커서를 `BAD_REQUEST` 예외로 처리하도록 보강했습니다.
- 약 복용 Swagger 예시를 실제 `ApiResponseTemplate` 구조와 DTO 필드명에 맞췄습니다.
- 건강 일정 Swagger 예시에서 실제 응답 DTO에 없는 필드를 제거했습니다.
- 목표 홈 Swagger 설명에서 실제 DTO에 없는 필드를 제거하고, 실제 응답 구조에 맞는 성공 예시를 추가했습니다.
- 알림 카테고리 조회 응답 메시지를 도메인 메시지로 정리했습니다.
- 앨범 커서 파서 단위 테스트를 추가했습니다.

## 테스트
- `bash scripts/harness/validate-java-rules.sh ...`: 통과
- `./gradlew :backend:widyu-api:test --tests com.widyu.album.dto.request.AlbumFeedRequestTest`: 통과
- `./gradlew :backend:widyu-api:test`: 통과

## 체크리스트
- [x] 엔티티 변경이 없음을 확인했습니다.
- [x] MySQL ENUM 변경이 없음을 확인했습니다.
- [x] `@Async` 메서드 변경이 없음을 확인했습니다.
- [x] LLD가 없는 작업이며, 이슈 완료 조건을 충족했습니다.

## Open Questions (LLD 미결정 사항)
없습니다.

## 비고
원격 브랜치는 `feature/#363`으로 생성했습니다.
