### PR TITLE
feat(health): 일자별 약 복용 조회 응답에 proofImageUrl 추가

### DIFF
--- a/backend/widyu-api/src/main/java/com/widyu/goal/medicineschedule/application/MedicineScheduleService.java
+++ b/backend/widyu-api/src/main/java/com/widyu/goal/medicineschedule/application/MedicineScheduleService.java
@@ -18,6 +18,7 @@ import com.widyu.goal.medicineschedule.repository.MedicineRepository;
 import com.widyu.goal.medicineschedule.repository.MedicineScheduleRepository;
 import com.widyu.member.Member;
 import com.widyu.member.repository.MemberRepository;
+import com.widyu.medicine.MedicationProof;
 import com.widyu.medicine.Medicine;
 import com.widyu.medicine.MedicineCategory;
 import com.widyu.medicine.MedicineSchedule;
@@ -54,33 +55,49 @@ public class MedicineScheduleService {
         List<MedicineSchedule> schedules = medicineScheduleRepository
                 .findByMemberAndStatusWithDetails(targetMember, Status.ACTIVE);
 
-        Set<Long> verifiedScheduleIds = findVerifiedScheduleIds(schedules, date);
+        if (schedules.isEmpty()) {
+            return MedicineScheduleDailyResponse.of(List.of());
+        }
+
+        Map<Long, MedicationProof> proofsByScheduleId = findProofsByScheduleId(targetMember, date);
         LocalDateTime now = LocalDateTime.now();
 
         List<MedicineScheduleDailyResponse.ScheduleItem> scheduleItems = schedules.stream()
                 .map(schedule -> {
-                    boolean verified = verifiedScheduleIds.contains(schedule.getId());
+                    MedicationProof proof = proofsByScheduleId.get(schedule.getId());
+                    boolean verified = proof != null;
                     MedicationStatus status = MedicationStatus.of(verified, date, schedule.getAlarmTime(), now);
-                    return MedicineScheduleDailyResponse.ScheduleItem.from(schedule, status);
+                    String proofImageUrl = extractProofImageUrl(proof);
+                    return MedicineScheduleDailyResponse.ScheduleItem.from(schedule, status, proofImageUrl);
                 })
                 .collect(Collectors.toList());
 
         return MedicineScheduleDailyResponse.of(scheduleItems);
     }
 
-    private Set<Long> findVerifiedScheduleIds(List<MedicineSchedule> schedules, LocalDate date) {
-        List<Long> scheduleIds = schedules.stream()
-                .map(MedicineSchedule::getId)
-                .collect(Collectors.toList());
-
-        if (scheduleIds.isEmpty()) {
-            return Set.of();
-        }
-
+    private Map<Long, MedicationProof> findProofsByScheduleId(Member member, LocalDate date) {
         LocalDateTime startOfDay = date.atStartOfDay();
         LocalDateTime endOfDay = date.atTime(LocalTime.MAX);
 
-        return Set.copyOf(medicationProofRepository.findVerifiedScheduleIds(scheduleIds, startOfDay, endOfDay));
+        return medicationProofRepository.findByMemberIdAndDateRange(member.getId(), startOfDay, endOfDay)
+                .stream()
+                .collect(Collectors.toMap(
+                        proof -> proof.getMedicineSchedule().getId(),
+                        proof -> proof,
+                        (existing, duplicate) -> existing
+                ));
+    }
+
+    private String extractProofImageUrl(MedicationProof proof) {
+        if (proof == null) {
+            return null;
+        }
+
+        if (proof.getProofImageUrls().isEmpty()) {
+            return null;
+        }
+
+        return proof.getProofImageUrls().get(0);
     }
 
     public MedicineMonthlyResponse getMonthlyStats(int year, int month, Long memberId) {

--- a/backend/widyu-api/src/main/java/com/widyu/goal/medicineschedule/controller/docs/MedicineScheduleDocs.java
+++ b/backend/widyu-api/src/main/java/com/widyu/goal/medicineschedule/controller/docs/MedicineScheduleDocs.java
@@ -41,6 +41,7 @@ public interface MedicineScheduleDocs {
                       - DONE: 복용 인증 완료
                       - UPCOMING: 아직 인증 마감(알람+30분) 전 (미복용)
                       - MISSED: 인증 마감이 지났는데 미인증
+                    - 각 스케줄의 복용 인증 이미지(proofImageUrl) 반환 (인증 없으면 null)
 
                     **파라미터:**
                     - date: 조회할 날짜 (yyyy-MM-dd)
@@ -69,6 +70,7 @@ public interface MedicineScheduleDocs {
                                                     "totalCount": 3,
                                                     "alarmTime": "08:00",
                                                     "status": "DONE",
+                                                    "proofImageUrl": "https://www.widyu.shop/proof/1.jpg",
                                                     "medicines": [
                                                       {
                                                         "name": "타이레놀",
@@ -85,6 +87,7 @@ public interface MedicineScheduleDocs {
                                                     "totalCount": 1,
                                                     "alarmTime": "20:00",
                                                     "status": "UPCOMING",
+                                                    "proofImageUrl": null,
                                                     "medicines": [
                                                       {
                                                         "name": "오메가3",

--- a/backend/widyu-api/src/main/java/com/widyu/goal/medicineschedule/dto/response/MedicineScheduleDailyResponse.java
+++ b/backend/widyu-api/src/main/java/com/widyu/goal/medicineschedule/dto/response/MedicineScheduleDailyResponse.java
@@ -16,9 +16,10 @@ public record MedicineScheduleDailyResponse(
             Integer totalCount,
             String alarmTime,
             MedicationStatus status,
+            String proofImageUrl,
             List<MedicineItem> medicines
     ) {
-        public static ScheduleItem from(MedicineSchedule schedule, MedicationStatus status) {
+        public static ScheduleItem from(MedicineSchedule schedule, MedicationStatus status, String proofImageUrl) {
             List<MedicineItem> medicines = schedule.getCategories().stream()
                     .flatMap(category -> category.getMedicines().stream()
                             .map(detail -> MedicineItem.of(
@@ -32,6 +33,7 @@ public record MedicineScheduleDailyResponse(
                     schedule.getTotalCount(),
                     schedule.getAlarmTime().toString(),
                     status,
+                    proofImageUrl,
                     medicines
             );
         }

--- a/backend/widyu-api/src/test/java/com/widyu/goal/medicineschedule/application/MedicineScheduleServiceTest.java
+++ b/backend/widyu-api/src/test/java/com/widyu/goal/medicineschedule/application/MedicineScheduleServiceTest.java
@@ -2,7 +2,7 @@ package com.widyu.goal.medicineschedule.application;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.never;
 import static org.mockito.BDDMockito.then;
@@ -16,6 +16,7 @@ import com.widyu.goal.medicineschedule.dto.response.MedicineScheduleDailyRespons
 import com.widyu.goal.medicineschedule.repository.MedicationProofRepository;
 import com.widyu.goal.medicineschedule.repository.MedicineRepository;
 import com.widyu.goal.medicineschedule.repository.MedicineScheduleRepository;
+import com.widyu.medicine.MedicationProof;
 import com.widyu.medicine.MedicineSchedule;
 import com.widyu.member.Member;
 import com.widyu.member.repository.MemberRepository;
@@ -53,8 +54,8 @@ class MedicineScheduleServiceTest {
     }
 
     @Test
-    @DisplayName("지난 날짜를 조회하면 인증된 스케줄은 DONE, 미인증 스케줄은 MISSED로 반환된다")
-    void 지난_날짜_조회하면_인증_스케줄은_DONE_미인증은_MISSED로_반영된다() {
+    @DisplayName("지난 날짜를 조회하면 인증 스케줄은 DONE과 인증 이미지, 미인증 스케줄은 MISSED와 null을 반환한다")
+    void 지난_날짜_조회하면_인증_스케줄은_DONE과_이미지_미인증은_MISSED와_null을_반영한다() {
         // given
         Long memberId = 1L;
         LocalDate pastDate = LocalDate.of(2020, 1, 1);
@@ -63,20 +64,27 @@ class MedicineScheduleServiceTest {
         MedicineSchedule verified = scheduleWithId(10L, LocalTime.of(8, 0));
         MedicineSchedule notVerified = scheduleWithId(20L, LocalTime.of(20, 0));
 
+        MedicationProof proof = mock(MedicationProof.class);
+        given(proof.getMedicineSchedule()).willReturn(verified);
+        given(proof.getProofImageUrls()).willReturn(List.of("https://widyu.shop/proof/10.jpg"));
+
         given(memberRepository.findById(memberId)).willReturn(Optional.of(targetMember));
+        given(targetMember.getId()).willReturn(memberId);
         given(medicineScheduleRepository.findByMemberAndStatusWithDetails(targetMember, Status.ACTIVE))
                 .willReturn(List.of(verified, notVerified));
-        given(medicationProofRepository.findVerifiedScheduleIds(anyList(), any(), any()))
-                .willReturn(List.of(10L));
+        given(medicationProofRepository.findByMemberIdAndDateRange(anyLong(), any(), any()))
+                .willReturn(List.of(proof));
 
         // when
         MedicineScheduleDailyResponse response = medicineScheduleService.getDailySchedules(memberId, pastDate);
 
         // then
-        Map<Long, MedicationStatus> statusByScheduleId = response.medicineSchedules().stream()
-                .collect(Collectors.toMap(ScheduleItem::medicineScheduleId, ScheduleItem::status));
-        assertThat(statusByScheduleId.get(10L)).isEqualTo(MedicationStatus.DONE);
-        assertThat(statusByScheduleId.get(20L)).isEqualTo(MedicationStatus.MISSED);
+        Map<Long, ScheduleItem> itemByScheduleId = response.medicineSchedules().stream()
+                .collect(Collectors.toMap(ScheduleItem::medicineScheduleId, item -> item));
+        assertThat(itemByScheduleId.get(10L).status()).isEqualTo(MedicationStatus.DONE);
+        assertThat(itemByScheduleId.get(10L).proofImageUrl()).isEqualTo("https://widyu.shop/proof/10.jpg");
+        assertThat(itemByScheduleId.get(20L).status()).isEqualTo(MedicationStatus.MISSED);
+        assertThat(itemByScheduleId.get(20L).proofImageUrl()).isNull();
     }
 
     @Test
@@ -96,6 +104,6 @@ class MedicineScheduleServiceTest {
 
         // then
         assertThat(response.medicineSchedules()).isEmpty();
-        then(medicationProofRepository).should(never()).findVerifiedScheduleIds(anyList(), any(), any());
+        then(medicationProofRepository).should(never()).findByMemberIdAndDateRange(anyLong(), any(), any());
     }
 }

--- a/docs/lld/LLD-0007-medicine-daily-status.md
+++ b/docs/lld/LLD-0007-medicine-daily-status.md
@@ -54,6 +54,7 @@ Response:
         "totalCount": 3,
         "alarmTime": "08:00",
         "status": "DONE",
+        "proofImageUrl": "https://www.widyu.shop/proof/1.jpg",
         "medicines": [
           { "name": "타이레놀", "count": 1 },
           { "name": "비타민C", "count": 2 }
@@ -64,6 +65,7 @@ Response:
         "totalCount": 1,
         "alarmTime": "20:00",
         "status": "UPCOMING",
+        "proofImageUrl": null,
         "medicines": [
           { "name": "오메가3", "count": 1 }
         ]
@@ -75,14 +77,16 @@ Response:
 
 `status`: `DONE`(복용 인증 완료) / `UPCOMING`(미인증, 인증 마감 전) / `MISSED`(미인증, 인증 마감 후)
 
+`proofImageUrl`: 해당 날짜의 복용 인증 이미지 첫 장 URL. 인증이 없거나 이미지가 없으면 `null` (#370).
+
 ## 4. 데이터 모델
 
 신규 엔티티·테이블·컬럼 없음.
 
 - `MedicationStatus` (widyu-api, `goal/medicineschedule/dto/response`): 응답 계산용 enum. **영속 대상 아님** (DB ENUM 컬럼 아님).
   - 상수 `ALLOWED_WINDOW_MINUTES = 30` 를 단일 정의. `MedicationProofService`의 인증 허용창도 이 상수를 참조.
-- `MedicineScheduleDailyResponse` (widyu-api, dto/response): 기존 `MedicineScheduleTodayResponse`를 대체. 정적 팩토리 `of()` / `ScheduleItem.from(schedule, status)` 사용.
-- 재사용 엔티티: `MedicineSchedule`(알람시간·카테고리·약품), `MedicationProof`(`verifiedAt`).
+- `MedicineScheduleDailyResponse` (widyu-api, dto/response): 기존 `MedicineScheduleTodayResponse`를 대체. 정적 팩토리 `of()` / `ScheduleItem.from(schedule, status, proofImageUrl)` 사용. `ScheduleItem`은 `proofImageUrl`(복용 인증 이미지) 필드를 포함한다(#370).
+- 재사용 엔티티: `MedicineSchedule`(알람시간·카테고리·약품), `MedicationProof`(`verifiedAt`, `proofImageUrls`).
 
 ## 5. 처리 흐름
 
@@ -93,12 +97,14 @@ Response:
 2. getMember(memberId): null이면 memberUtil.getCurrentMember(), 아니면 memberRepository.findById
 3. medicineScheduleRepository.findByMemberAndStatusWithDetails(member, ACTIVE)
    → 활성 스케줄 + 카테고리/약품 fetch join
-4. 인증된 스케줄 id 집합 조회 (findVerifiedScheduleIds)
-   - 스케줄 id 목록이 비면 조회 생략 후 빈 Set 반환
-   - MedicationProofRepository.findVerifiedScheduleIds(ids, date 00:00:00 ~ date 23:59:59.999999999)
-5. now = LocalDateTime.now()
-6. 스케줄별로 verified = 집합 포함 여부 → MedicationStatus.of(verified, date, alarmTime, now)
-7. MedicineScheduleDailyResponse.of(items) 반환
+4. 활성 스케줄이 비면 인증 조회를 생략하고 빈 목록 반환
+5. 스케줄별 복용 인증 조회 (findProofsByScheduleId)
+   - MedicationProofRepository.findByMemberIdAndDateRange(memberId, date 00:00:00 ~ date 23:59:59.999999999)
+   - 결과를 scheduleId → MedicationProof Map으로 수집 (중복 시 첫 인증 유지)
+6. now = LocalDateTime.now()
+7. 스케줄별로 verified = Map에 인증 존재 여부 → MedicationStatus.of(verified, date, alarmTime, now)
+   - proofImageUrl = 인증의 proofImageUrls 첫 장 (없으면 null)
+8. MedicineScheduleDailyResponse.of(items) 반환
 ```
 
 상태 계산 `MedicationStatus.of(verified, date, alarmTime, now)`:
@@ -128,6 +134,7 @@ now > date.atTime(alarmTime) + 30분(인증 마감)     → MISSED
 - [x] 복용 인증이 있으면 `DONE`을 반환한다.
 - [x] 미인증이고 인증 마감(알람+30분) 전이면 `UPCOMING`을 반환한다.
 - [x] 미인증이고 인증 마감이 지났으면 `MISSED`를 반환한다.
+- [x] 각 스케줄에 복용 인증 이미지(`proofImageUrl`)를 반환하고, 인증이 없으면 `null`을 반환한다 (#370).
 - [x] 활성 스케줄이 없으면 빈 목록을 반환하고 인증 조회를 생략한다.
 - [x] 인증 허용창(30분)은 `MedicationStatus`의 단일 상수이며 `verifyMedication`도 이를 참조한다.
 - [x] Swagger에 `status` 설명과 일자별 조회 응답이 반영된다.


### PR DESCRIPTION
## 개요

일자별 약 복용 조회 API(`GET /medicine-schedules/daily`) 응답의 각 스케줄에 복용 인증 이미지(`proofImageUrl`)가 포함되지 않던 문제를 해결합니다. 목표 홈 보호자 응답과 동일하게 인증 이미지를 내려줘, 날짜별 화면에서 인증 사진을 확인할 수 있습니다.

## 관련 문서

- LLD: docs/lld/LLD-0007-medicine-daily-status.md
- ADR: -

## 관련 이슈

Closes #370

## 변경 사항

- 변경 모듈: widyu-api (`goal/medicineschedule`)
- `MedicineScheduleDailyResponse.ScheduleItem`에 `proofImageUrl` 필드를 추가했습니다. (`from` 팩토리가 인자로 받음)
- `MedicineScheduleService.getDailySchedules`를 인증 스케줄 ID 집합(`findVerifiedScheduleIds`) 조회에서 복용 인증(`findByMemberIdAndDateRange`) 조회로 전환해, 스케줄별 `MedicationProof`를 매핑하고 첫 인증 이미지를 반환합니다. 인증이 없으면 `null`입니다.
- 활성 스케줄이 없으면 인증 조회를 생략하고 빈 목록을 반환하는 기존 동작을 유지했습니다.
- Swagger 예시(`MedicineScheduleDocs`)와 LLD-0007에 `proofImageUrl`을 반영했습니다.

## 테스트

- `./gradlew :backend:widyu-api:test` (MedicineScheduleService·MedicationStatus): 통과 (`BUILD SUCCESSFUL`)
- 인증 스케줄은 `DONE`과 이미지 URL, 미인증은 `MISSED`와 `null`을 반환하는 케이스를 단위 테스트로 검증했습니다.

## 체크리스트

- [x] 엔티티 변경 없음
- [x] MySQL ENUM 변경 없음
- [x] `@Async` 변경 없음
- [x] LLD 인수조건 충족 (proofImageUrl 반환 포함)

## Open Questions (LLD 미결정 사항)

없습니다.

## 비고

- 응답에 필드가 추가되는 하위 호환 변경입니다. 기존 클라이언트는 영향받지 않으며, 인증 이미지 표시가 필요한 화면에서 새 필드를 사용하면 됩니다.
