### PR TITLE
웹소켓 토큰 쿼리 로그 노출을 방지합니다

### DIFF
--- a/backend/widyu-api/src/main/resources/application-dev.yml
+++ b/backend/widyu-api/src/main/resources/application-dev.yml
@@ -14,6 +14,6 @@ spring:
 
 logging:
   level:
-    org.springframework.web: debug
+    org.springframework.web: info
     org.hibernate.SQL: debug
     org.hibernate.type: trace

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -18,6 +18,12 @@ http {
                     '"$http_user_agent" "$http_x_forwarded_for" '
                     'rt=$request_time uct=$upstream_connect_time uht=$upstream_header_time urt=$upstream_response_time';
 
+    log_format ws_no_query '$remote_addr - $remote_user [$time_local] '
+                           '"$request_method $uri $server_protocol" '
+                           '$status $body_bytes_sent "$http_referer" '
+                           '"$http_user_agent" "$http_x_forwarded_for" '
+                           'rt=$request_time uct=$upstream_connect_time uht=$upstream_header_time urt=$upstream_response_time';
+
     access_log /var/log/nginx/access.log main;
 
     # Performance
@@ -52,6 +58,12 @@ http {
         # Certbot ACME challenge location (인증 갱신용)
         location /.well-known/acme-challenge/ {
             root /var/www/certbot;
+        }
+
+        # WebSocket access logs must not include token query strings.
+        location /ws/ {
+            access_log /var/log/nginx/access.log ws_no_query;
+            return 301 https://$host$request_uri;
         }
 
         # 모든 HTTP 요청을 HTTPS로 리다이렉트
@@ -89,8 +101,10 @@ http {
         add_header Referrer-Policy "strict-origin-when-cross-origin" always;
         add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;
 
-        # [NEW] WebSocket Requests (추가된 부분)
+        # WebSocket Requests
         location /ws/ {
+            access_log /var/log/nginx/access.log ws_no_query;
+
             proxy_pass http://spring_backend;
             proxy_http_version 1.1;
 


### PR DESCRIPTION
## 개요
WebSocket 연결 토큰이 query string으로 전달될 때 Nginx access log에 토큰 값이 기록되지 않도록 `/ws/` 경로 전용 로그 포맷을 적용합니다.

## 관련 문서
- LLD: docs/lld/LLD-0001-websocket-realtime-location.md
- ADR: docs/adr/ADR-0002-auth-jwt-family-access.md

## 관련 이슈
없습니다.

## 변경 사항
- 변경 모듈: nginx, widyu-api 설정
- `/ws/` 요청 전용 `ws_no_query` 로그 포맷을 추가했습니다.
- WebSocket HTTPS 프록시 경로에서 `$request` 대신 `$request_method $uri $server_protocol` 기반 로그를 기록하도록 적용했습니다.
- HTTP 80의 `/ws/` 리다이렉트 경로에도 동일한 로그 포맷을 적용해 query string 기록을 방지했습니다.
- 개발서버 Spring web 로그 레벨을 `debug`에서 `info`로 낮춰 프레임워크 요청 로그에 query string이 남을 수 있는 경로를 줄였습니다.

## 테스트
- `git diff --check`: 통과했습니다.
- `./gradlew :backend:widyu-api:test`: 미실행했습니다. Nginx 설정만 변경했으며 Java 코드 변경은 없습니다.
- `nginx -t`: 미실행했습니다. 로컬은 IntelliJ로 애플리케이션을 실행하고, Nginx는 개발서버 Docker 환경에서만 실행됩니다.

## 체크리스트
- [x] 엔티티 변경이 없습니다.
- [x] MySQL ENUM 변경이 없습니다.
- [x] `@Async` 메서드 변경이 없습니다.
- [x] LLD의 WebSocket 토큰 로그 노출 방지 맥락을 확인했습니다.

## Open Questions (LLD 미결정 사항)
없습니다.

## 비고
개발서버 반영 후 `docker exec widyu-nginx-dev nginx -t`와 `docker exec widyu-nginx-dev nginx -s reload`로 Nginx 설정 검증 및 reload가 필요합니다.
