### PR TITLE
건강 목표 도메인 일정 상태·걷기 소급·주소 즐겨찾기 응답 개선 3건

### DIFF
--- a/backend/widyu-api/src/main/java/com/widyu/goal/addressbookmark/application/AddressBookmarkService.java
+++ b/backend/widyu-api/src/main/java/com/widyu/goal/addressbookmark/application/AddressBookmarkService.java
@@ -2,6 +2,7 @@ package com.widyu.goal.addressbookmark.application;
 
 import com.widyu.addressbookmark.AddressBookmark;
 import com.widyu.goal.addressbookmark.dto.request.AddressBookmarkCreateRequest;
+import com.widyu.goal.addressbookmark.dto.response.AddressBookmarkIdResponse;
 import com.widyu.goal.addressbookmark.dto.response.AddressBookmarkResponse;
 import com.widyu.goal.addressbookmark.repository.AddressBookmarkRepository;
 import com.widyu.global.error.BusinessException;
@@ -31,14 +32,16 @@ public class AddressBookmarkService {
     }
 
     @Transactional
-    public void create(AddressBookmarkCreateRequest request) {
+    public AddressBookmarkIdResponse create(AddressBookmarkCreateRequest request) {
         Member member = memberUtil.getCurrentMember();
 
         if (addressBookmarkRepository.existsByMemberAndRoadAddress(member, request.roadAddress())) {
             throw new BusinessException(ErrorCode.BAD_REQUEST, "이미 즐겨찾기에 추가된 주소입니다.");
         }
 
-        addressBookmarkRepository.save(request.toEntity(member));
+        AddressBookmark saved = addressBookmarkRepository.save(request.toEntity(member));
+
+        return AddressBookmarkIdResponse.of(saved);
     }
 
     @Transactional

--- a/backend/widyu-api/src/main/java/com/widyu/goal/addressbookmark/controller/AddressBookmarkController.java
+++ b/backend/widyu-api/src/main/java/com/widyu/goal/addressbookmark/controller/AddressBookmarkController.java
@@ -3,6 +3,7 @@ package com.widyu.goal.addressbookmark.controller;
 import com.widyu.goal.addressbookmark.application.AddressBookmarkService;
 import com.widyu.goal.addressbookmark.controller.docs.AddressBookmarkDocs;
 import com.widyu.goal.addressbookmark.dto.request.AddressBookmarkCreateRequest;
+import com.widyu.goal.addressbookmark.dto.response.AddressBookmarkIdResponse;
 import com.widyu.goal.addressbookmark.dto.response.AddressBookmarkResponse;
 import com.widyu.global.response.ApiResponseTemplate;
 import jakarta.validation.Valid;
@@ -24,14 +25,14 @@ public class AddressBookmarkController implements AddressBookmarkDocs {
     private final AddressBookmarkService addressBookmarkService;
 
     @PostMapping
-    public ApiResponseTemplate<Void> createAddressBookmark(
+    public ApiResponseTemplate<AddressBookmarkIdResponse> createAddressBookmark(
         @Valid @RequestBody AddressBookmarkCreateRequest request
     ) {
-        addressBookmarkService.create(request);
+        AddressBookmarkIdResponse data = addressBookmarkService.create(request);
         return ApiResponseTemplate.ok()
             .code("ADR_2001")
             .message("주소 즐겨찾기가 생성되었습니다.")
-            .build();
+            .body(data);
     }
 
     @DeleteMapping("/{addressBookmarkId}")

--- a/backend/widyu-api/src/main/java/com/widyu/goal/addressbookmark/controller/docs/AddressBookmarkDocs.java
+++ b/backend/widyu-api/src/main/java/com/widyu/goal/addressbookmark/controller/docs/AddressBookmarkDocs.java
@@ -1,6 +1,7 @@
 package com.widyu.goal.addressbookmark.controller.docs;
 
 import com.widyu.goal.addressbookmark.dto.request.AddressBookmarkCreateRequest;
+import com.widyu.goal.addressbookmark.dto.response.AddressBookmarkIdResponse;
 import com.widyu.goal.addressbookmark.dto.response.AddressBookmarkResponse;
 import com.widyu.global.response.ApiResponseTemplate;
 import io.swagger.v3.oas.annotations.Operation;
@@ -64,13 +65,15 @@ public interface AddressBookmarkDocs {
                     {
                         "code": "ADR_2001",
                         "message": "주소 즐겨찾기가 생성되었습니다.",
-                        "data": null
+                        "data": {
+                            "addressBookmarkId": 1
+                        }
                     }
                     """
             )
         )
     )
-    ApiResponseTemplate<Void> createAddressBookmark(
+    ApiResponseTemplate<AddressBookmarkIdResponse> createAddressBookmark(
         AddressBookmarkCreateRequest request
     );
 

--- a/backend/widyu-api/src/main/java/com/widyu/goal/addressbookmark/dto/response/AddressBookmarkIdResponse.java
+++ b/backend/widyu-api/src/main/java/com/widyu/goal/addressbookmark/dto/response/AddressBookmarkIdResponse.java
@@ -1,0 +1,11 @@
+package com.widyu.goal.addressbookmark.dto.response;
+
+import com.widyu.addressbookmark.AddressBookmark;
+
+public record AddressBookmarkIdResponse(
+        Long addressBookmarkId
+) {
+    public static AddressBookmarkIdResponse of(AddressBookmark addressBookmark) {
+        return new AddressBookmarkIdResponse(addressBookmark.getId());
+    }
+}

--- a/backend/widyu-api/src/main/java/com/widyu/goal/healthschedule/application/HealthScheduleProgressService.java
+++ b/backend/widyu-api/src/main/java/com/widyu/goal/healthschedule/application/HealthScheduleProgressService.java
@@ -68,17 +68,15 @@ public class HealthScheduleProgressService {
     }
 
     /**
-     * 어제 하루치 UPCOMING 일정을 INCOMPLETE로 변경
+     * 예정일이 지난(오늘 이전) UPCOMING 일정을 모두 INCOMPLETE로 변경.
+     * 배치가 하루 이상 누락되어도 밀린 지난 일정까지 일괄 정리한다.
      */
     @Transactional
     public void markOverdueSchedulesAsIncomplete() {
-        LocalDateTime now = LocalDateTime.now();
+        LocalDateTime todayStart = LocalDateTime.now().withHour(0).withMinute(0).withSecond(0).withNano(0);
 
-        LocalDateTime yesterdayStart = now.minusDays(1).withHour(0).withMinute(0).withSecond(0).withNano(0);
-        LocalDateTime todayStart = now.withHour(0).withMinute(0).withSecond(0).withNano(0);
-
-        List<HealthSchedule> overdueSchedules = healthScheduleRepository.findByStatusAndDateRange(
-                ProgressStatus.UPCOMING, yesterdayStart, todayStart
+        List<HealthSchedule> overdueSchedules = healthScheduleRepository.findByStatusAndScheduledAtBefore(
+                ProgressStatus.UPCOMING, todayStart
         );
 
         for (HealthSchedule schedule : overdueSchedules) {

--- a/backend/widyu-api/src/main/java/com/widyu/goal/healthschedule/dto/response/HealthScheduleDayResponse.java
+++ b/backend/widyu-api/src/main/java/com/widyu/goal/healthschedule/dto/response/HealthScheduleDayResponse.java
@@ -11,7 +11,7 @@ public record HealthScheduleDayResponse(
     public static HealthScheduleDayResponse from(HealthSchedule healthSchedule) {
         return new HealthScheduleDayResponse(
                 healthSchedule.getScheduledAt().toLocalDate(),
-                healthSchedule.getProgressStatus()
+                healthSchedule.getDisplayProgressStatus()
         );
     }
 }

--- a/backend/widyu-api/src/main/java/com/widyu/goal/healthschedule/dto/response/HealthScheduleDetailResponse.java
+++ b/backend/widyu-api/src/main/java/com/widyu/goal/healthschedule/dto/response/HealthScheduleDetailResponse.java
@@ -21,7 +21,7 @@ public record HealthScheduleDetailResponse(
                 healthSchedule.getPlaceAddress(),
                 healthSchedule.getLatitude(),
                 healthSchedule.getLongitude(),
-                healthSchedule.getProgressStatus()
+                healthSchedule.getDisplayProgressStatus()
         );
     }
 }

--- a/backend/widyu-api/src/main/java/com/widyu/goal/healthschedule/dto/response/HealthScheduleDetailWithRewardResponse.java
+++ b/backend/widyu-api/src/main/java/com/widyu/goal/healthschedule/dto/response/HealthScheduleDetailWithRewardResponse.java
@@ -23,7 +23,7 @@ public record HealthScheduleDetailWithRewardResponse(
                 healthSchedule.getPlaceAddress(),
                 healthSchedule.getLatitude(),
                 healthSchedule.getLongitude(),
-                healthSchedule.getProgressStatus(),
+                healthSchedule.getDisplayProgressStatus(),
                 healthSchedule.getRewardPoint(),
                 healthSchedule.getIsReward()
         );

--- a/backend/widyu-api/src/main/java/com/widyu/goal/healthschedule/repository/HealthScheduleRepository.java
+++ b/backend/widyu-api/src/main/java/com/widyu/goal/healthschedule/repository/HealthScheduleRepository.java
@@ -45,4 +45,10 @@ public interface HealthScheduleRepository extends JpaRepository<HealthSchedule, 
             @Param("startDate") LocalDateTime startDate,
             @Param("endDate") LocalDateTime endDate
     );
+
+    @Query("SELECT h FROM HealthSchedule h WHERE h.progressStatus = :status AND h.scheduledAt < :beforeDate")
+    List<HealthSchedule> findByStatusAndScheduledAtBefore(
+            @Param("status") ProgressStatus status,
+            @Param("beforeDate") LocalDateTime beforeDate
+    );
 }

--- a/backend/widyu-api/src/main/java/com/widyu/goal/walk/application/WalkService.java
+++ b/backend/widyu-api/src/main/java/com/widyu/goal/walk/application/WalkService.java
@@ -52,7 +52,7 @@ public class WalkService {
                 requestedMonth
         );
 
-        return new WalkMonthlyResponse(summary, dailyData);
+        return WalkMonthlyResponse.of(summary, dailyData);
     }
 
     public WalkDetailResponse getWalkDetail(Long memberId) {
@@ -183,10 +183,13 @@ public class WalkService {
         YearMonth previousMonth = requestedMonth.minusMonths(1);
         WalkMonthlyResponse.WalkSummary.MonthStats previous = getMonthStats(member, previousMonth);
 
-        YearMonth targetMonth = requestedMonth.equals(currentMonth) ? currentMonth : requestedMonth;
+        YearMonth targetMonth = requestedMonth;
+        if (requestedMonth.equals(currentMonth)) {
+            targetMonth = currentMonth;
+        }
         WalkMonthlyResponse.WalkSummary.MonthStats current = getMonthStats(member, targetMonth);
 
-        return new WalkMonthlyResponse.WalkSummary(previous, current);
+        return WalkMonthlyResponse.WalkSummary.of(previous, current);
     }
 
     private WalkMonthlyResponse.WalkSummary.MonthStats getMonthStats(Member member, YearMonth month) {
@@ -196,7 +199,7 @@ public class WalkService {
         long achieved = walkRepository.countAchievedGoals(member.getId(), startDate, endDate);
         long total = walkRepository.countTotalRecords(member.getId(), startDate, endDate);
 
-        return new WalkMonthlyResponse.WalkSummary.MonthStats(achieved, total);
+        return WalkMonthlyResponse.WalkSummary.MonthStats.of(achieved, total);
     }
 
     private List<WalkMonthlyResponse.WalkDaily> getDailyDataForMonth(
@@ -219,12 +222,14 @@ public class WalkService {
             defaultWalkGoal = member.getSeniorProfile().getDefaultWalkGoal();
         }
 
+        LocalDate today = LocalDate.now();
+
         List<WalkMonthlyResponse.WalkDaily> dailyData = new ArrayList<>();
         for (LocalDate date = startDate; !date.isAfter(endDate); date = date.plusDays(1)) {
             Walk walk = walkMap.get(date);
             if (walk != null) {
                 // Walk 기록이 있으면 실제 기록 반환
-                dailyData.add(new WalkMonthlyResponse.WalkDaily(
+                dailyData.add(WalkMonthlyResponse.WalkDaily.of(
                         date.toString(),
                         walk.getGoalSteps(),
                         walk.getActualSteps()
@@ -232,9 +237,15 @@ public class WalkService {
                 continue;
             }
 
+            // 과거 날짜는 기록이 없으면 그날 목표가 없었던 것이므로 채우지 않는다.
+            // (기본 목표를 소급 적용하면 목표 설정 이전의 지난 날짜까지 오염됨)
+            if (date.isBefore(today)) {
+                continue;
+            }
+
             if (defaultWalkGoal != null) {
-                // Walk 기록이 없어도 defaultWalkGoal이 있으면 기본 목표로 반환
-                dailyData.add(new WalkMonthlyResponse.WalkDaily(
+                // 오늘·미래 날짜는 기록이 없어도 defaultWalkGoal이 있으면 기본 목표로 반환
+                dailyData.add(WalkMonthlyResponse.WalkDaily.of(
                         date.toString(),
                         defaultWalkGoal,
                         0

--- a/backend/widyu-api/src/main/java/com/widyu/goal/walk/dto/response/WalkMonthlyResponse.java
+++ b/backend/widyu-api/src/main/java/com/widyu/goal/walk/dto/response/WalkMonthlyResponse.java
@@ -6,14 +6,25 @@ public record WalkMonthlyResponse(
         WalkSummary summary,
         List<WalkDaily> dailyData
 ) {
+    public static WalkMonthlyResponse of(WalkSummary summary, List<WalkDaily> dailyData) {
+        return new WalkMonthlyResponse(summary, dailyData);
+    }
+
     public record WalkSummary(
             MonthStats previous,
             MonthStats current
     ) {
+        public static WalkSummary of(MonthStats previous, MonthStats current) {
+            return new WalkSummary(previous, current);
+        }
+
         public record MonthStats(
                 long achieved,
                 long total
         ) {
+            public static MonthStats of(long achieved, long total) {
+                return new MonthStats(achieved, total);
+            }
         }
     }
 
@@ -22,5 +33,8 @@ public record WalkMonthlyResponse(
             Integer goal,
             Integer actual
     ) {
+        public static WalkDaily of(String date, Integer goal, Integer actual) {
+            return new WalkDaily(date, goal, actual);
+        }
     }
 }

--- a/backend/widyu-api/src/test/java/com/widyu/goal/addressbookmark/application/AddressBookmarkServiceTest.java
+++ b/backend/widyu-api/src/test/java/com/widyu/goal/addressbookmark/application/AddressBookmarkServiceTest.java
@@ -1,0 +1,84 @@
+package com.widyu.goal.addressbookmark.application;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+
+import com.widyu.addressbookmark.AddressBookmark;
+import com.widyu.global.error.BusinessException;
+import com.widyu.global.util.MemberUtil;
+import com.widyu.goal.addressbookmark.dto.request.AddressBookmarkCreateRequest;
+import com.widyu.goal.addressbookmark.dto.response.AddressBookmarkIdResponse;
+import com.widyu.goal.addressbookmark.repository.AddressBookmarkRepository;
+import com.widyu.member.Member;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("AddressBookmarkService 생성 단위 테스트")
+class AddressBookmarkServiceTest {
+
+    @Mock private AddressBookmarkRepository addressBookmarkRepository;
+    @Mock private MemberUtil memberUtil;
+
+    @InjectMocks private AddressBookmarkService addressBookmarkService;
+
+    private AddressBookmarkCreateRequest createRequest() {
+        return new AddressBookmarkCreateRequest(
+                "서울특별시 마포구 성암로 301",
+                "서울특별시 마포구 상암동 1595",
+                "MBC",
+                37.5789,
+                126.8912,
+                "성암로 301",
+                "상암동 1595"
+        );
+    }
+
+    @Test
+    @DisplayName("즐겨찾기를 생성하면 저장된 addressBookmarkId를 반환한다")
+    void 즐겨찾기를_생성하면_저장된_id를_반환한다() {
+        // given
+        Member member = mock(Member.class);
+        AddressBookmarkCreateRequest request = createRequest();
+        given(memberUtil.getCurrentMember()).willReturn(member);
+        given(addressBookmarkRepository.existsByMemberAndRoadAddress(member, request.roadAddress()))
+                .willReturn(false);
+        given(addressBookmarkRepository.save(any(AddressBookmark.class))).willAnswer(invocation -> {
+            AddressBookmark saved = invocation.getArgument(0);
+            ReflectionTestUtils.setField(saved, "id", 100L);
+            return saved;
+        });
+
+        // when
+        AddressBookmarkIdResponse response = addressBookmarkService.create(request);
+
+        // then
+        assertThat(response.addressBookmarkId()).isEqualTo(100L);
+    }
+
+    @Test
+    @DisplayName("이미 즐겨찾기된 주소를 생성하면 예외가 발생하고 저장하지 않는다")
+    void 이미_즐겨찾기된_주소는_예외가_발생한다() {
+        // given
+        Member member = mock(Member.class);
+        AddressBookmarkCreateRequest request = createRequest();
+        given(memberUtil.getCurrentMember()).willReturn(member);
+        given(addressBookmarkRepository.existsByMemberAndRoadAddress(member, request.roadAddress()))
+                .willReturn(true);
+
+        // when & then
+        assertThatThrownBy(() -> addressBookmarkService.create(request))
+                .isInstanceOf(BusinessException.class);
+        then(addressBookmarkRepository).should(never()).save(any(AddressBookmark.class));
+    }
+}

--- a/backend/widyu-api/src/test/java/com/widyu/goal/healthschedule/application/HealthScheduleProgressServiceTest.java
+++ b/backend/widyu-api/src/test/java/com/widyu/goal/healthschedule/application/HealthScheduleProgressServiceTest.java
@@ -1,0 +1,80 @@
+package com.widyu.goal.healthschedule.application;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+
+import com.widyu.goal.healthschedule.repository.HealthScheduleRepository;
+import com.widyu.global.util.MemberUtil;
+import com.widyu.healthschedule.HealthSchedule;
+import com.widyu.healthschedule.ProgressStatus;
+import com.widyu.member.Member;
+import com.widyu.member.MemberType;
+import com.widyu.member.repository.FamilyMembershipRepository;
+import com.widyu.member.repository.SeniorProfileRepository;
+import java.time.LocalDateTime;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("HealthScheduleProgressService 지난 일정 마감 배치 단위 테스트")
+class HealthScheduleProgressServiceTest {
+
+    @Mock private HealthScheduleRepository healthScheduleRepository;
+    @Mock private SeniorProfileRepository seniorProfileRepository;
+    @Mock private FamilyMembershipRepository familyMembershipRepository;
+    @Mock private MemberUtil memberUtil;
+
+    @InjectMocks private HealthScheduleProgressService healthScheduleProgressService;
+
+    @Captor private ArgumentCaptor<LocalDateTime> beforeDateCaptor;
+
+    private HealthSchedule upcomingScheduleAt(LocalDateTime scheduledAt) {
+        Member member = Member.createMember(MemberType.SENIOR, "부모님", "01011112222");
+        return HealthSchedule.create(member, "건강검진", "서울시", 37.5, 127.0, scheduledAt);
+    }
+
+    @Test
+    @DisplayName("오늘 이전 UPCOMING 일정을 여러 날치 조회해 모두 INCOMPLETE로 마감한다")
+    void 오늘_이전_UPCOMING_일정을_모두_INCOMPLETE로_마감한다() {
+        // given
+        HealthSchedule yesterday = upcomingScheduleAt(LocalDateTime.now().minusDays(1));
+        HealthSchedule threeDaysAgo = upcomingScheduleAt(LocalDateTime.now().minusDays(3));
+        given(healthScheduleRepository.findByStatusAndScheduledAtBefore(
+                eq(ProgressStatus.UPCOMING), beforeDateCaptor.capture()))
+                .willReturn(List.of(yesterday, threeDaysAgo));
+
+        // when
+        healthScheduleProgressService.markOverdueSchedulesAsIncomplete();
+
+        // then
+        assertThat(yesterday.getProgressStatus()).isEqualTo(ProgressStatus.INCOMPLETE);
+        assertThat(threeDaysAgo.getProgressStatus()).isEqualTo(ProgressStatus.INCOMPLETE);
+        assertThat(beforeDateCaptor.getValue().toLocalTime())
+                .isEqualTo(java.time.LocalTime.MIDNIGHT);
+    }
+
+    @Test
+    @DisplayName("마감할 지난 일정이 없으면 아무 상태도 변경하지 않는다")
+    void 마감할_지난_일정이_없으면_변경하지_않는다() {
+        // given
+        given(healthScheduleRepository.findByStatusAndScheduledAtBefore(
+                eq(ProgressStatus.UPCOMING), beforeDateCaptor.capture()))
+                .willReturn(List.of());
+
+        // when
+        healthScheduleProgressService.markOverdueSchedulesAsIncomplete();
+
+        // then
+        then(healthScheduleRepository).should()
+                .findByStatusAndScheduledAtBefore(eq(ProgressStatus.UPCOMING), beforeDateCaptor.capture());
+    }
+}

--- a/backend/widyu-api/src/test/java/com/widyu/goal/walk/application/WalkServiceTest.java
+++ b/backend/widyu-api/src/test/java/com/widyu/goal/walk/application/WalkServiceTest.java
@@ -1,0 +1,69 @@
+package com.widyu.goal.walk.application;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.BDDMockito.given;
+
+import com.widyu.global.util.MemberUtil;
+import com.widyu.goal.walk.dto.response.WalkMonthlyResponse;
+import com.widyu.goal.walk.repository.WalkRepository;
+import com.widyu.member.Member;
+import com.widyu.member.SeniorProfile;
+import com.widyu.member.repository.MemberRepository;
+import java.time.LocalDate;
+import java.time.YearMonth;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("WalkService 월별 조회 단위 테스트")
+class WalkServiceTest {
+
+    @Mock private WalkRepository walkRepository;
+    @Mock private MemberRepository memberRepository;
+    @Mock private MemberUtil memberUtil;
+
+    @InjectMocks private WalkService walkService;
+
+    @Test
+    @DisplayName("기록이 없는 과거 날짜는 기본 목표를 소급 적용하지 않고 오늘·미래만 기본 목표로 채운다")
+    void 기록이_없는_과거_날짜는_기본_목표를_소급하지_않는다() {
+        // given
+        Long memberId = 1L;
+        Member member = org.mockito.Mockito.mock(Member.class);
+        SeniorProfile seniorProfile = org.mockito.Mockito.mock(SeniorProfile.class);
+        given(memberRepository.findById(memberId)).willReturn(Optional.of(member));
+        given(member.getId()).willReturn(memberId);
+        given(member.getSeniorProfile()).willReturn(seniorProfile);
+        given(seniorProfile.hasDefaultWalkGoal()).willReturn(true);
+        given(seniorProfile.getDefaultWalkGoal()).willReturn(5000);
+        given(walkRepository.countAchievedGoals(anyLong(), any(), any())).willReturn(0L);
+        given(walkRepository.countTotalRecords(anyLong(), any(), any())).willReturn(0L);
+        given(walkRepository.findByMemberAndWalkDateBetweenOrderByWalkDateAsc(any(), any(), any()))
+                .willReturn(List.of());
+
+        YearMonth currentMonth = YearMonth.now();
+        LocalDate today = LocalDate.now();
+
+        // when
+        WalkMonthlyResponse response = walkService.getMonthlyStats(
+                currentMonth.getYear(), currentMonth.getMonthValue(), memberId);
+
+        // then
+        List<LocalDate> dates = response.dailyData().stream()
+                .map(daily -> LocalDate.parse(daily.date()))
+                .toList();
+        assertThat(dates).isNotEmpty();
+        assertThat(dates).allSatisfy(date -> assertThat(date).isAfterOrEqualTo(today));
+
+        long expectedDays = currentMonth.atEndOfMonth().getDayOfMonth() - today.getDayOfMonth() + 1;
+        assertThat(dates).hasSize((int) expectedDays);
+    }
+}

--- a/backend/widyu-domain/src/main/java/com/widyu/healthschedule/HealthSchedule.java
+++ b/backend/widyu-domain/src/main/java/com/widyu/healthschedule/HealthSchedule.java
@@ -13,6 +13,7 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import lombok.AccessLevel;
 import lombok.Builder;
@@ -76,10 +77,22 @@ public class HealthSchedule extends BaseTimeEntity {
         this.latitude = latitude;
         this.longitude = longitude;
         this.scheduledAt = scheduledAt;
-        this.progressStatus = progressStatus != null ? progressStatus : ProgressStatus.UPCOMING;
-        this.rewardPoint = rewardPoint != null ? rewardPoint : 100;
-        this.isReward = isReward != null ? isReward : false;
-        this.status = status != null ? status : Status.ACTIVE;
+        this.progressStatus = ProgressStatus.UPCOMING;
+        if (progressStatus != null) {
+            this.progressStatus = progressStatus;
+        }
+        this.rewardPoint = 100;
+        if (rewardPoint != null) {
+            this.rewardPoint = rewardPoint;
+        }
+        this.isReward = false;
+        if (isReward != null) {
+            this.isReward = isReward;
+        }
+        this.status = Status.ACTIVE;
+        if (status != null) {
+            this.status = status;
+        }
     }
 
     public static HealthSchedule create(Member member, String scheduleName, String placeAddress, Double latitude,
@@ -126,5 +139,18 @@ public class HealthSchedule extends BaseTimeEntity {
 
     public void markIncomplete() {
         this.progressStatus = ProgressStatus.INCOMPLETE;
+    }
+
+    /**
+     * 조회 시점 기준의 진행 상태.
+     * 저장된 상태가 UPCOMING이라도 예정일이 이미 지났다면 INCOMPLETE로 간주한다.
+     * (자정 배치가 아직 반영하지 못한 지난 일정도 올바르게 표시하기 위함)
+     */
+    public ProgressStatus getDisplayProgressStatus() {
+        if (progressStatus == ProgressStatus.UPCOMING
+                && scheduledAt.toLocalDate().isBefore(LocalDate.now())) {
+            return ProgressStatus.INCOMPLETE;
+        }
+        return progressStatus;
     }
 }

--- a/backend/widyu-domain/src/test/java/com/widyu/healthschedule/HealthScheduleTest.java
+++ b/backend/widyu-domain/src/test/java/com/widyu/healthschedule/HealthScheduleTest.java
@@ -1,0 +1,71 @@
+package com.widyu.healthschedule;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.widyu.member.Member;
+import com.widyu.member.MemberType;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+@DisplayName("HealthSchedule 표시용 진행상태 단위 테스트")
+class HealthScheduleTest {
+
+    private HealthSchedule scheduleAt(LocalDateTime scheduledAt) {
+        Member member = Member.createMember(MemberType.SENIOR, "부모님", "01011112222");
+        return HealthSchedule.create(member, "건강검진", "서울시", 37.5, 127.0, scheduledAt);
+    }
+
+    @Test
+    @DisplayName("예정일이 지난 UPCOMING 일정을 조회하면 INCOMPLETE를 반환한다")
+    void 예정일이_지난_UPCOMING_일정은_INCOMPLETE를_반환한다() {
+        // given
+        HealthSchedule schedule = scheduleAt(LocalDate.now().minusDays(2).atTime(9, 0));
+
+        // when & then
+        assertThat(schedule.getDisplayProgressStatus()).isEqualTo(ProgressStatus.INCOMPLETE);
+    }
+
+    @Test
+    @DisplayName("예정일이 오늘인 UPCOMING 일정을 조회하면 UPCOMING을 그대로 반환한다")
+    void 예정일이_오늘인_UPCOMING_일정은_UPCOMING을_유지한다() {
+        // given
+        HealthSchedule schedule = scheduleAt(LocalDate.now().atTime(9, 0));
+
+        // when & then
+        assertThat(schedule.getDisplayProgressStatus()).isEqualTo(ProgressStatus.UPCOMING);
+    }
+
+    @Test
+    @DisplayName("예정일이 미래인 UPCOMING 일정을 조회하면 UPCOMING을 그대로 반환한다")
+    void 예정일이_미래인_UPCOMING_일정은_UPCOMING을_유지한다() {
+        // given
+        HealthSchedule schedule = scheduleAt(LocalDate.now().plusDays(2).atTime(9, 0));
+
+        // when & then
+        assertThat(schedule.getDisplayProgressStatus()).isEqualTo(ProgressStatus.UPCOMING);
+    }
+
+    @Test
+    @DisplayName("예정일이 지났어도 COMPLETED 일정은 COMPLETED를 그대로 반환한다")
+    void 완료된_일정은_예정일이_지나도_COMPLETED를_유지한다() {
+        // given
+        HealthSchedule schedule = scheduleAt(LocalDate.now().minusDays(2).atTime(9, 0));
+        schedule.complete();
+
+        // when & then
+        assertThat(schedule.getDisplayProgressStatus()).isEqualTo(ProgressStatus.COMPLETED);
+    }
+
+    @Test
+    @DisplayName("이미 INCOMPLETE로 마감된 일정은 INCOMPLETE를 그대로 반환한다")
+    void 이미_INCOMPLETE인_일정은_INCOMPLETE를_유지한다() {
+        // given
+        HealthSchedule schedule = scheduleAt(LocalDate.now().minusDays(2).atTime(9, 0));
+        schedule.markIncomplete();
+
+        // when & then
+        assertThat(schedule.getDisplayProgressStatus()).isEqualTo(ProgressStatus.INCOMPLETE);
+    }
+}


### PR DESCRIPTION
## 개요
건강 목표 도메인에서 제보된 버그 2건과 개선 요청 1건을 처리합니다. 배치 성격이라 한 PR로 묶되, 커밋을 항목별로 분리했습니다.

## 관련 문서
- LLD: -
- ADR: -

## 관련 이슈
Closes #383

## 변경 사항
- 변경 모듈: widyu-api, widyu-domain

**1. 지난 건강 일정이 UPCOMING으로 표시되는 문제 (fix)**
- `HealthSchedule.getDisplayProgressStatus()` 추가 — 저장값이 UPCOMING이라도 예정일이 오늘 이전이면 조회 시점에 INCOMPLETE로 반환합니다. 자정 배치 타이밍과 무관하게 표시가 정확해집니다.
- 일자별·상세·캘린더 응답 DTO가 표시 상태를 사용하도록 변경했습니다.
- 자정 배치 대상을 "어제 하루" → "오늘 이전 전체"로 확대해 밀린 지난 일정도 보정합니다(`findByStatusAndScheduledAtBefore` 추가).

**2. 걷기 월별 조회 시 과거 날짜에 기본 목표가 소급되는 문제 (fix)**
- 월별 조회에서 기록 없는 과거 날짜는 기본 목표(`defaultWalkGoal`)를 채우지 않도록 변경했습니다. 오늘·미래는 기존대로 표시합니다.

**3. 주소 즐겨찾기 생성 응답에 id 반환 (feat)**
- `AddressBookmarkIdResponse`를 추가하고 생성 응답으로 저장된 `addressBookmarkId`를 반환합니다. Docs 예시도 갱신했습니다.

**함께 정리한 규칙 준수 (refactor)**
- 위 파일을 수정하며 걸린 하네스 규칙 위반을 함께 정리했습니다: `HealthSchedule` 생성자·`WalkService`의 삼항 연산자를 if 문으로, `WalkMonthlyResponse`에 `of()` 팩토리를 추가해 Service의 DTO 직접 생성을 제거했습니다.

## 테스트
- `./gradlew :backend:widyu-api:test`: 통과
- `./gradlew :backend:widyu-domain:test`: 통과
- 추가 테스트: `HealthScheduleTest`, `HealthScheduleProgressServiceTest`, `WalkServiceTest`, `AddressBookmarkServiceTest`

## 체크리스트
- [x] 엔티티 변경 시 `./gradlew compileJava` 실행
- [x] MySQL ENUM 변경 없음
- [x] `@Async` 메서드 해당 없음
- [x] LLD 없음 — 코딩 규칙·모듈 배치 기준 확인

## Open Questions (LLD 미결정 사항)
없습니다.

## 비고
- 리뷰어 집중 포인트: **1번 건강 일정 상태를 "조회 시점 계산 + 배치 확대" 두 방식으로 함께 처리한 접근**이 적절한지 확인 부탁드립니다.
- 걷기는 약 복용(#380)과 달리 effectiveFrom 개념이 없어, 기록 없는 과거 날짜는 표시에서 제외하는 방식으로 처리했습니다. 과거에 목표는 있었으나 미접속으로 기록이 없는 날은 표시되지 않습니다.
- 스키마 변경은 없습니다.
