### PR TITLE
약 복용 스케줄 버전링 안정성을 보강합니다

### DIFF
--- a/backend/widyu-api/src/main/java/com/widyu/goal/medicineschedule/application/MedicationProofService.java
+++ b/backend/widyu-api/src/main/java/com/widyu/goal/medicineschedule/application/MedicationProofService.java
@@ -50,6 +50,11 @@ public class MedicationProofService {
         }
 
         LocalDateTime now = LocalDateTime.now();
+        if (!schedule.isEffectiveOn(now.toLocalDate())) {
+            throw new BusinessException(ErrorCode.BAD_REQUEST,
+                    "오늘 유효하지 않은 약 복용 스케줄입니다.");
+        }
+
         LocalTime alarmTime = schedule.getAlarmTime();
 
         // 알람 시간 전후 30분 체크

--- a/backend/widyu-api/src/main/java/com/widyu/goal/medicineschedule/application/MedicineScheduleEffectivePeriodInitializer.java
+++ b/backend/widyu-api/src/main/java/com/widyu/goal/medicineschedule/application/MedicineScheduleEffectivePeriodInitializer.java
@@ -1,0 +1,26 @@
+package com.widyu.goal.medicineschedule.application;
+
+import com.widyu.goal.medicineschedule.repository.MedicineScheduleRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.ApplicationArguments;
+import org.springframework.boot.ApplicationRunner;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class MedicineScheduleEffectivePeriodInitializer implements ApplicationRunner {
+
+    private final MedicineScheduleRepository medicineScheduleRepository;
+
+    @Override
+    @Transactional
+    public void run(ApplicationArguments args) {
+        int updatedCount = medicineScheduleRepository.backfillMissingEffectiveFrom();
+        if (updatedCount > 0) {
+            log.info("약 복용 스케줄 effectiveFrom 보정 완료: count={}", updatedCount);
+        }
+    }
+}

--- a/backend/widyu-api/src/main/java/com/widyu/goal/medicineschedule/repository/MedicineScheduleRepository.java
+++ b/backend/widyu-api/src/main/java/com/widyu/goal/medicineschedule/repository/MedicineScheduleRepository.java
@@ -8,6 +8,7 @@ import java.time.LocalTime;
 import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
@@ -25,7 +26,7 @@ public interface MedicineScheduleRepository extends JpaRepository<MedicineSchedu
     @Query("SELECT DISTINCT ms FROM MedicineSchedule ms " +
            "LEFT JOIN FETCH ms.categories c " +
            "WHERE ms.member = :member AND ms.status = :status " +
-           "AND ms.effectiveFrom <= :date " +
+           "AND (ms.effectiveFrom IS NULL OR ms.effectiveFrom <= :date) " +
            "AND (ms.effectiveTo IS NULL OR ms.effectiveTo >= :date) " +
            "ORDER BY ms.alarmTime ASC")
     List<MedicineSchedule> findEffectiveByMemberAndDateWithDetails(
@@ -48,7 +49,7 @@ public interface MedicineScheduleRepository extends JpaRepository<MedicineSchedu
     // [start, end] 기간과 겹치는 모든 스케줄 버전 조회 (월별 통계에서 날짜별 유효 수 계산용)
     @Query("SELECT ms FROM MedicineSchedule ms " +
            "WHERE ms.member = :member AND ms.status = :status " +
-           "AND ms.effectiveFrom <= :end " +
+           "AND (ms.effectiveFrom IS NULL OR ms.effectiveFrom <= :end) " +
            "AND (ms.effectiveTo IS NULL OR ms.effectiveTo >= :start)")
     List<MedicineSchedule> findEffectiveByMemberAndDateRange(
             @Param("member") Member member,
@@ -61,7 +62,7 @@ public interface MedicineScheduleRepository extends JpaRepository<MedicineSchedu
     @Query("SELECT DISTINCT ms FROM MedicineSchedule ms " +
            "LEFT JOIN FETCH ms.member " +
            "WHERE ms.alarmTime = :alarmTime AND ms.status = :status " +
-           "AND ms.effectiveFrom <= :date " +
+           "AND (ms.effectiveFrom IS NULL OR ms.effectiveFrom <= :date) " +
            "AND (ms.effectiveTo IS NULL OR ms.effectiveTo >= :date)")
     List<MedicineSchedule> findByAlarmTimeAndStatusEffectiveOn(
             @Param("alarmTime") LocalTime alarmTime,
@@ -72,11 +73,19 @@ public interface MedicineScheduleRepository extends JpaRepository<MedicineSchedu
     // 특정 날짜에 유효했던 스케줄 개수 (포인트 정산 시 그날 기준 총 일정 수)
     @Query("SELECT COUNT(ms) FROM MedicineSchedule ms " +
            "WHERE ms.member = :member AND ms.status = :status " +
-           "AND ms.effectiveFrom <= :date " +
+           "AND (ms.effectiveFrom IS NULL OR ms.effectiveFrom <= :date) " +
            "AND (ms.effectiveTo IS NULL OR ms.effectiveTo >= :date)")
     long countEffectiveByMemberAndDate(
             @Param("member") Member member,
             @Param("status") Status status,
             @Param("date") LocalDate date
     );
+
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
+    @Query(value = """
+            UPDATE medicine_schedule
+               SET effective_from = CAST(created_at AS DATE)
+             WHERE effective_from IS NULL
+            """, nativeQuery = true)
+    int backfillMissingEffectiveFrom();
 }

--- a/backend/widyu-api/src/test/java/com/widyu/goal/medicineschedule/application/MedicationProofServiceTest.java
+++ b/backend/widyu-api/src/test/java/com/widyu/goal/medicineschedule/application/MedicationProofServiceTest.java
@@ -1,0 +1,61 @@
+package com.widyu.goal.medicineschedule.application;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.never;
+import static org.mockito.BDDMockito.then;
+
+import com.widyu.global.entity.Status;
+import com.widyu.global.error.BusinessException;
+import com.widyu.global.infrastructure.s3.S3Service;
+import com.widyu.global.util.MemberUtil;
+import com.widyu.goal.medicineschedule.repository.MedicationProofRepository;
+import com.widyu.goal.medicineschedule.repository.MedicineScheduleRepository;
+import com.widyu.member.Member;
+import com.widyu.medicine.MedicationProof;
+import com.widyu.medicine.MedicineSchedule;
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("MedicationProofService 복용 인증 단위 테스트")
+class MedicationProofServiceTest {
+
+    @Mock private MedicationProofRepository medicationProofRepository;
+    @Mock private MedicineScheduleRepository medicineScheduleRepository;
+    @Mock private MemberUtil memberUtil;
+    @Mock private S3Service s3Service;
+
+    @InjectMocks private MedicationProofService medicationProofService;
+
+    @Test
+    @DisplayName("오늘 유효하지 않은 과거 스케줄로 복용 인증하면 예외가 발생한다")
+    void 오늘_유효하지_않은_과거_스케줄은_복용_인증할_수_없다() {
+        // given
+        Long scheduleId = 1L;
+        Member member = org.mockito.Mockito.mock(Member.class);
+        given(member.getId()).willReturn(10L);
+        given(memberUtil.getCurrentMember()).willReturn(member);
+
+        MedicineSchedule closedSchedule = MedicineSchedule.create(member, LocalTime.now());
+        ReflectionTestUtils.setField(closedSchedule, "effectiveFrom", LocalDate.now().minusDays(10));
+        ReflectionTestUtils.setField(closedSchedule, "effectiveTo", LocalDate.now().minusDays(1));
+
+        given(medicineScheduleRepository.findByIdAndStatusWithDetails(scheduleId, Status.ACTIVE))
+                .willReturn(Optional.of(closedSchedule));
+
+        // when & then
+        assertThatThrownBy(() -> medicationProofService.verifyMedication(scheduleId, List.of()))
+                .isInstanceOf(BusinessException.class);
+        then(medicationProofRepository).should(never()).save(org.mockito.ArgumentMatchers.any(MedicationProof.class));
+    }
+}

--- a/backend/widyu-api/src/test/java/com/widyu/goal/medicineschedule/repository/MedicineScheduleRepositoryTest.java
+++ b/backend/widyu-api/src/test/java/com/widyu/goal/medicineschedule/repository/MedicineScheduleRepositoryTest.java
@@ -1,0 +1,112 @@
+package com.widyu.goal.medicineschedule.repository;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import com.widyu.global.config.JpaAuditingConfig;
+import com.widyu.global.entity.Status;
+import com.widyu.member.Member;
+import com.widyu.member.MemberType;
+import com.widyu.medicine.MedicineSchedule;
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.util.ReflectionTestUtils;
+
+@DataJpaTest
+@ActiveProfiles("test")
+@Import(JpaAuditingConfig.class)
+@DisplayName("MedicineScheduleRepository 유효기간 쿼리 테스트")
+class MedicineScheduleRepositoryTest {
+
+    @Autowired private MedicineScheduleRepository medicineScheduleRepository;
+    @Autowired private TestEntityManager entityManager;
+    @MockBean private JPAQueryFactory jpaQueryFactory;
+
+    private Member persistSenior(String phoneNumber) {
+        Member member = Member.createMember(MemberType.SENIOR, "부모님", phoneNumber);
+        entityManager.persistAndFlush(member);
+        return member;
+    }
+
+    private MedicineSchedule persistSchedule(
+            Member member,
+            LocalTime alarmTime,
+            LocalDate effectiveFrom,
+            LocalDate effectiveTo
+    ) {
+        MedicineSchedule schedule = MedicineSchedule.create(member, alarmTime);
+        ReflectionTestUtils.setField(schedule, "effectiveFrom", effectiveFrom);
+        ReflectionTestUtils.setField(schedule, "effectiveTo", effectiveTo);
+        entityManager.persistAndFlush(schedule);
+        return schedule;
+    }
+
+    @Test
+    @DisplayName("특정 날짜에 유효한 스케줄 버전만 조회한다")
+    void 특정_날짜에_유효한_스케줄_버전만_조회한다() {
+        // given
+        Member member = persistSenior("01011112222");
+        MedicineSchedule closed = persistSchedule(
+                member, LocalTime.of(8, 0), LocalDate.of(2026, 7, 1), LocalDate.of(2026, 7, 10));
+        MedicineSchedule current = persistSchedule(
+                member, LocalTime.of(9, 0), LocalDate.of(2026, 7, 11), null);
+        persistSchedule(member, LocalTime.of(10, 0), LocalDate.of(2026, 8, 1), null);
+
+        // when
+        List<MedicineSchedule> july10Schedules = medicineScheduleRepository.findEffectiveByMemberAndDateWithDetails(
+                member, Status.ACTIVE, LocalDate.of(2026, 7, 10));
+        List<MedicineSchedule> july11Schedules = medicineScheduleRepository.findEffectiveByMemberAndDateWithDetails(
+                member, Status.ACTIVE, LocalDate.of(2026, 7, 11));
+
+        // then
+        assertThat(july10Schedules).extracting(MedicineSchedule::getId).containsExactly(closed.getId());
+        assertThat(july11Schedules).extracting(MedicineSchedule::getId).containsExactly(current.getId());
+    }
+
+    @Test
+    @DisplayName("월 범위와 겹치는 스케줄 버전만 조회한다")
+    void 월_범위와_겹치는_스케줄_버전만_조회한다() {
+        // given
+        Member member = persistSenior("01022223333");
+        persistSchedule(member, LocalTime.of(7, 0), LocalDate.of(2026, 6, 1), LocalDate.of(2026, 6, 30));
+        MedicineSchedule overlapping = persistSchedule(
+                member, LocalTime.of(8, 0), LocalDate.of(2026, 6, 25), LocalDate.of(2026, 7, 2));
+        MedicineSchedule current = persistSchedule(member, LocalTime.of(9, 0), LocalDate.of(2026, 7, 15), null);
+        persistSchedule(member, LocalTime.of(10, 0), LocalDate.of(2026, 8, 1), null);
+
+        // when
+        List<MedicineSchedule> schedules = medicineScheduleRepository.findEffectiveByMemberAndDateRange(
+                member, Status.ACTIVE, LocalDate.of(2026, 7, 1), LocalDate.of(2026, 7, 31));
+
+        // then
+        assertThat(schedules).extracting(MedicineSchedule::getId)
+                .containsExactlyInAnyOrder(overlapping.getId(), current.getId());
+    }
+
+    @Test
+    @DisplayName("effectiveFrom이 누락된 기존 스케줄을 createdAt 기준으로 보정한다")
+    void effectiveFrom이_누락된_기존_스케줄을_createdAt_기준으로_보정한다() {
+        // given
+        Member member = persistSenior("01033334444");
+        MedicineSchedule schedule = persistSchedule(member, LocalTime.of(8, 0), null, null);
+        entityManager.clear();
+
+        // when
+        int updatedCount = medicineScheduleRepository.backfillMissingEffectiveFrom();
+        entityManager.clear();
+
+        // then
+        MedicineSchedule reloaded = entityManager.find(MedicineSchedule.class, schedule.getId());
+        assertThat(updatedCount).isEqualTo(1);
+        assertThat(reloaded.getEffectiveFrom()).isNotNull();
+    }
+}

--- a/backend/widyu-domain/src/main/java/com/widyu/medicine/MedicineSchedule.java
+++ b/backend/widyu-domain/src/main/java/com/widyu/medicine/MedicineSchedule.java
@@ -50,7 +50,7 @@ public class MedicineSchedule extends BaseTimeEntity {
     private Status status = Status.ACTIVE;
 
     // 이 버전이 유효한 시작일 (수정 시 새 버전이 생기고, 과거 버전은 그대로 보존된다)
-    @Column(nullable = false)
+    @Column
     private LocalDate effectiveFrom;
 
     // 유효 종료일. null이면 현재 유효한 최신 버전
@@ -92,7 +92,7 @@ public class MedicineSchedule extends BaseTimeEntity {
     }
 
     public boolean isEffectiveOn(LocalDate date) {
-        if (date.isBefore(effectiveFrom)) {
+        if (date.isBefore(getEffectiveStartDate())) {
             return false;
         }
         if (effectiveTo == null) {
@@ -102,12 +102,22 @@ public class MedicineSchedule extends BaseTimeEntity {
     }
 
     public boolean startedOn(LocalDate date) {
-        return effectiveFrom.equals(date);
+        return getEffectiveStartDate().equals(date);
     }
 
     // 현재 유효한 최신 버전인지 여부 (마감된 과거 버전은 수정·삭제 대상이 아니다)
     public boolean isCurrent() {
         return effectiveTo == null;
+    }
+
+    private LocalDate getEffectiveStartDate() {
+        if (effectiveFrom != null) {
+            return effectiveFrom;
+        }
+        if (getCreatedAt() != null) {
+            return getCreatedAt().toLocalDate();
+        }
+        return LocalDate.MIN;
     }
 
     public Integer getTotalCount() {

--- a/backend/widyu-domain/src/test/java/com/widyu/medicine/MedicineScheduleTest.java
+++ b/backend/widyu-domain/src/test/java/com/widyu/medicine/MedicineScheduleTest.java
@@ -57,4 +57,15 @@ class MedicineScheduleTest {
         assertThat(schedule.isEffectiveOn(LocalDate.of(2026, 7, 5))).isTrue();
         assertThat(schedule.isEffectiveOn(LocalDate.of(2026, 7, 6))).isFalse();
     }
+
+    @Test
+    @DisplayName("effectiveFrom이 없는 기존 데이터는 모든 날짜에 유효한 기존 스케줄로 취급한다")
+    void effectiveFrom이_없는_기존_데이터는_기존_스케줄로_취급한다() {
+        // given
+        MedicineSchedule schedule = scheduleEffectiveBetween(null, null);
+
+        // when & then
+        assertThat(schedule.isEffectiveOn(LocalDate.of(2020, 1, 1))).isTrue();
+        assertThat(schedule.startedOn(LocalDate.of(2020, 1, 1))).isFalse();
+    }
 }

--- a/docs/lld/LLD-0008-medicine-schedule-versioning.md
+++ b/docs/lld/LLD-0008-medicine-schedule-versioning.md
@@ -21,7 +21,7 @@
 
 ### In scope
 - 변경 모듈: widyu-domain(엔티티), widyu-api(medicineschedule, home, fcm 리스너, 스케줄러)
-- `MedicineSchedule`에 `effectiveFrom`(적용 시작일, NOT NULL) / `effectiveTo`(종료일, null=현재 유효) 추가
+- `MedicineSchedule`에 `effectiveFrom`(적용 시작일) / `effectiveTo`(종료일, null=현재 유효) 추가
 - 조회: 날짜 D 기준 `effectiveFrom <= D <= (effectiveTo ?? ∞)`인 버전만 반환
 - 수정: 과거부터 유효한 버전은 어제까지 마감(`effectiveTo = 어제`) + 오늘부터 유효한 새 버전 생성. 당일 생성/수정분은 in-place 수정
 - 삭제: `effectiveTo = 어제`로 마감(오늘부터 중단, 과거 보존)
@@ -48,7 +48,7 @@
 
 | 컬럼 | 타입 | 설명 |
 | --- | --- | --- |
-| `effective_from` | DATE, NOT NULL | 이 버전이 유효한 시작일. 생성 시 오늘 |
+| `effective_from` | DATE | 이 버전이 유효한 시작일. 생성 시 오늘. 기존 데이터는 시작 시 `created_at` 기준으로 보정 |
 | `effective_to` | DATE, NULL | 유효 종료일. null이면 현재 유효한 최신 버전 |
 
 - 도메인 메서드: `isEffectiveOn(date)`, `closeAsOf(date)`, `startedOn(date)`, `clearCategories()`
@@ -86,11 +86,10 @@
 
 ## 8. 영향 범위 / 마이그레이션
 
-**DB 마이그레이션(배포 전 필수)** — `effective_from`이 NOT NULL이라 `ddl-auto: update`만으로는 기존 행이 깨진다.
+**DB 마이그레이션** — 기존 행은 애플리케이션 시작 시 `created_at` 기준으로 `effective_from`을 보정한다. 수동 보정이 필요한 환경에서는 아래 SQL을 사용할 수 있다.
 ```sql
 ALTER TABLE medicine_schedule ADD COLUMN effective_from DATE NULL, ADD COLUMN effective_to DATE NULL;
 UPDATE medicine_schedule SET effective_from = DATE(created_at) WHERE effective_from IS NULL;
-ALTER TABLE medicine_schedule MODIFY COLUMN effective_from DATE NOT NULL;
 ```
 - ERD(`ERD-0001-initial-domain.md`) 동기화 완료.
 - API 계약(경로·필드) 변경 없음. 수정 시 새 버전 id가 생기므로 클라이언트는 수정 후 재조회한다.
@@ -98,7 +97,6 @@ ALTER TABLE medicine_schedule MODIFY COLUMN effective_from DATE NOT NULL;
 ## 9. 미결정 사항 (Open Questions)
 
 - 같은 스케줄을 하루에 여러 번 수정하는 경우 in-place로 처리(현재 정책). 추후 이력 보관 필요 시 재검토.
-- repository JPQL(effectiveFrom/To 필터)에 대한 `@DataJpaTest` 보강은 후속 과제.
 
 ## 10. 참고
 


### PR DESCRIPTION
## 개요
약 복용 스케줄 버전링에서 기존 데이터의 `effective_from` 누락과 마감된 스케줄 ID 인증 가능성을 보강합니다.

## 관련 문서
- LLD: docs/lld/LLD-0008-medicine-schedule-versioning.md
- ADR: -

## 관련 이슈
Closes #385

## 변경 사항
- 변경 모듈: widyu-api / widyu-domain
- 기존 `MedicineSchedule` 데이터의 `effective_from` 누락분을 애플리케이션 시작 시 `created_at` 기준으로 보정합니다.
- 유효기간 기반 Repository 쿼리에서 `effectiveFrom`이 누락된 기존 데이터를 조회에서 제외하지 않도록 보강합니다.
- 복용 인증 시 요청된 스케줄이 오늘 기준 유효하지 않으면 인증을 차단합니다.
- 유효기간 경계와 보정 쿼리를 `@DataJpaTest`로 검증합니다.
- LLD-0008의 마이그레이션 설명을 현재 보정 방식에 맞게 갱신합니다.

## 테스트
- `./gradlew compileJava`: 통과
- `./gradlew :backend:widyu-api:test`: 통과
- `./gradlew :backend:widyu-domain:test`: 통과

## 체크리스트
- [x] 엔티티 변경 시 `./gradlew compileJava` 실행
- [x] MySQL ENUM 변경 시 ALTER TABLE 명시
- [x] `@Async` 메서드에 `@Transactional` 확인
- [x] LLD 인수조건 전체 충족

## Open Questions (LLD 미결정 사항)
- 같은 스케줄을 하루에 여러 번 수정하는 경우 in-place로 처리(현재 정책). 추후 이력 보관 필요 시 재검토.

## 비고
MySQL ENUM 변경은 없습니다. 기존 데이터의 `effective_from`은 애플리케이션 시작 시 보정됩니다.
