### PR TITLE
RedisHash 심박 결과 조회 매핑 예외를 수정합니다

### DIFF
--- a/backend/widyu-domain/build.gradle
+++ b/backend/widyu-domain/build.gradle
@@ -26,6 +26,12 @@ dependencies {
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 }
 
+tasks.withType(JavaCompile).configureEach {
+    // @RedisHash 엔티티를 파라미터가 있는 생성자로 역직렬화할 때 파라미터 이름이 필요하다.
+    // widyu-api는 Spring Boot 플러그인이 -parameters를 자동 적용하지만, 이 모듈(java-library)은 직접 지정한다.
+    options.compilerArgs.add('-parameters')
+}
+
 tasks.named('test') {
     useJUnitPlatform()
 }

--- a/backend/widyu-domain/src/test/java/com/widyu/global/RedisHashDeserializationTest.java
+++ b/backend/widyu-domain/src/test/java/com/widyu/global/RedisHashDeserializationTest.java
@@ -1,0 +1,86 @@
+package com.widyu.global;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.widyu.auth.TemporaryMember;
+import com.widyu.heart.HeartRateResult;
+import com.widyu.heart.HeartRateStatus;
+import com.widyu.location.SeniorLocation;
+import java.time.LocalDateTime;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.data.redis.core.convert.MappingRedisConverter;
+import org.springframework.data.redis.core.convert.RedisData;
+import org.springframework.data.redis.core.mapping.RedisMappingContext;
+
+/**
+ * @RedisHash 엔티티가 Redis 저장 후 다시 읽힐 때(역직렬화) 원본 값이 복원되는지 검증한다.
+ * <p>
+ * 파라미터가 있는 생성자만 가진 엔티티는 컴파일 시 -parameters 플래그가 없으면
+ * "Parameter does not have a name" MappingException으로 역직렬화가 깨진다.
+ * 이 테스트는 실제 실패 경로인 {@link MappingRedisConverter#read}를 write→read 왕복으로 재현한다.
+ */
+@DisplayName("@RedisHash 엔티티 Redis 역직렬화 테스트")
+class RedisHashDeserializationTest {
+
+    private final MappingRedisConverter converter = newConverter();
+
+    private static MappingRedisConverter newConverter() {
+        final MappingRedisConverter converter = new MappingRedisConverter(new RedisMappingContext());
+        converter.afterPropertiesSet();
+        return converter;
+    }
+
+    @Test
+    @DisplayName("HeartRateResult를 저장 후 다시 읽으면 원본 값이 복원된다")
+    void 심박결과_역직렬화() {
+        // given
+        final LocalDateTime measuredAt = LocalDateTime.of(2026, 7, 8, 23, 0, 0);
+        final HeartRateResult origin = HeartRateResult.of(1L, HeartRateStatus.ANOMALY, 120, measuredAt);
+        final RedisData sink = new RedisData();
+        converter.write(origin, sink);
+
+        // when
+        final HeartRateResult read = converter.read(HeartRateResult.class, sink);
+
+        // then
+        assertThat(read.getMemberId()).isEqualTo(1L);
+        assertThat(read.getStatus()).isEqualTo(HeartRateStatus.ANOMALY);
+        assertThat(read.getHeartRate()).isEqualTo(120);
+        assertThat(read.getMeasuredAt()).isEqualTo(measuredAt);
+    }
+
+    @Test
+    @DisplayName("TemporaryMember를 저장 후 다시 읽으면 원본 값이 복원된다")
+    void 임시회원_역직렬화() {
+        // given
+        final TemporaryMember origin = TemporaryMember.createTemporaryMember("홍길동", "01012345678");
+        final RedisData sink = new RedisData();
+        converter.write(origin, sink);
+
+        // when
+        final TemporaryMember read = converter.read(TemporaryMember.class, sink);
+
+        // then
+        assertThat(read.getId()).isEqualTo(origin.getId());
+        assertThat(read.getName()).isEqualTo("홍길동");
+        assertThat(read.getPhoneNumber()).isEqualTo("01012345678");
+    }
+
+    @Test
+    @DisplayName("SeniorLocation을 저장 후 다시 읽으면 원본 값이 복원된다")
+    void 시니어위치_역직렬화() {
+        // given
+        final SeniorLocation origin = SeniorLocation.of(1L, 37.5665, 126.9780);
+        final RedisData sink = new RedisData();
+        converter.write(origin, sink);
+
+        // when
+        final SeniorLocation read = converter.read(SeniorLocation.class, sink);
+
+        // then
+        assertThat(read.getSeniorId()).isEqualTo(1L);
+        assertThat(read.getLatitude()).isEqualTo(37.5665);
+        assertThat(read.getLongitude()).isEqualTo(126.9780);
+    }
+}


### PR DESCRIPTION
## 개요

`GET /api/v1/heart-rate/status` 등에서 Redis에 저장된 `@RedisHash` 객체를 다시 읽을 때 `MappingException: Parameter ... does not have a name` 예외가 발생하던 문제를 수정합니다.

근본 원인은 `widyu-domain` 모듈이 `java-library` 플러그인만 적용해 **`-parameters` 컴파일 플래그 없이 빌드**된다는 점입니다. 그 결과 이 모듈의 `@RedisHash` 엔티티는 생성자 파라미터 이름이 바이트코드에 남지 않고, Spring Data Redis가 파라미터 있는 생성자로 역직렬화할 때 파라미터 이름을 찾지 못해 실패합니다. no-arg 생성자가 없는 모든 `@RedisHash` 엔티티가 동일한 잠재 버그를 갖고 있었습니다(예: `TemporaryMember`는 회원가입 `findById`, `RefreshToken`은 토큰 갱신에서 역직렬화됨).

## 관련 문서
- LLD: -
- ADR: -

## 관련 이슈
Closes #377

## 변경 사항
- 변경 모듈: widyu-domain
- `widyu-domain` 컴파일에 `-parameters` 플래그 추가 (`tasks.withType(JavaCompile)`)
  - 파라미터 이름이 보존되어 파라미터 있는 생성자로 역직렬화 가능
  - 현재·미래의 모든 `@RedisHash` 엔티티가 일괄 해결 (`HeartRateResult`, `SeniorLocation`, `TemporaryMember`, `RefreshToken`, `OAuthState` 등)
  - `widyu-api`는 Spring Boot 플러그인이 `-parameters`를 자동 적용하므로 동작이 일치하게 됩니다
- `RedisHashDeserializationTest` 추가: `MappingRedisConverter`로 write→read 왕복시켜 원본 값 복원을 검증 (`HeartRateResult`·`TemporaryMember`·`SeniorLocation`)

## 의도적으로 안 한 것
- 개별 엔티티에 no-arg 생성자를 추가하는 방식(증상별 대응)은 채택하지 않았습니다. 루트 원인(`-parameters` 부재)을 해결하면 엔티티 수정 없이 전체가 해결되고, 새 엔티티마다 생성자를 챙길 필요가 없습니다.

## 테스트
- `./gradlew :backend:widyu-domain:test`: 통과 (`RedisHashDeserializationTest` 3건 포함)
- `./gradlew :backend:widyu-api:test`: 통과

## 체크리스트
- [x] 엔티티 변경 없음 (Q-클래스 재생성 불필요)
- [x] MySQL ENUM 변경 없음
- [x] `@Async` 관련 변경 없음
- [x] 역직렬화 왕복 테스트로 결과 검증

## Open Questions (LLD 미결정 사항)
없습니다.

## 비고
