### PR TITLE
CD nginx 설정 배포 시 reload가 반영되지 않는 문제 수정

### DIFF
--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -93,7 +93,10 @@ jobs:
             docker-compose.yml docker-compose.dev.yml \
             ${{ env.EC2_SSH_USER }}@${{ env.EC2_HOST }}:/home/ec2-user/widyu/
 
-          rsync -avz -e "ssh -i private_key.pem -o StrictHostKeyChecking=no" \
+          # --inplace: nginx.conf가 단일 파일 바인드 마운트라, 파일 교체 시 inode가 바뀌면
+          # 컨테이너가 옛 파일을 계속 참조해 `nginx -s reload`가 반영되지 않는다.
+          # in-place로 덮어써 inode를 유지하면 reload가 정상 반영된다.
+          rsync -avz --inplace -e "ssh -i private_key.pem -o StrictHostKeyChecking=no" \
             nginx/ \
             ${{ env.EC2_SSH_USER }}@${{ env.EC2_HOST }}:/home/ec2-user/widyu/nginx/
 


### PR DESCRIPTION
## 개요

개발 서버 CD가 nginx 설정 변경을 배포해도 실제 컨테이너에는 반영되지 않던 문제를 수정합니다. `nginx.conf`가 단일 파일 바인드 마운트라, rsync가 파일을 rename으로 교체하면 inode가 바뀌어 컨테이너가 옛 파일을 계속 참조했고, 그 결과 `nginx -s reload`가 no-op이 되어 설정 변경이 조용히 누락됐습니다.

## 관련 문서
- LLD: -
- ADR: -

## 관련 이슈
Closes #373

## 변경 사항
- 변경 모듈: CI (`.github/workflows/deploy-dev.yml`)
- nginx 디렉터리 rsync 스텝에 `--inplace` 옵션을 추가해 파일 교체 시 inode를 유지합니다.
- inode가 유지되면 컨테이너가 갱신된 파일 내용을 그대로 보게 되어, 기존 `nginx -s reload` 흐름 그대로 새 설정이 반영됩니다.
- 왜 `--inplace`가 필요한지 코드 옆 주석으로 남겨 회귀를 방지합니다.

## 테스트
- CI 워크플로우 변경만 있어 애플리케이션 테스트 대상 아님.
- 반영 확인 방법: develop 배포 후 `docker exec widyu-nginx-dev nginx -T | grep ws_no_query`로 컨테이너에 새 설정이 실린 것을 확인합니다.

## 체크리스트
- [x] 엔티티 변경 없음 (compileJava 불필요)
- [x] MySQL ENUM 변경 없음
- [x] `@Async`/`@Transactional` 해당 없음
- [x] 무중단 reload 흐름 유지

## Open Questions (LLD 미결정 사항)
없습니다.

## 비고
- 무중단 방식(reload)을 그대로 유지하는 최소 변경입니다.
- 근본적으로는 nginx 설정을 디렉터리 마운트로 바꾸는 방안도 있으나, 범위를 넓히지 않기 위해 이번 PR에서는 다루지 않았습니다.
