### PR TITLE
refactor(health): 약복용·목표홈 응답 필드명·복용 status 계약 통일

### DIFF
--- a/backend/widyu-api/src/main/java/com/widyu/goal/home/application/GoalHomeService.java
+++ b/backend/widyu-api/src/main/java/com/widyu/goal/home/application/GoalHomeService.java
@@ -11,6 +11,7 @@ import com.widyu.goal.home.dto.response.GuardianGoalHomeResponse;
 import com.widyu.goal.home.dto.response.GuardianGoalStatsResponse;
 import com.widyu.goal.home.dto.response.SeniorGoalHomeResponse;
 import com.widyu.goal.home.dto.response.SeniorWeeklyGoalStatusResponse;
+import com.widyu.goal.medicineschedule.dto.response.MedicationStatus;
 import com.widyu.goal.medicineschedule.repository.MedicationProofRepository;
 import com.widyu.goal.medicineschedule.repository.MedicineScheduleRepository;
 import com.widyu.goal.walk.repository.WalkRepository;
@@ -387,6 +388,7 @@ public class GoalHomeService {
 
         LocalDateTime startOfDay = today.atStartOfDay();
         LocalDateTime endOfDay = today.atTime(LocalTime.MAX);
+        LocalDateTime now = LocalDateTime.now();
 
         // 오늘 복용 인증 정보 조회
         Map<Long, MedicationProof> proofMap = medicationProofRepository
@@ -413,6 +415,8 @@ public class GoalHomeService {
                 takenCount += scheduleTotal;
             }
 
+            MedicationStatus status = MedicationStatus.of(taken, today, schedule.getAlarmTime(), now);
+
             List<GuardianGoalHomeResponse.MedicineItem> medicineItems = schedule.getCategories().stream()
                     .flatMap(category -> category.getMedicines().stream())
                     .map(detail -> new GuardianGoalHomeResponse.MedicineItem(
@@ -428,7 +432,7 @@ public class GoalHomeService {
             scheduleItems.add(new GuardianGoalHomeResponse.ScheduleItem(
                     schedule.getId(),
                     schedule.getAlarmTime().format(TIME_FORMATTER),
-                    taken ? "taken" : "not_taken",
+                    status,
                     proofImageUrl,
                     medicineItems
             ));

--- a/backend/widyu-api/src/main/java/com/widyu/goal/home/controller/docs/GoalHomeDocs.java
+++ b/backend/widyu-api/src/main/java/com/widyu/goal/home/controller/docs/GoalHomeDocs.java
@@ -94,8 +94,8 @@ public interface GoalHomeDocs {
                                               "data": {
                                                 "medicine": {
                                                   "medicineScheduleId": 1,
-                                                  "todayTakenCount": 2,
-                                                  "todayTotalCount": 3,
+                                                  "takenCount": 2,
+                                                  "totalCount": 3,
                                                   "nextDoseCount": 4,
                                                   "nextAlarmTime": "17:00"
                                                 },
@@ -232,7 +232,7 @@ public interface GoalHomeDocs {
 
                     **약 스케줄 상세:**
                     - 각 알람 시간 (HH:mm 형식, 예: "19:00")
-                    - 복용 여부 (taken/not_taken)
+                    - 복용 상태 (DONE: 복용 완료, UPCOMING: 복용 시간 전, MISSED: 놓침)
                     - 복용 인증 사진 URL
                     - 복용해야 할 약 목록 (약 이름, 개수)
 
@@ -256,11 +256,11 @@ public interface GoalHomeDocs {
                                                 "medicine": {
                                                   "totalCount": 6,
                                                   "takenCount": 1,
-                                                  "schedules": [
+                                                  "medicineSchedules": [
                                                     {
                                                       "medicineScheduleId": 101,
                                                       "alarmTime": "19:00",
-                                                      "status": "taken",
+                                                      "status": "DONE",
                                                       "proofImageUrl": "https://www.widyu.shop/img",
                                                       "medicines": [
                                                         {

--- a/backend/widyu-api/src/main/java/com/widyu/goal/home/dto/response/GuardianGoalHomeResponse.java
+++ b/backend/widyu-api/src/main/java/com/widyu/goal/home/dto/response/GuardianGoalHomeResponse.java
@@ -1,6 +1,7 @@
 package com.widyu.goal.home.dto.response;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
+import com.widyu.goal.medicineschedule.dto.response.MedicationStatus;
 import io.swagger.v3.oas.annotations.media.Schema;
 import java.time.LocalDateTime;
 import java.util.List;
@@ -24,7 +25,7 @@ public record GuardianGoalHomeResponse(
             Integer takenCount,
 
             @Schema(description = "약 스케줄 목록")
-            List<ScheduleItem> schedules
+            List<ScheduleItem> medicineSchedules
     ) {
     }
 
@@ -36,8 +37,8 @@ public record GuardianGoalHomeResponse(
             @Schema(description = "알람 시간", example = "19:00")
             String alarmTime,
 
-            @Schema(description = "복용 상태 (taken/not_taken)", example = "taken")
-            String status,
+            @Schema(description = "복용 상태 (DONE: 복용 완료, UPCOMING: 복용 시간 전, MISSED: 놓침)", example = "DONE")
+            MedicationStatus status,
 
             @Schema(description = "복용 인증 이미지 URL", example = "https://www.widyu.shop/img")
             String proofImageUrl,

--- a/backend/widyu-api/src/main/java/com/widyu/goal/home/dto/response/SeniorGoalHomeResponse.java
+++ b/backend/widyu-api/src/main/java/com/widyu/goal/home/dto/response/SeniorGoalHomeResponse.java
@@ -20,10 +20,10 @@ public record SeniorGoalHomeResponse(
             Long medicineScheduleId,
 
             @Schema(description = "오늘 복용한 횟수", example = "2")
-            Integer todayTakenCount,
+            Integer takenCount,
 
             @Schema(description = "오늘 총 복용 예정 횟수", example = "3")
-            Integer todayTotalCount,
+            Integer totalCount,
 
             @Schema(description = "다음 복용 예정 개수", example = "4")
             Integer nextDoseCount,

--- a/backend/widyu-api/src/main/java/com/widyu/goal/medicineschedule/controller/docs/MedicineScheduleDocs.java
+++ b/backend/widyu-api/src/main/java/com/widyu/goal/medicineschedule/controller/docs/MedicineScheduleDocs.java
@@ -63,7 +63,7 @@ public interface MedicineScheduleDocs {
                                               "code": "MEDICINE_2001",
                                               "message": "일자별 약 복용 현황 조회 성공",
                                               "data": {
-                                                "medicineSchedule": [
+                                                "medicineSchedules": [
                                                   {
                                                     "medicineScheduleId": 1,
                                                     "totalCount": 3,
@@ -190,12 +190,12 @@ public interface MedicineScheduleDocs {
                                               "code": "MEDICINE_2003",
                                               "message": "시니어 약복용 홈 조회 성공",
                                               "data": {
-                                                "schedules": [
+                                                "medicineSchedules": [
                                                   {
-                                                    "scheduleId": 1,
-                                                    "medicineTotalCount": 3,
+                                                    "medicineScheduleId": 1,
+                                                    "totalCount": 3,
                                                     "alarmTime": "08:00",
-                                                    "medicineDetails": [
+                                                    "medicines": [
                                                       {
                                                         "name": "타이레놀",
                                                         "count": 1
@@ -207,10 +207,10 @@ public interface MedicineScheduleDocs {
                                                     ]
                                                   },
                                                   {
-                                                    "scheduleId": 2,
-                                                    "medicineTotalCount": 1,
+                                                    "medicineScheduleId": 2,
+                                                    "totalCount": 1,
                                                     "alarmTime": "20:00",
-                                                    "medicineDetails": [
+                                                    "medicines": [
                                                       {
                                                         "name": "오메가3",
                                                         "count": 1

--- a/backend/widyu-api/src/main/java/com/widyu/goal/medicineschedule/dto/response/MedicineHomeResponse.java
+++ b/backend/widyu-api/src/main/java/com/widyu/goal/medicineschedule/dto/response/MedicineHomeResponse.java
@@ -5,22 +5,22 @@ import java.util.List;
 import java.util.stream.Collectors;
 
 public record MedicineHomeResponse(
-        List<ScheduleItem> schedules
+        List<ScheduleItem> medicineSchedules
 ) {
-    public static MedicineHomeResponse of(List<ScheduleItem> schedules) {
-        return new MedicineHomeResponse(schedules);
+    public static MedicineHomeResponse of(List<ScheduleItem> medicineSchedules) {
+        return new MedicineHomeResponse(medicineSchedules);
     }
 
     public record ScheduleItem(
-            Long scheduleId,
-            Integer medicineTotalCount,
+            Long medicineScheduleId,
+            Integer totalCount,
             String alarmTime,
-            List<MedicineDetail> medicineDetails
+            List<MedicineItem> medicines
     ) {
         public static ScheduleItem from(MedicineSchedule schedule) {
-            List<MedicineDetail> medicineDetails = schedule.getCategories().stream()
+            List<MedicineItem> medicines = schedule.getCategories().stream()
                     .flatMap(category -> category.getMedicines().stream()
-                            .map(detail -> MedicineDetail.of(
+                            .map(detail -> MedicineItem.of(
                                     detail.getMedicine().getName(),
                                     detail.getDose()
                             )))
@@ -30,17 +30,17 @@ public record MedicineHomeResponse(
                     schedule.getId(),
                     schedule.getTotalCount(),
                     schedule.getAlarmTime().toString(),
-                    medicineDetails
+                    medicines
             );
         }
     }
 
-    public record MedicineDetail(
+    public record MedicineItem(
             String name,
             Integer count
     ) {
-        public static MedicineDetail of(String name, Integer count) {
-            return new MedicineDetail(name, count);
+        public static MedicineItem of(String name, Integer count) {
+            return new MedicineItem(name, count);
         }
     }
 }

--- a/backend/widyu-api/src/main/java/com/widyu/goal/medicineschedule/dto/response/MedicineScheduleDailyResponse.java
+++ b/backend/widyu-api/src/main/java/com/widyu/goal/medicineschedule/dto/response/MedicineScheduleDailyResponse.java
@@ -5,10 +5,10 @@ import java.util.List;
 import java.util.stream.Collectors;
 
 public record MedicineScheduleDailyResponse(
-        List<ScheduleItem> medicineSchedule
+        List<ScheduleItem> medicineSchedules
 ) {
-    public static MedicineScheduleDailyResponse of(List<ScheduleItem> medicineSchedule) {
-        return new MedicineScheduleDailyResponse(medicineSchedule);
+    public static MedicineScheduleDailyResponse of(List<ScheduleItem> medicineSchedules) {
+        return new MedicineScheduleDailyResponse(medicineSchedules);
     }
 
     public record ScheduleItem(

--- a/backend/widyu-api/src/test/java/com/widyu/goal/medicineschedule/application/MedicineScheduleServiceTest.java
+++ b/backend/widyu-api/src/test/java/com/widyu/goal/medicineschedule/application/MedicineScheduleServiceTest.java
@@ -73,7 +73,7 @@ class MedicineScheduleServiceTest {
         MedicineScheduleDailyResponse response = medicineScheduleService.getDailySchedules(memberId, pastDate);
 
         // then
-        Map<Long, MedicationStatus> statusByScheduleId = response.medicineSchedule().stream()
+        Map<Long, MedicationStatus> statusByScheduleId = response.medicineSchedules().stream()
                 .collect(Collectors.toMap(ScheduleItem::medicineScheduleId, ScheduleItem::status));
         assertThat(statusByScheduleId.get(10L)).isEqualTo(MedicationStatus.DONE);
         assertThat(statusByScheduleId.get(20L)).isEqualTo(MedicationStatus.MISSED);
@@ -95,7 +95,7 @@ class MedicineScheduleServiceTest {
         MedicineScheduleDailyResponse response = medicineScheduleService.getDailySchedules(memberId, date);
 
         // then
-        assertThat(response.medicineSchedule()).isEmpty();
+        assertThat(response.medicineSchedules()).isEmpty();
         then(medicationProofRepository).should(never()).findVerifiedScheduleIds(anyList(), any(), any());
     }
 }

--- a/docs/lld/LLD-0007-medicine-daily-status.md
+++ b/docs/lld/LLD-0007-medicine-daily-status.md
@@ -48,7 +48,7 @@ Response:
   "code": "MEDICINE_2001",
   "message": "일자별 약 복용 현황 조회 성공",
   "result": {
-    "medicineSchedule": [
+    "medicineSchedules": [
       {
         "medicineScheduleId": 1,
         "totalCount": 3,
@@ -117,7 +117,7 @@ now > date.atTime(alarmTime) + 30분(인증 마감)     → MISSED
 | `date` 형식 오류 | 400 Bad Request (Spring `@DateTimeFormat(ISO.DATE)` 파싱 실패) |
 | 존재하지 않는 `memberId` | `BusinessException(BAD_REQUEST)` "존재하지 않는 사용자입니다." |
 | 보호자-시니어 가족 연결 없음 | 403 Forbidden (`@ValidateFamilyAccess`) |
-| 활성 스케줄 없음 | 빈 `medicineSchedule` 목록 반환 (인증 조회 생략) |
+| 활성 스케줄 없음 | 빈 `medicineSchedules` 목록 반환 (인증 조회 생략) |
 
 신규 에러 코드 없음. 성공 코드 `MEDICINE_2001` 유지(메시지만 "일자별 …"로 변경).
 
@@ -140,6 +140,7 @@ now > date.atTime(alarmTime) + 30분(인증 마감)     → MISSED
 - **API 계약 변경(Breaking)**: `/today`가 제거되고 `/daily?date=`로 대체된다. 응답에서 기존 `taken`(boolean, 실제로는 미포함) 대신 `status`가 추가된다.
   - 앱 클라이언트가 `date` 파라미터 전달 + `status` 분기를 구현해야 하며, 배포 타이밍을 서버와 맞춰야 한다.
 - `MedicationProofService`의 인증 허용창 상수 출처가 `MedicationStatus.ALLOWED_WINDOW_MINUTES`로 변경(값 30분 동일, 동작 변화 없음).
+- 응답 리스트 키를 `medicineSchedule`(단수) → `medicineSchedules`(복수)로 정정(#366). 약복용 홈·목표 홈 응답과 필드명·`status` 표현을 통일하는 작업의 일부이며, 단수 키 파싱 클라이언트는 수정이 필요하다.
 
 ## 9. 미결정 사항 (Open Questions)
 


### PR DESCRIPTION
## 개요

약 복용 홈, 일자별 현황, 목표 홈(시니어/보호자)이 같은 "약 스케줄" 데이터를 서로 다른 필드명과 복용 상태 표현으로 반환하고 있었습니다. 클라이언트가 응답마다 다른 키로 파싱해야 했고, 복용 상태도 일자별은 `DONE/UPCOMING/MISSED`(3단계 enum), 목표 홈 보호자는 `taken/not_taken`(2단계 문자열)로 제각각이었습니다. 네 응답의 필드명과 `status` 표현을 하나의 계약으로 통일합니다.

## 관련 문서

- LLD: docs/lld/LLD-0007-medicine-daily-status.md (일자별 응답 리스트 키를 `medicineSchedule`(단수) → `medicineSchedules`(복수)로 정정)
- ADR: -

## 관련 이슈

Closes #366

## 변경 사항

- 변경 모듈: widyu-api (`goal/medicineschedule`, `goal/home`)
- 네 응답의 동일 의미 필드를 통일했습니다.
  - 리스트 키: `schedules` / `medicineSchedule`(단수) → `medicineSchedules`(복수)
  - 스케줄 ID: `scheduleId` → `medicineScheduleId`
  - 개수: `medicineTotalCount` / `todayTakenCount` / `todayTotalCount` → `totalCount` / `takenCount`
  - 약 목록: `medicineDetails` → `medicines`
- 목표 홈 보호자 응답의 `status`를 문자열(`taken`/`not_taken`)에서 `MedicationStatus`(DONE/UPCOMING/MISSED) enum으로 통일했습니다. `GoalHomeService`가 알람 ±30분 창을 기준으로 상태를 계산합니다.
- Swagger 예시(`MedicineScheduleDocs`, `GoalHomeDocs`)와 LLD-0007을 통일된 계약과 일치하도록 갱신했습니다.
- 약 복용 홈(`/home`) 응답에는 `status` 필드를 추가하지 않았습니다. (홈 목록은 상태 미표기 유지)

## 테스트

- `./gradlew :backend:widyu-api:test`: 통과 (Medicine·GoalHome·MedicationStatus 대상, `BUILD SUCCESSFUL`)

## 체크리스트

- [x] 엔티티 변경 없음 (`MedicationStatus`는 응답 전용 enum, DB 미영속)
- [x] MySQL ENUM 변경 없음
- [x] `@Async` 변경 없음
- [x] LLD-0007 인수조건 충족 (응답 키 정정 반영)

## Open Questions (LLD 미결정 사항)

없습니다.

## 비고

- **API 계약 Breaking Change입니다.** 앱 클라이언트가 새 필드명과 3단계 `status`를 파싱하도록 수정해야 하며, 서버 배포와 타이밍을 맞춰야 합니다.
- 후속 후보: 약 복용 홈(`/home`)에도 `status`가 필요한지 여부는 별도 논의가 필요합니다.
