### PR TITLE
에러 응답 HTTP 상태코드 정확화 (500 남발 개선)

### DIFF
--- a/backend/widyu-api/src/main/java/com/widyu/global/error/GlobalExceptionHandler.java
+++ b/backend/widyu-api/src/main/java/com/widyu/global/error/GlobalExceptionHandler.java
@@ -14,11 +14,19 @@ import org.slf4j.Marker;
 import org.slf4j.MarkerFactory;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.http.converter.HttpMessageNotReadableException;
 import org.springframework.validation.FieldError;
+import org.springframework.web.HttpMediaTypeNotSupportedException;
+import org.springframework.web.HttpRequestMethodNotSupportedException;
 import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.MissingServletRequestParameterException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 import org.springframework.web.method.annotation.HandlerMethodValidationException;
+import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
+import org.springframework.web.multipart.MaxUploadSizeExceededException;
+import org.springframework.web.multipart.support.MissingServletRequestPartException;
+import org.springframework.web.servlet.resource.NoResourceFoundException;
 
 @Slf4j
 @RestControllerAdvice
@@ -49,10 +57,14 @@ public class GlobalExceptionHandler {
     ) {
         final FieldError fieldError = e.getBindingResult().getFieldError();
 
-        final String field = (fieldError != null) ? fieldError.getField() : "unknown";
-        final String defaultMsg = (fieldError != null && fieldError.getDefaultMessage() != null)
-                ? fieldError.getDefaultMessage()
-                : "요청 값이 유효하지 않습니다";
+        String field = "unknown";
+        String defaultMsg = "요청 값이 유효하지 않습니다";
+        if (fieldError != null) {
+            field = fieldError.getField();
+            if (fieldError.getDefaultMessage() != null) {
+                defaultMsg = fieldError.getDefaultMessage();
+            }
+        }
 
         final String message = String.format("%s (%s)", trimTrailingPeriod(defaultMsg), field);
 
@@ -75,6 +87,94 @@ public class GlobalExceptionHandler {
         log.error("Validation error: {}", message);
 
         return toResponse(HttpStatus.BAD_REQUEST, ErrorCode.BAD_REQUEST.getCode(), message);
+    }
+
+    @ExceptionHandler(HttpMessageNotReadableException.class)
+    protected ResponseEntity<ApiResponseTemplate<Void>> handleHttpMessageNotReadableException(
+            final HttpMessageNotReadableException e
+    ) {
+        log.warn("Malformed request body: {}", e.getMessage());
+
+        return toResponse(HttpStatus.BAD_REQUEST, ErrorCode.BAD_REQUEST.getCode(), "요청 본문을 읽을 수 없습니다. 형식을 확인해주세요.");
+    }
+
+    @ExceptionHandler(MethodArgumentTypeMismatchException.class)
+    protected ResponseEntity<ApiResponseTemplate<Void>> handleMethodArgumentTypeMismatchException(
+            final MethodArgumentTypeMismatchException e
+    ) {
+        final String message = String.format("요청 값의 타입이 올바르지 않습니다 (%s)", e.getName());
+        log.warn("Type mismatch for parameter {}: {}", e.getName(), e.getMessage());
+
+        return toResponse(HttpStatus.BAD_REQUEST, ErrorCode.BAD_REQUEST.getCode(), message);
+    }
+
+    @ExceptionHandler(MissingServletRequestParameterException.class)
+    protected ResponseEntity<ApiResponseTemplate<Void>> handleMissingServletRequestParameterException(
+            final MissingServletRequestParameterException e
+    ) {
+        final String message = String.format("필수 요청 파라미터가 누락되었습니다 (%s)", e.getParameterName());
+        log.warn("Missing request parameter: {}", e.getParameterName());
+
+        return toResponse(HttpStatus.BAD_REQUEST, ErrorCode.BAD_REQUEST.getCode(), message);
+    }
+
+    @ExceptionHandler(MissingServletRequestPartException.class)
+    protected ResponseEntity<ApiResponseTemplate<Void>> handleMissingServletRequestPartException(
+            final MissingServletRequestPartException e
+    ) {
+        final String message = String.format("필수 요청 파트가 누락되었습니다 (%s)", e.getRequestPartName());
+        log.warn("Missing request part: {}", e.getRequestPartName());
+
+        return toResponse(HttpStatus.BAD_REQUEST, ErrorCode.BAD_REQUEST.getCode(), message);
+    }
+
+    @ExceptionHandler(MaxUploadSizeExceededException.class)
+    protected ResponseEntity<ApiResponseTemplate<Void>> handleMaxUploadSizeExceededException(
+            final MaxUploadSizeExceededException e
+    ) {
+        log.warn("Upload size exceeded: {}", e.getMessage());
+
+        return toResponse(
+                ErrorCode.PAYLOAD_TOO_LARGE.getHttpStatus(),
+                ErrorCode.PAYLOAD_TOO_LARGE.getCode(),
+                ErrorCode.PAYLOAD_TOO_LARGE.getMessage()
+        );
+    }
+
+    @ExceptionHandler(HttpRequestMethodNotSupportedException.class)
+    protected ResponseEntity<ApiResponseTemplate<Void>> handleHttpRequestMethodNotSupportedException(
+            final HttpRequestMethodNotSupportedException e
+    ) {
+        final String message = String.format("지원하지 않는 HTTP 메서드입니다 (%s)", e.getMethod());
+        log.warn("Method not supported: {}", e.getMethod());
+
+        return toResponse(ErrorCode.METHOD_NOT_ALLOWED.getHttpStatus(), ErrorCode.METHOD_NOT_ALLOWED.getCode(), message);
+    }
+
+    @ExceptionHandler(HttpMediaTypeNotSupportedException.class)
+    protected ResponseEntity<ApiResponseTemplate<Void>> handleHttpMediaTypeNotSupportedException(
+            final HttpMediaTypeNotSupportedException e
+    ) {
+        log.warn("Media type not supported: {}", e.getContentType());
+
+        return toResponse(
+                ErrorCode.UNSUPPORTED_MEDIA_TYPE.getHttpStatus(),
+                ErrorCode.UNSUPPORTED_MEDIA_TYPE.getCode(),
+                ErrorCode.UNSUPPORTED_MEDIA_TYPE.getMessage()
+        );
+    }
+
+    @ExceptionHandler(NoResourceFoundException.class)
+    protected ResponseEntity<ApiResponseTemplate<Void>> handleNoResourceFoundException(
+            final NoResourceFoundException e
+    ) {
+        log.warn("No resource found: {}", e.getResourcePath());
+
+        return toResponse(
+                ErrorCode.NOT_FOUND.getHttpStatus(),
+                ErrorCode.NOT_FOUND.getCode(),
+                ErrorCode.NOT_FOUND.getMessage()
+        );
     }
 
     @ExceptionHandler(Exception.class)
@@ -107,7 +207,10 @@ public class GlobalExceptionHandler {
     private static HttpStatus getHttpStatusOrDefault(final ErrorCode errorCode) {
         try {
             final HttpStatus s = errorCode.getHttpStatus();
-            return (s != null) ? s : HttpStatus.BAD_REQUEST;
+            if (s == null) {
+                return HttpStatus.BAD_REQUEST;
+            }
+            return s;
         } catch (Exception ignore) {
             return HttpStatus.BAD_REQUEST;
         }
@@ -121,7 +224,10 @@ public class GlobalExceptionHandler {
         while (end > 0 && s.charAt(end - 1) == '.') {
             end--;
         }
-        return (end == s.length()) ? s : s.substring(0, end);
+        if (end == s.length()) {
+            return s;
+        }
+        return s.substring(0, end);
     }
 
     private void doBusinessLog(final RuntimeException runtimeException, final HttpServletRequest request) {
@@ -148,7 +254,10 @@ public class GlobalExceptionHandler {
     }
 
     private static String nullSafe(final String primary, final String fallback) {
-        return (primary == null || primary.isBlank()) ? fallback : primary;
+        if (primary == null || primary.isBlank()) {
+            return fallback;
+        }
+        return primary;
     }
 
     private String toStackTraceLog(final Exception exception) {

--- a/backend/widyu-api/src/test/java/com/widyu/global/error/GlobalExceptionHandlerTest.java
+++ b/backend/widyu-api/src/test/java/com/widyu/global/error/GlobalExceptionHandlerTest.java
@@ -1,0 +1,184 @@
+package com.widyu.global.error;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.http.MediaType.APPLICATION_JSON;
+import static org.springframework.http.MediaType.TEXT_PLAIN;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.multipart;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.widyu.global.response.ApiResponseTemplate;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.http.converter.json.MappingJackson2HttpMessageConverter;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RequestPart;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.multipart.MaxUploadSizeExceededException;
+import org.springframework.web.multipart.MultipartFile;
+import org.springframework.web.servlet.resource.NoResourceFoundException;
+
+/**
+ * 예외가 실제 성격에 맞는 HTTP 상태코드로 응답되는지 검증한다.
+ * <p>
+ * mock할 협력 객체가 없고 "예외 → 상태코드 라우팅" 자체가 검증 대상이므로
+ * MockitoExtension/BDDMockito 대신 MockMvc standalone + 더미 컨트롤러를 사용한다.
+ * (같은 저장소의 {@code PaymentControllerTest}와 동일한 standaloneSetup 방식)
+ */
+@DisplayName("GlobalExceptionHandler 에러 상태코드 테스트")
+class GlobalExceptionHandlerTest {
+
+    private MockMvc mockMvc;
+
+    @BeforeEach
+    void setUp() {
+        ObjectMapper objectMapper = new ObjectMapper();
+
+        mockMvc = MockMvcBuilders.standaloneSetup(new TestController())
+                .setControllerAdvice(new GlobalExceptionHandler())
+                .setMessageConverters(new MappingJackson2HttpMessageConverter(objectMapper))
+                .build();
+    }
+
+    @Test
+    @DisplayName("요청 본문 JSON이 깨져 있으면 400을 반환한다")
+    void 깨진_JSON_본문() throws Exception {
+        mockMvc.perform(post("/test/body")
+                        .contentType(APPLICATION_JSON)
+                        .content("{ this is broken"))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.code").value(ErrorCode.BAD_REQUEST.getCode()));
+    }
+
+    @Test
+    @DisplayName("경로 변수 타입이 맞지 않으면 400을 반환한다")
+    void 경로_변수_타입_불일치() throws Exception {
+        mockMvc.perform(get("/test/type/not-a-number"))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.code").value(ErrorCode.BAD_REQUEST.getCode()))
+                .andExpect(jsonPath("$.message").value("요청 값의 타입이 올바르지 않습니다 (id)"));
+    }
+
+    @Test
+    @DisplayName("필수 요청 파라미터가 누락되면 400을 반환한다")
+    void 필수_파라미터_누락() throws Exception {
+        mockMvc.perform(get("/test/param"))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.code").value(ErrorCode.BAD_REQUEST.getCode()))
+                .andExpect(jsonPath("$.message").value("필수 요청 파라미터가 누락되었습니다 (name)"));
+    }
+
+    @Test
+    @DisplayName("필수 multipart 파트가 누락되면 400을 반환한다")
+    void 필수_파트_누락() throws Exception {
+        mockMvc.perform(multipart("/test/part"))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.code").value(ErrorCode.BAD_REQUEST.getCode()))
+                .andExpect(jsonPath("$.message").value("필수 요청 파트가 누락되었습니다 (file)"));
+    }
+
+    @Test
+    @DisplayName("지원하지 않는 HTTP 메서드로 호출하면 405를 반환한다")
+    void 지원하지_않는_메서드() throws Exception {
+        mockMvc.perform(delete("/test/param"))
+                .andExpect(status().isMethodNotAllowed())
+                .andExpect(jsonPath("$.code").value(ErrorCode.METHOD_NOT_ALLOWED.getCode()));
+    }
+
+    @Test
+    @DisplayName("지원하지 않는 미디어 타입으로 호출하면 415를 반환한다")
+    void 지원하지_않는_미디어_타입() throws Exception {
+        mockMvc.perform(post("/test/body")
+                        .contentType(TEXT_PLAIN)
+                        .content("plain text"))
+                .andExpect(status().isUnsupportedMediaType())
+                .andExpect(jsonPath("$.code").value(ErrorCode.UNSUPPORTED_MEDIA_TYPE.getCode()));
+    }
+
+    @Test
+    @DisplayName("401로 재분류된 BusinessException은 401을 반환한다")
+    void 재분류된_401_비즈니스_예외() throws Exception {
+        mockMvc.perform(get("/test/business/apple-token"))
+                .andExpect(status().isUnauthorized())
+                .andExpect(jsonPath("$.code").value(ErrorCode.APPLE_ID_TOKEN_INVALID.getCode()));
+    }
+
+    @Test
+    @DisplayName("502로 재분류된 BusinessException은 502를 반환한다")
+    void 재분류된_502_비즈니스_예외() throws Exception {
+        mockMvc.perform(get("/test/business/naver"))
+                .andExpect(status().isBadGateway())
+                .andExpect(jsonPath("$.code").value(ErrorCode.NAVER_COMMUNICATION_ERROR.getCode()));
+    }
+
+    @Test
+    @DisplayName("업로드 파일 크기를 초과하면 413을 반환한다")
+    void 파일_크기_초과() {
+        GlobalExceptionHandler handler = new GlobalExceptionHandler();
+
+        ResponseEntity<ApiResponseTemplate<Void>> response =
+                handler.handleMaxUploadSizeExceededException(new MaxUploadSizeExceededException(100L));
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.PAYLOAD_TOO_LARGE);
+        assertThat(response.getBody().getCode()).isEqualTo(ErrorCode.PAYLOAD_TOO_LARGE.getCode());
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 리소스를 요청하면 404를 반환한다")
+    void 존재하지_않는_리소스() {
+        GlobalExceptionHandler handler = new GlobalExceptionHandler();
+
+        ResponseEntity<ApiResponseTemplate<Void>> response =
+                handler.handleNoResourceFoundException(new NoResourceFoundException(HttpMethod.GET, "/not-exist"));
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.NOT_FOUND);
+        assertThat(response.getBody().getCode()).isEqualTo(ErrorCode.NOT_FOUND.getCode());
+    }
+
+    @RestController
+    static class TestController {
+
+        @PostMapping(value = "/test/body", consumes = "application/json")
+        void body(@RequestBody final SampleRequest request) {
+        }
+
+        @GetMapping("/test/type/{id}")
+        void type(@PathVariable final Long id) {
+        }
+
+        @GetMapping("/test/param")
+        void param(@RequestParam final String name) {
+        }
+
+        @PostMapping("/test/part")
+        void part(@RequestPart final MultipartFile file) {
+        }
+
+        @GetMapping("/test/business/apple-token")
+        void appleToken() {
+            throw new BusinessException(ErrorCode.APPLE_ID_TOKEN_INVALID);
+        }
+
+        @GetMapping("/test/business/naver")
+        void naver() {
+            throw new BusinessException(ErrorCode.NAVER_COMMUNICATION_ERROR);
+        }
+    }
+
+    record SampleRequest(String value) {
+    }
+}

--- a/backend/widyu-domain/src/main/java/com/widyu/global/error/ErrorCode.java
+++ b/backend/widyu-domain/src/main/java/com/widyu/global/error/ErrorCode.java
@@ -41,29 +41,29 @@ public enum ErrorCode {
     // 문자 인증
     SMS_VERIFICATION_CODE_NOT_FOUND(HttpStatus.NOT_FOUND, "SMS_4040", "문자 인증 코드가 존재하지 않습니다."),
     SMS_VERIFICATION_CODE_MISMATCH(HttpStatus.BAD_REQUEST, "SMS_4000", "문자 인증 코드가 일치하지 않습니다."),
-    SMS_SEND_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "SMS_5000", "SMS 전송에 실패했습니다."),
+    SMS_SEND_FAILED(HttpStatus.BAD_GATEWAY, "SMS_5000", "SMS 전송에 실패했습니다."),
     INVALID_PHONE_NUMBER(HttpStatus.BAD_REQUEST, "SMS_4001", "유효하지 않은 전화번호 형식입니다."),
     PHONE_NUMBER_REQUIRED(HttpStatus.BAD_REQUEST, "SMS_4002", "전화번호는 필수입니다."),
 
     // 네이버
-    NAVER_COMMUNICATION_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "NAVER_5000", "네이버 통신에 실패하였습니다."),
+    NAVER_COMMUNICATION_ERROR(HttpStatus.BAD_GATEWAY, "NAVER_5000", "네이버 통신에 실패하였습니다."),
     NAVER_TOKEN_IS_BLANK(HttpStatus.BAD_REQUEST, "NAVER_4000", "네이버 토큰이 비어 있습니다."),
-    NAVER_WITHDRAW_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "NAVER_5001", "네이버 계정 탈퇴에 실패하였습니다."),
+    NAVER_WITHDRAW_ERROR(HttpStatus.BAD_GATEWAY, "NAVER_5001", "네이버 계정 탈퇴에 실패하였습니다."),
 
     // 카카오
-    KAKAO_COMMUNICATION_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "KAKAO_5000", "카카오 통신에 실패하였습니다."),
+    KAKAO_COMMUNICATION_ERROR(HttpStatus.BAD_GATEWAY, "KAKAO_5000", "카카오 통신에 실패하였습니다."),
     KAKAO_TOKEN_IS_BLANK(HttpStatus.BAD_REQUEST, "KAKAO_4000", "카카오 토큰이 비어 있습니다."),
-    KAKAO_WITHDRAW_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "KAKAO_5001", "카카오 계정 탈퇴에 실패하였습니다."),
+    KAKAO_WITHDRAW_ERROR(HttpStatus.BAD_GATEWAY, "KAKAO_5001", "카카오 계정 탈퇴에 실패하였습니다."),
 
     // 애플
-    APPLE_COMMUNICATION_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "APPLE_5000", "애플 통신에 실패하였습니다."),
+    APPLE_COMMUNICATION_ERROR(HttpStatus.BAD_GATEWAY, "APPLE_5000", "애플 통신에 실패하였습니다."),
     APPLE_AUTHORIZATION_CODE_IS_BLANK(HttpStatus.BAD_REQUEST, "APPLE_4000", "애플 인증 코드가 비어 있습니다."),
-    APPLE_TOKEN_EXCHANGE_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "APPLE_5001", "애플 토큰 교환에 실패하였습니다."),
-    APPLE_TOKEN_RESPONSE_INVALID(HttpStatus.INTERNAL_SERVER_ERROR, "APPLE_5002", "애플 토큰 응답이 유효하지 않습니다."),
-    APPLE_ID_TOKEN_INVALID(HttpStatus.INTERNAL_SERVER_ERROR, "APPLE_5003", "애플 ID 토큰이 유효하지 않습니다."),
-    APPLE_SIGNATURE_VERIFICATION_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "APPLE_5004", "애플 ID 토큰 서명 검증에 실패하였습니다."),
+    APPLE_TOKEN_EXCHANGE_FAILED(HttpStatus.BAD_GATEWAY, "APPLE_5001", "애플 토큰 교환에 실패하였습니다."),
+    APPLE_TOKEN_RESPONSE_INVALID(HttpStatus.BAD_GATEWAY, "APPLE_5002", "애플 토큰 응답이 유효하지 않습니다."),
+    APPLE_ID_TOKEN_INVALID(HttpStatus.UNAUTHORIZED, "APPLE_5003", "애플 ID 토큰이 유효하지 않습니다."),
+    APPLE_SIGNATURE_VERIFICATION_FAILED(HttpStatus.UNAUTHORIZED, "APPLE_5004", "애플 ID 토큰 서명 검증에 실패하였습니다."),
     APPLE_PRIVATE_KEY_PARSING_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "APPLE_5005", "애플 비밀 키 파싱에 실패하였습니다."),
-    APPLE_WITHDRAW_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "APPLE_5006", "애플 계정 탈퇴에 실패하였습니다."),
+    APPLE_WITHDRAW_ERROR(HttpStatus.BAD_GATEWAY, "APPLE_5006", "애플 계정 탈퇴에 실패하였습니다."),
 
     // 회원 관련
     MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, "MEMBER_4041", "회원을 찾을 수 없습니다."),
@@ -115,6 +115,9 @@ public enum ErrorCode {
 
     // 잘못된 요청
     BAD_REQUEST(HttpStatus.BAD_REQUEST, "REQ_4000", "잘못된 요청입니다."),
+    METHOD_NOT_ALLOWED(HttpStatus.METHOD_NOT_ALLOWED, "REQ_4050", "지원하지 않는 HTTP 메서드입니다."),
+    PAYLOAD_TOO_LARGE(HttpStatus.PAYLOAD_TOO_LARGE, "REQ_4130", "요청 크기가 허용 범위를 초과했습니다."),
+    UNSUPPORTED_MEDIA_TYPE(HttpStatus.UNSUPPORTED_MEDIA_TYPE, "REQ_4150", "지원하지 않는 미디어 타입입니다."),
 
     // 서버 오류
     INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "SRV_5000", "서버 내부 오류가 발생했습니다."),


### PR DESCRIPTION
## 개요

에러 발생 시 응답이 대부분 `500`으로 내려와 원인을 한눈에 구분하기 어려운 문제를 개선합니다. `ErrorCode`의 잘못된 상태코드 분류를 바로잡고, `GlobalExceptionHandler`가 처리하지 못해 catch-all(500)로 빠지던 Spring 표준 예외들을 실제 성격에 맞는 4xx로 응답하도록 핸들러를 추가했습니다.

## 관련 문서
- LLD: -
- ADR: -

## 관련 이슈
Closes #375

## 변경 사항
- 변경 모듈: widyu-api / widyu-domain
- `ErrorCode` 상태코드 재분류 (code 문자열·메시지는 유지, `HttpStatus`만 변경)
  - 클라이언트 인증 문제 → `401`: `APPLE_ID_TOKEN_INVALID`, `APPLE_SIGNATURE_VERIFICATION_FAILED`
  - 외부 서비스(업스트림) 실패 → `502`: `SMS_SEND_FAILED`, `NAVER_COMMUNICATION_ERROR`, `NAVER_WITHDRAW_ERROR`, `KAKAO_COMMUNICATION_ERROR`, `KAKAO_WITHDRAW_ERROR`, `APPLE_COMMUNICATION_ERROR`, `APPLE_TOKEN_EXCHANGE_FAILED`, `APPLE_TOKEN_RESPONSE_INVALID`, `APPLE_WITHDRAW_ERROR`
  - 진짜 서버 문제는 `500` 유지 (`FAMILY_CODE_GENERATION_FAILED`, `APPLE_PRIVATE_KEY_PARSING_FAILED`, `FILE_UPLOAD_FAILED`, `PAYMENT_FAILED`, `INTERNAL_SERVER_ERROR`)
- `ErrorCode`에 `METHOD_NOT_ALLOWED`(405), `PAYLOAD_TOO_LARGE`(413), `UNSUPPORTED_MEDIA_TYPE`(415) 추가
- `GlobalExceptionHandler`에 Spring 표준 예외 핸들러 8종 추가
  - 400: `HttpMessageNotReadableException`, `MethodArgumentTypeMismatchException`, `MissingServletRequestParameterException`, `MissingServletRequestPartException`
  - 413: `MaxUploadSizeExceededException` / 405: `HttpRequestMethodNotSupportedException` / 415: `HttpMediaTypeNotSupportedException` / 404: `NoResourceFoundException`
  - 위 예외는 클라이언트 오류이므로 `log.warn`으로 기록합니다.
- 이미 손댄 파일의 기존 삼항 연산자를 if/else로 정리 (하네스 규칙 준수, 동작 변화 없음)
- `GlobalExceptionHandlerTest` 추가 — 예외 → 상태코드 라우팅 10건 검증

## 의도적으로 안 한 것
- `code` 문자열(`NAVER_5000` 등) 네이밍은 변경하지 않았습니다. (클라이언트 파싱 호환성 유지)
- 진짜 500(`SRV_5000`)의 응답 바디에 원인·스택트레이스를 노출하지 않는 기존 정책은 유지했습니다. (보안상 의도된 동작, 로그 `EXCEPTION-LOG`에서 확인)

## 테스트
- `./gradlew :backend:widyu-api:test`: 통과
- `GlobalExceptionHandlerTest`: 10건 통과

## 체크리스트
- [ ] 엔티티 변경 시 `./gradlew compileJava` 실행 (해당 없음)
- [ ] MySQL ENUM 변경 시 ALTER TABLE 명시 (해당 없음)
- [ ] `@Async` 메서드에 `@Transactional` 확인 (해당 없음)
- [x] 변경분 규칙 검사(`validate-java-rules.sh`) 통과

## Open Questions (LLD 미결정 사항)
없습니다.

## 리뷰어가 집중할 포인트
- 각 예외가 실제 성격에 맞는 HTTP 상태코드로 응답되는지 (특히 502/413 도입의 적절성)

## 비고
- API 상태코드 계약이 일부 변경됩니다. 클라이언트가 HTTP status로 분기하는 경우(예: 애플 로그인 실패, 외부 통신 실패) 영향이 있을 수 있어 프론트 확인이 필요합니다.
