### PR TITLE
docs: 이슈 생성 스킬에 assignee·label 지정 추가 및 CLAUDE.md에 .agents 스킬 참조 명시

### DIFF
--- a/.agents/skills/issue/SKILL.md
+++ b/.agents/skills/issue/SKILL.md
@@ -15,6 +15,8 @@ WIDYU-server 작업을 시작하기 전에 GitHub Issue를 생성하고, 필요�
 - 작업 범위가 크면 분리안을 제안한다.
 - 미결정 사항은 `확인 필요`로 남긴다.
 - 브랜치는 사용자 요청 시 또는 바로 작업할 때만 만든다.
+- 기본 Assignee: `dongkyun0713`.
+- 변경 성격에 맞는 label을 확인하고 가능하면 함께 지정한다.
 
 ## 절차
 
@@ -25,9 +27,23 @@ WIDYU-server 작업을 시작하기 전에 GitHub Issue를 생성하고, 필요�
 2. `gh issue list --state open --limit 30 --json number,title,labels`로 중복 확인.
 3. 관련 LLD가 `docs/lld/`에 있으면 이슈 본문에 링크를 건다.
 4. 아래 템플릿으로 본문 작성.
-5. `gh issue create --title "<title>" --body-file <tmpfile>`.
-6. 필요하면 최신화된 `develop`에서 `git switch -c feature/<issue-number>`로 브랜치를 만든다.
-7. 이슈 번호, URL, 브랜치명 보고.
+5. `gh label list --limit 50`로 사용 가능한 label을 확인한다.
+6. `gh issue create --title "<title>" --body-file <tmpfile> --assignee dongkyun0713 --label "<label>"`.
+7. `gh issue view <N> --json assignees,labels`로 assignee와 label 반영을 확인한다.
+8. 필요하면 최신화된 `develop`에서 `git switch -c feature/<issue-number>`로 브랜치를 만든다.
+9. 이슈 번호, URL, 브랜치명 보고.
+
+### Label 선택 기준
+
+| 변경 성격 | label |
+| --- | --- |
+| 문서/가이드/스킬 문서 | `Docs` |
+| 개발 환경, CI, 설정, 하네스 | `Setting` |
+| 테스트 코드/검증 보강 | `Test` |
+| 기능 구현 | `Feature` |
+| 버그 수정 | `bug` |
+| 구조 개선 | `Refactor` |
+| 배포/인프라 | `Devops` |
 
 ## 이슈 본문 템플릿
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -3,6 +3,8 @@
 This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
 
 > 도메인 상세 로직, 비즈니스 플로우, DB·외부 연동·보안 설계는 [backend/CLAUDE.md](backend/CLAUDE.md)를 참조하세요.
+>
+> 이슈·커밋·PR·리뷰·구현 작업은 항상 [.agents/skills](.agents/skills) 아래 해당 스킬(`issue`, `commit`, `pr`, `review`, `implement`)의 절차·컨벤션을 먼저 확인하고 그대로 따르세요. 예: 이슈 생성 → [.agents/skills/issue/SKILL.md](.agents/skills/issue/SKILL.md), 커밋 → [.agents/skills/commit/SKILL.md](.agents/skills/commit/SKILL.md), PR → [.agents/skills/pr/SKILL.md](.agents/skills/pr/SKILL.md).
 
 ## Project Overview
 


### PR DESCRIPTION
## 개요

이슈 생성 스킬(`.agents/skills/issue`)에 담당자·라벨 지정 절차가 없어 이슈 생성 시 assignee·label이 누락되던 문제를 보완합니다. 또한 루트 `CLAUDE.md`가 `.agents/skills` 절차를 항상 참고하도록 안내를 추가합니다.

## 관련 문서

- LLD: -
- ADR: -

## 관련 이슈

Closes #368

## 변경 사항

- `.agents/skills/issue/SKILL.md`
  - 핵심 원칙에 기본 Assignee(`dongkyun0713`)와 label 지정 항목 추가
  - 절차에 `gh label list` 확인, `gh issue create --assignee --label`, `gh issue view`로 반영 확인 단계 추가
  - PR 스킬과 동일한 Label 선택 기준 표 추가
- `CLAUDE.md`
  - 상단에 이슈·커밋·PR·리뷰·구현 작업 시 `.agents/skills` 절차를 먼저 확인하도록 안내 추가

## 테스트

- 문서 변경으로 코드 테스트 대상이 아닙니다.

## 체크리스트

- [x] 엔티티 변경 없음
- [x] MySQL ENUM 변경 없음
- [x] `@Async` 변경 없음
- [x] 문서 전용 변경

## Open Questions (LLD 미결정 사항)

없습니다.

## 비고

- 이후 이슈 생성 작업부터 assignee·label이 자동으로 지정되도록 하는 컨벤션 정비입니다.
