### PR TITLE
test: 예외 처리 경로 검증 보강

### DIFF
--- a/backend/widyu-api/src/main/java/com/widyu/album/application/AlbumFileService.java
+++ b/backend/widyu-api/src/main/java/com/widyu/album/application/AlbumFileService.java
@@ -193,6 +193,9 @@ public class AlbumFileService {
         } catch (Exception e) {
             cleanupUploadedFiles(mediaUrls);
             cleanupUploadedFiles(thumbnailUrls);
+            if (e instanceof BusinessException be) {
+                throw be;
+            }
             throw new BusinessException(ErrorCode.FILE_UPLOAD_FAILED, e.getMessage());
         }
     }

--- a/backend/widyu-api/src/main/java/com/widyu/fcm/application/NotificationSettingService.java
+++ b/backend/widyu-api/src/main/java/com/widyu/fcm/application/NotificationSettingService.java
@@ -59,6 +59,10 @@ public class NotificationSettingService {
     public NotificationSettingResponse updateNotificationSetting(UpdateNotificationSettingRequest request) {
         Member member = memberUtil.getCurrentMember();
 
+        if (request.group() == null || request.group().isBlank()) {
+            throw new BusinessException(ErrorCode.INVALID_FCM_CATEGORY);
+        }
+
         NotificationSettingGroup group;
         try {
             group = NotificationSettingGroup.valueOf(request.group());

--- a/backend/widyu-api/src/main/java/com/widyu/global/aspect/FamilyAccessAspect.java
+++ b/backend/widyu-api/src/main/java/com/widyu/global/aspect/FamilyAccessAspect.java
@@ -87,7 +87,8 @@ public class FamilyAccessAspect {
             }
         }
 
-        throw new IllegalArgumentException(
+        throw new BusinessException(
+                ErrorCode.BAD_REQUEST,
                 String.format("파라미터 '%s'를 찾을 수 없습니다.", paramName)
         );
     }

--- a/backend/widyu-api/src/main/java/com/widyu/global/security/JwtTokenProvider.java
+++ b/backend/widyu-api/src/main/java/com/widyu/global/security/JwtTokenProvider.java
@@ -54,9 +54,15 @@ public class JwtTokenProvider {
 
     public AccessTokenDto retrieveAccessToken(String accessTokenValue) {
         try {
-            return jwtUtil.parseAccessToken(accessTokenValue);
+            AccessTokenDto accessTokenDto = jwtUtil.parseAccessToken(accessTokenValue);
+            if (accessTokenDto == null) {
+                throw new BusinessException(ErrorCode.INVALID_ACCESS_TOKEN);
+            }
+            return accessTokenDto;
         } catch (ExpiredJwtException e) {
             throw new BusinessException(ErrorCode.EXPIRED_ACCESS_TOKEN);
+        } catch (BusinessException e) {
+            throw e;
         } catch (Exception e) {
             throw new BusinessException(ErrorCode.INVALID_ACCESS_TOKEN);
         }
@@ -81,9 +87,15 @@ public class JwtTokenProvider {
 
     public SocialTemporaryTokenDto retrieveSocialTemporaryToken(String socialTemporaryTokenValue) {
         try {
-            return jwtUtil.parseSocialTemporaryToken(socialTemporaryTokenValue);
+            SocialTemporaryTokenDto socialTemporaryTokenDto = jwtUtil.parseSocialTemporaryToken(socialTemporaryTokenValue);
+            if (socialTemporaryTokenDto == null) {
+                throw new BusinessException(ErrorCode.INVALID_TEMPORARY_TOKEN);
+            }
+            return socialTemporaryTokenDto;
         } catch (ExpiredJwtException e) {
             throw new BusinessException(ErrorCode.TEMPORARY_TOKEN_EXPIRED);
+        } catch (BusinessException e) {
+            throw e;
         } catch (Exception e) {
             log.debug("Social Temporary Token 파싱 실패: {}", e.getMessage());
             throw new BusinessException(ErrorCode.INVALID_TEMPORARY_TOKEN);

--- a/backend/widyu-api/src/main/java/com/widyu/global/util/SecurityUtil.java
+++ b/backend/widyu-api/src/main/java/com/widyu/global/util/SecurityUtil.java
@@ -28,8 +28,10 @@ public class SecurityUtil {
                     .orElseThrow(() -> new BusinessException(ErrorCode.UNAUTHORIZED))
                     .getAuthority();
 
+        } catch (BusinessException e) {
+            throw e;
         } catch (Exception e) {
-            throw new BusinessException(ErrorCode.INTERNAL_SERVER_ERROR);
+            throw new BusinessException(ErrorCode.UNAUTHORIZED);
         }
     }
 }

--- a/backend/widyu-api/src/main/java/com/widyu/global/util/TemporaryMemberUtil.java
+++ b/backend/widyu-api/src/main/java/com/widyu/global/util/TemporaryMemberUtil.java
@@ -34,7 +34,7 @@ public class TemporaryMemberUtil {
         }
 
         // 역할 확인(임시 토큰만 허용)
-        if (dto.memberRole() == null || !(dto.memberRole() == MemberRole.TEMPORARY)) {
+        if (dto == null || dto.memberRole() == null || !(dto.memberRole() == MemberRole.TEMPORARY)) {
             throw new BusinessException(ErrorCode.UNAUTHORIZED);
         }
 

--- a/backend/widyu-api/src/main/java/com/widyu/heart/application/HeartRateService.java
+++ b/backend/widyu-api/src/main/java/com/widyu/heart/application/HeartRateService.java
@@ -40,6 +40,9 @@ public class HeartRateService {
 
     @Transactional
     public HeartRateStatusResponse processHeartRates(Long memberId, HeartRateSendRequest request) {
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.MEMBER_NOT_FOUND));
+
         List<Integer> heartRateValues = request.heartRates().stream()
                 .map(HeartRateMeasurement::heartRate)
                 .toList();
@@ -59,9 +62,6 @@ public class HeartRateService {
                 latestMeasurement.measuredAt()
         );
         heartRateResultRepository.save(result);
-
-        Member member = memberRepository.findById(memberId)
-                .orElseThrow(() -> new BusinessException(ErrorCode.MEMBER_NOT_FOUND));
 
         List<HeartRateEvent> events = request.heartRates().stream()
                 .map(m -> HeartRateEvent.of(member, m.heartRate(), m.measuredAt(), status))

--- a/backend/widyu-api/src/test/java/com/widyu/admin/application/AdminAuthServiceTest.java
+++ b/backend/widyu-api/src/test/java/com/widyu/admin/application/AdminAuthServiceTest.java
@@ -1,0 +1,97 @@
+package com.widyu.admin.application;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.BDDMockito.given;
+
+import com.widyu.admin.repository.AdminAuditLogRepository;
+import com.widyu.global.error.BusinessException;
+import com.widyu.global.error.ErrorCode;
+import com.widyu.global.security.JwtTokenProvider;
+import com.widyu.member.LocalAccount;
+import com.widyu.member.Member;
+import com.widyu.member.MemberRole;
+import com.widyu.member.MemberType;
+import com.widyu.member.repository.LocalAccountRepository;
+import java.util.Optional;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.test.util.ReflectionTestUtils;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("AdminAuthService 예외 처리 단위 테스트")
+class AdminAuthServiceTest {
+
+    @Mock private LocalAccountRepository localAccountRepository;
+    @Mock private PasswordEncoder passwordEncoder;
+    @Mock private JwtTokenProvider jwtTokenProvider;
+    @Mock private AdminAuditLogRepository adminAuditLogRepository;
+
+    @InjectMocks
+    private AdminAuthService adminAuthService;
+
+    @Test
+    @DisplayName("등록되지 않은 이메일로 로그인하면 INVALID_EMAIL 예외를 던진다")
+    void 등록되지_않은_이메일_로그인_시_예외가_발생한다() {
+        // given
+        given(localAccountRepository.findByEmail("admin@test.com")).willReturn(Optional.empty());
+
+        // when & then
+        assertThatThrownBy(() -> adminAuthService.login("admin@test.com", "password"))
+                .isInstanceOf(BusinessException.class)
+                .hasFieldOrPropertyWithValue("errorCode", ErrorCode.INVALID_EMAIL)
+                .hasMessageContaining("이메일이 올바르지 않습니다.");
+    }
+
+    @Test
+    @DisplayName("비밀번호가 다르면 INVALID_PASSWORD 예외를 던진다")
+    void 비밀번호가_다르면_예외가_발생한다() {
+        // given
+        LocalAccount localAccount = LocalAccount.createLocalAccount(
+                member(1L, MemberRole.ADMIN), "admin@test.com", "encoded");
+        given(localAccountRepository.findByEmail("admin@test.com")).willReturn(Optional.of(localAccount));
+        given(passwordEncoder.matches("wrong", "encoded")).willReturn(false);
+
+        // when & then
+        assertThatThrownBy(() -> adminAuthService.login("admin@test.com", "wrong"))
+                .isInstanceOf(BusinessException.class)
+                .hasFieldOrPropertyWithValue("errorCode", ErrorCode.INVALID_PASSWORD)
+                .hasMessageContaining("비밀번호가 올바르지 않습니다.");
+    }
+
+    @Test
+    @DisplayName("관리자 권한이 아니면 FORBIDDEN 예외를 던진다")
+    void 관리자_권한이_아니면_예외가_발생한다() {
+        // given
+        LocalAccount localAccount = LocalAccount.createLocalAccount(
+                member(1L, MemberRole.USER), "user@test.com", "encoded");
+        given(localAccountRepository.findByEmail("user@test.com")).willReturn(Optional.of(localAccount));
+        given(passwordEncoder.matches("password", "encoded")).willReturn(true);
+
+        // when & then
+        assertThatThrownBy(() -> adminAuthService.login("user@test.com", "password"))
+                .isInstanceOf(BusinessException.class)
+                .hasFieldOrPropertyWithValue("errorCode", ErrorCode.FORBIDDEN)
+                .hasMessageContaining("접근 권한이 없습니다.");
+    }
+
+    @Test
+    @DisplayName("리프레시 토큰이 비어 있으면 UNAUTHORIZED 예외를 던진다")
+    void 리프레시_토큰이_비어_있으면_예외가_발생한다() {
+        assertThatThrownBy(() -> adminAuthService.refresh(" "))
+                .isInstanceOf(BusinessException.class)
+                .hasFieldOrPropertyWithValue("errorCode", ErrorCode.UNAUTHORIZED)
+                .hasMessageContaining("리프레시 토큰이 없습니다.");
+    }
+
+    private Member member(Long id, MemberRole role) {
+        Member member = Member.createMember(MemberType.GUARDIAN, "관리자", "01011112222");
+        ReflectionTestUtils.setField(member, "id", id);
+        ReflectionTestUtils.setField(member, "role", role);
+        return member;
+    }
+}

--- a/backend/widyu-api/src/test/java/com/widyu/admin/application/AdminMemberServiceTest.java
+++ b/backend/widyu-api/src/test/java/com/widyu/admin/application/AdminMemberServiceTest.java
@@ -1,0 +1,68 @@
+package com.widyu.admin.application;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.BDDMockito.given;
+
+import com.widyu.album.repository.AlbumRepository;
+import com.widyu.fcm.repository.MemberFcmTokenRepository;
+import com.widyu.global.entity.Status;
+import com.widyu.global.error.BusinessException;
+import com.widyu.global.error.ErrorCode;
+import com.widyu.heart.repository.HeartRateEmergencyRepository;
+import com.widyu.member.Member;
+import com.widyu.member.MemberType;
+import com.widyu.member.repository.FamilyMembershipRepository;
+import com.widyu.member.repository.MemberRepository;
+import com.widyu.member.repository.SeniorProfileRepository;
+import com.widyu.pay.repository.PaymentRepository;
+import java.util.Optional;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("AdminMemberService 예외 처리 단위 테스트")
+class AdminMemberServiceTest {
+
+    @Mock private MemberRepository memberRepository;
+    @Mock private SeniorProfileRepository seniorProfileRepository;
+    @Mock private FamilyMembershipRepository familyMembershipRepository;
+    @Mock private MemberFcmTokenRepository memberFcmTokenRepository;
+    @Mock private AlbumRepository albumRepository;
+    @Mock private PaymentRepository paymentRepository;
+    @Mock private HeartRateEmergencyRepository heartRateEmergencyRepository;
+    @Mock private AdminAuditLogService adminAuditLogService;
+
+    @InjectMocks
+    private AdminMemberService adminMemberService;
+
+    @Test
+    @DisplayName("존재하지 않는 회원 상세 조회 시 MEMBER_NOT_FOUND 예외를 던진다")
+    void 존재하지_않는_회원_상세_조회_시_예외가_발생한다() {
+        // given
+        given(memberRepository.findById(1L)).willReturn(Optional.empty());
+
+        // when & then
+        assertThatThrownBy(() -> adminMemberService.getMemberDetail(1L))
+                .isInstanceOf(BusinessException.class)
+                .hasFieldOrPropertyWithValue("errorCode", ErrorCode.MEMBER_NOT_FOUND)
+                .hasMessageContaining("회원을 찾을 수 없습니다.");
+    }
+
+    @Test
+    @DisplayName("허용되지 않는 회원 상태 변경 시 FORBIDDEN 예외를 던진다")
+    void 허용되지_않는_회원_상태_변경_시_예외가_발생한다() {
+        // given
+        Member member = Member.createMember(MemberType.GUARDIAN, "보호자", "01011112222");
+        given(memberRepository.findById(1L)).willReturn(Optional.of(member));
+
+        // when & then
+        assertThatThrownBy(() -> adminMemberService.changeStatus(1L, Status.DELETED))
+                .isInstanceOf(BusinessException.class)
+                .hasFieldOrPropertyWithValue("errorCode", ErrorCode.FORBIDDEN)
+                .hasMessageContaining("ACTIVE 또는 INACTIVE만 허용됩니다.");
+    }
+}

--- a/backend/widyu-api/src/test/java/com/widyu/admin/application/AdminPointGrantServiceTest.java
+++ b/backend/widyu-api/src/test/java/com/widyu/admin/application/AdminPointGrantServiceTest.java
@@ -1,0 +1,64 @@
+package com.widyu.admin.application;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.Mockito.never;
+
+import com.widyu.global.error.BusinessException;
+import com.widyu.global.error.ErrorCode;
+import com.widyu.member.Member;
+import com.widyu.member.MemberType;
+import com.widyu.member.PointHistory;
+import com.widyu.member.repository.MemberRepository;
+import com.widyu.member.repository.PointHistoryRepository;
+import com.widyu.member.repository.SeniorProfileRepository;
+import java.util.Optional;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("AdminPointGrantService 예외 처리 단위 테스트")
+class AdminPointGrantServiceTest {
+
+    @Mock private MemberRepository memberRepository;
+    @Mock private SeniorProfileRepository seniorProfileRepository;
+    @Mock private PointHistoryRepository pointHistoryRepository;
+
+    @InjectMocks
+    private AdminPointGrantService adminPointGrantService;
+
+    @Test
+    @DisplayName("존재하지 않는 회원에게 포인트 지급 시 MEMBER_NOT_FOUND 예외를 던진다")
+    void 존재하지_않는_회원_포인트_지급_시_예외가_발생한다() {
+        // given
+        given(memberRepository.findById(1L)).willReturn(Optional.empty());
+
+        // when & then
+        assertThatThrownBy(() -> adminPointGrantService.grant(1L, 100L))
+                .isInstanceOf(BusinessException.class)
+                .hasFieldOrPropertyWithValue("errorCode", ErrorCode.MEMBER_NOT_FOUND)
+                .hasMessageContaining("회원을 찾을 수 없습니다.");
+        then(pointHistoryRepository).should(never()).save(any(PointHistory.class));
+    }
+
+    @Test
+    @DisplayName("보호자에게 포인트 지급 시 FORBIDDEN 예외를 던진다")
+    void 보호자_포인트_지급_시_예외가_발생한다() {
+        // given
+        Member guardian = Member.createMember(MemberType.GUARDIAN, "보호자", "01011112222");
+        given(memberRepository.findById(1L)).willReturn(Optional.of(guardian));
+
+        // when & then
+        assertThatThrownBy(() -> adminPointGrantService.grant(1L, 100L))
+                .isInstanceOf(BusinessException.class)
+                .hasFieldOrPropertyWithValue("errorCode", ErrorCode.FORBIDDEN)
+                .hasMessageContaining("포인트는 시니어 회원에게만 지급할 수 있습니다.");
+        then(pointHistoryRepository).should(never()).save(any(PointHistory.class));
+    }
+}

--- a/backend/widyu-api/src/test/java/com/widyu/album/application/AlbumFileServiceTest.java
+++ b/backend/widyu-api/src/test/java/com/widyu/album/application/AlbumFileServiceTest.java
@@ -1,0 +1,95 @@
+package com.widyu.album.application;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.Mockito.never;
+
+import com.widyu.global.error.BusinessException;
+import com.widyu.global.error.ErrorCode;
+import com.widyu.global.infrastructure.s3.S3Service;
+import com.widyu.global.infrastructure.video.VideoCompressionService;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.web.multipart.MultipartFile;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("AlbumFileService 예외 처리 단위 테스트")
+class AlbumFileServiceTest {
+
+    @Mock private S3Service s3Service;
+    @Mock private VideoCompressionService videoCompressionService;
+    @Mock private AlbumMediaPolicy mediaPolicy;
+
+    @InjectMocks
+    private AlbumFileService albumFileService;
+
+    @Test
+    @DisplayName("미디어 업로드 중 BusinessException이 발생하면 원본 errorCode를 보존한다")
+    void 미디어_업로드_중_비즈니스_예외는_원본_errorCode를_보존한다() {
+        // given
+        List<MultipartFile> files = List.of(imageFile());
+        given(s3Service.generateFilePath(anyString(), anyString())).willReturn("albums/photos/1/photo.jpg");
+        given(s3Service.uploadFile(files.get(0), "albums/photos/1/photo.jpg"))
+                .willThrow(new BusinessException(ErrorCode.INVALID_FILE_TYPE));
+
+        // when & then
+        assertThatThrownBy(() -> albumFileService.uploadMediaFiles(files, 1L))
+                .isInstanceOf(BusinessException.class)
+                .hasFieldOrPropertyWithValue("errorCode", ErrorCode.INVALID_FILE_TYPE)
+                .hasMessageContaining("지원하지 않는 파일 형식입니다.");
+    }
+
+    @Test
+    @DisplayName("두 번째 파일 업로드 실패 시 이미 업로드된 파일을 정리한다")
+    void 두번째_파일_업로드_실패_시_업로드된_파일을_정리한다() {
+        // given
+        MultipartFile first = imageFile("first.jpg");
+        MultipartFile second = imageFile("second.jpg");
+        List<MultipartFile> files = List.of(first, second);
+
+        given(s3Service.generateFilePath(anyString(), anyString()))
+                .willReturn("albums/photos/1/first.jpg")
+                .willReturn("albums/photos/1/second.jpg");
+        given(s3Service.uploadFile(first, "albums/photos/1/first.jpg")).willReturn("https://cdn/first.jpg");
+        given(s3Service.uploadFile(second, "albums/photos/1/second.jpg"))
+                .willThrow(new BusinessException(ErrorCode.FILE_UPLOAD_FAILED));
+
+        // when & then
+        assertThatThrownBy(() -> albumFileService.uploadMediaFiles(files, 1L))
+                .isInstanceOf(BusinessException.class)
+                .hasFieldOrPropertyWithValue("errorCode", ErrorCode.FILE_UPLOAD_FAILED)
+                .hasMessageContaining("파일 업로드에 실패했습니다.");
+        then(s3Service).should().deleteFile("https://cdn/first.jpg");
+    }
+
+    @Test
+    @DisplayName("썸네일 파일이 이미지가 아니면 INVALID_FILE_TYPE 예외를 던지고 업로드하지 않는다")
+    void 썸네일_파일이_이미지가_아니면_예외가_발생한다() {
+        // given
+        MockMultipartFile thumbnail = new MockMultipartFile(
+                "thumbnail", "thumbnail.txt", "text/plain", "text".getBytes());
+
+        // when & then
+        assertThatThrownBy(() -> albumFileService.uploadThumbnail(thumbnail, 1L))
+                .isInstanceOf(BusinessException.class)
+                .hasFieldOrPropertyWithValue("errorCode", ErrorCode.INVALID_FILE_TYPE)
+                .hasMessageContaining("지원하지 않는 파일 형식입니다.");
+        then(s3Service).should(never()).uploadFile(org.mockito.ArgumentMatchers.any(), anyString());
+    }
+
+    private MultipartFile imageFile() {
+        return imageFile("photo.jpg");
+    }
+
+    private MultipartFile imageFile(String filename) {
+        return new MockMultipartFile("mediaFiles", filename, "image/jpeg", "image".getBytes());
+    }
+}

--- a/backend/widyu-api/src/test/java/com/widyu/album/application/AlbumMediaPolicyTest.java
+++ b/backend/widyu-api/src/test/java/com/widyu/album/application/AlbumMediaPolicyTest.java
@@ -1,0 +1,75 @@
+package com.widyu.album.application;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+
+import com.widyu.global.error.BusinessException;
+import com.widyu.global.error.ErrorCode;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.web.multipart.MultipartFile;
+
+@DisplayName("AlbumMediaPolicy 예외 처리 단위 테스트")
+class AlbumMediaPolicyTest {
+
+    private final AlbumMediaPolicy albumMediaPolicy = new AlbumMediaPolicy();
+
+    @Test
+    @DisplayName("파일 목록이 비어 있으면 FILE_IS_EMPTY 예외를 던진다")
+    void 파일_목록이_비어_있으면_예외가_발생한다() {
+        assertThatThrownBy(() -> albumMediaPolicy.validate(List.of()))
+                .isInstanceOf(BusinessException.class)
+                .hasFieldOrPropertyWithValue("errorCode", ErrorCode.FILE_IS_EMPTY)
+                .hasMessageContaining("파일이 비어있습니다.");
+    }
+
+    @Test
+    @DisplayName("지원하지 않는 콘텐츠 타입이면 INVALID_FILE_TYPE 예외를 던진다")
+    void 지원하지_않는_콘텐츠_타입이면_예외가_발생한다() {
+        // given
+        MultipartFile file = mockFile("application/pdf", 1024L);
+
+        // when & then
+        assertThatThrownBy(() -> albumMediaPolicy.validate(List.of(file)))
+                .isInstanceOf(BusinessException.class)
+                .hasFieldOrPropertyWithValue("errorCode", ErrorCode.INVALID_FILE_TYPE)
+                .hasMessageContaining("지원하지 않는 파일 형식입니다.");
+    }
+
+    @Test
+    @DisplayName("업로드 개수 제한을 초과하면 BAD_REQUEST 예외를 던진다")
+    void 업로드_개수_제한을_초과하면_예외가_발생한다() {
+        // given
+        List<MultipartFile> files = java.util.stream.IntStream.range(0, 9)
+                .mapToObj(i -> mockFile("image/jpeg", 1024L))
+                .toList();
+
+        // when & then
+        assertThatThrownBy(() -> albumMediaPolicy.validate(files))
+                .isInstanceOf(BusinessException.class)
+                .hasFieldOrPropertyWithValue("errorCode", ErrorCode.BAD_REQUEST)
+                .hasMessageContaining("전체 최대 8개");
+    }
+
+    @Test
+    @DisplayName("사진 크기 제한을 초과하면 FILE_TOO_LARGE 예외를 던진다")
+    void 사진_크기_제한을_초과하면_예외가_발생한다() {
+        // given
+        MultipartFile file = mockFile("image/jpeg", AlbumMediaPolicy.MAX_PHOTO_BYTES + 1);
+
+        // when & then
+        assertThatThrownBy(() -> albumMediaPolicy.validate(List.of(file)))
+                .isInstanceOf(BusinessException.class)
+                .hasFieldOrPropertyWithValue("errorCode", ErrorCode.FILE_TOO_LARGE)
+                .hasMessageContaining("사진은 최대 10MB");
+    }
+
+    private MultipartFile mockFile(String contentType, long size) {
+        MultipartFile file = mock(MultipartFile.class);
+        given(file.getContentType()).willReturn(contentType);
+        given(file.getSize()).willReturn(size);
+        return file;
+    }
+}

--- a/backend/widyu-api/src/test/java/com/widyu/auth/application/guardian/oauth/strategy/apple/AppleLoginStrategyTest.java
+++ b/backend/widyu-api/src/test/java/com/widyu/auth/application/guardian/oauth/strategy/apple/AppleLoginStrategyTest.java
@@ -1,0 +1,43 @@
+package com.widyu.auth.application.guardian.oauth.strategy.apple;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.mock;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.widyu.auth.application.guardian.oauth.strategy.UserInfo;
+import com.widyu.auth.dto.request.SocialLoginRequest;
+import com.widyu.global.error.BusinessException;
+import com.widyu.global.error.ErrorCode;
+import com.widyu.global.properties.AppleProperties;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.web.client.RestClient;
+
+@DisplayName("AppleLoginStrategy 예외 처리 단위 테스트")
+class AppleLoginStrategyTest {
+
+    private final AppleLoginStrategy strategy = new AppleLoginStrategy(
+            new AppleProperties("ios", "android", "team", "key", "private-key", "redirect-uri"),
+            mock(AppleJwtUtils.class),
+            RestClient.builder().build(),
+            new ObjectMapper()
+    );
+
+    @Test
+    @DisplayName("인증 코드가 비어 있으면 APPLE_AUTHORIZATION_CODE_IS_BLANK 예외를 던진다")
+    void 인증_코드가_비어_있으면_예외가_발생한다() {
+        assertThatThrownBy(() -> strategy.validateLoginRequest(SocialLoginRequest.builder().authorizationCode(" ").build()))
+                .isInstanceOf(BusinessException.class)
+                .hasFieldOrPropertyWithValue("errorCode", ErrorCode.APPLE_AUTHORIZATION_CODE_IS_BLANK)
+                .hasMessageContaining("애플 인증 코드가 비어 있습니다.");
+    }
+
+    @Test
+    @DisplayName("이메일이 없으면 SOCIAL_EMAIL_NOT_PROVIDED 예외를 던진다")
+    void 이메일이_없으면_예외가_발생한다() {
+        assertThatThrownBy(() -> strategy.validateUserInfo(UserInfo.of("익명의 사용자", null, null)))
+                .isInstanceOf(BusinessException.class)
+                .hasFieldOrPropertyWithValue("errorCode", ErrorCode.SOCIAL_EMAIL_NOT_PROVIDED)
+                .hasMessageContaining("소셜 로그인 제공자가 이메일을 제공하지 않습니다.");
+    }
+}

--- a/backend/widyu-api/src/test/java/com/widyu/auth/application/guardian/oauth/strategy/kakao/KakaoLoginStrategyTest.java
+++ b/backend/widyu-api/src/test/java/com/widyu/auth/application/guardian/oauth/strategy/kakao/KakaoLoginStrategyTest.java
@@ -1,0 +1,48 @@
+package com.widyu.auth.application.guardian.oauth.strategy.kakao;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.widyu.auth.application.guardian.oauth.strategy.UserInfo;
+import com.widyu.auth.dto.request.SocialLoginRequest;
+import com.widyu.global.error.BusinessException;
+import com.widyu.global.error.ErrorCode;
+import com.widyu.global.properties.KakaoProperties;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.web.client.RestClient;
+
+@DisplayName("KakaoLoginStrategy 예외 처리 단위 테스트")
+class KakaoLoginStrategyTest {
+
+    private final KakaoLoginStrategy strategy = new KakaoLoginStrategy(
+            RestClient.builder().build(),
+            new KakaoProperties("client-id", "redirect-uri", "admin-key")
+    );
+
+    @Test
+    @DisplayName("액세스 토큰이 비어 있으면 OAUTH_ACCESS_TOKEN_IS_BLANK 예외를 던진다")
+    void 액세스_토큰이_비어_있으면_예외가_발생한다() {
+        assertThatThrownBy(() -> strategy.validateLoginRequest(SocialLoginRequest.of(null)))
+                .isInstanceOf(BusinessException.class)
+                .hasFieldOrPropertyWithValue("errorCode", ErrorCode.OAUTH_ACCESS_TOKEN_IS_BLANK)
+                .hasMessageContaining("OAuth 액세스 토큰이 비어 있습니다.");
+    }
+
+    @Test
+    @DisplayName("이메일이 없으면 SOCIAL_EMAIL_NOT_PROVIDED 예외를 던진다")
+    void 이메일이_없으면_예외가_발생한다() {
+        assertThatThrownBy(() -> strategy.validateUserInfo(UserInfo.of("홍길동", " ", "01011112222")))
+                .isInstanceOf(BusinessException.class)
+                .hasFieldOrPropertyWithValue("errorCode", ErrorCode.SOCIAL_EMAIL_NOT_PROVIDED)
+                .hasMessageContaining("소셜 로그인 제공자가 이메일을 제공하지 않습니다.");
+    }
+
+    @Test
+    @DisplayName("이름이 없으면 SOCIAL_NAME_NOT_PROVIDED 예외를 던진다")
+    void 이름이_없으면_예외가_발생한다() {
+        assertThatThrownBy(() -> strategy.validateUserInfo(UserInfo.of(" ", "kakao@test.com", "01011112222")))
+                .isInstanceOf(BusinessException.class)
+                .hasFieldOrPropertyWithValue("errorCode", ErrorCode.SOCIAL_NAME_NOT_PROVIDED)
+                .hasMessageContaining("소셜 로그인 제공자가 이름을 제공하지 않습니다.");
+    }
+}

--- a/backend/widyu-api/src/test/java/com/widyu/auth/application/guardian/oauth/strategy/naver/NaverLoginStrategyTest.java
+++ b/backend/widyu-api/src/test/java/com/widyu/auth/application/guardian/oauth/strategy/naver/NaverLoginStrategyTest.java
@@ -1,0 +1,44 @@
+package com.widyu.auth.application.guardian.oauth.strategy.naver;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.widyu.auth.application.guardian.oauth.strategy.UserInfo;
+import com.widyu.auth.dto.request.SocialLoginRequest;
+import com.widyu.global.error.BusinessException;
+import com.widyu.global.error.ErrorCode;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.web.client.RestClient;
+
+@DisplayName("NaverLoginStrategy 예외 처리 단위 테스트")
+class NaverLoginStrategyTest {
+
+    private final NaverLoginStrategy strategy = new NaverLoginStrategy(RestClient.builder().build());
+
+    @Test
+    @DisplayName("액세스 토큰이 비어 있으면 OAUTH_ACCESS_TOKEN_IS_BLANK 예외를 던진다")
+    void 액세스_토큰이_비어_있으면_예외가_발생한다() {
+        assertThatThrownBy(() -> strategy.validateLoginRequest(SocialLoginRequest.of(" ")))
+                .isInstanceOf(BusinessException.class)
+                .hasFieldOrPropertyWithValue("errorCode", ErrorCode.OAUTH_ACCESS_TOKEN_IS_BLANK)
+                .hasMessageContaining("OAuth 액세스 토큰이 비어 있습니다.");
+    }
+
+    @Test
+    @DisplayName("이메일이 없으면 SOCIAL_EMAIL_NOT_PROVIDED 예외를 던진다")
+    void 이메일이_없으면_예외가_발생한다() {
+        assertThatThrownBy(() -> strategy.validateUserInfo(UserInfo.of("홍길동", null, "01011112222")))
+                .isInstanceOf(BusinessException.class)
+                .hasFieldOrPropertyWithValue("errorCode", ErrorCode.SOCIAL_EMAIL_NOT_PROVIDED)
+                .hasMessageContaining("소셜 로그인 제공자가 이메일을 제공하지 않습니다.");
+    }
+
+    @Test
+    @DisplayName("이름이 없으면 SOCIAL_NAME_NOT_PROVIDED 예외를 던진다")
+    void 이름이_없으면_예외가_발생한다() {
+        assertThatThrownBy(() -> strategy.validateUserInfo(UserInfo.of(null, "naver@test.com", "01011112222")))
+                .isInstanceOf(BusinessException.class)
+                .hasFieldOrPropertyWithValue("errorCode", ErrorCode.SOCIAL_NAME_NOT_PROVIDED)
+                .hasMessageContaining("소셜 로그인 제공자가 이름을 제공하지 않습니다.");
+    }
+}

--- a/backend/widyu-api/src/test/java/com/widyu/fcm/application/NotificationSettingServiceTest.java
+++ b/backend/widyu-api/src/test/java/com/widyu/fcm/application/NotificationSettingServiceTest.java
@@ -1,0 +1,64 @@
+package com.widyu.fcm.application;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.BDDMockito.given;
+
+import com.widyu.fcm.dto.request.UpdateNotificationSettingRequest;
+import com.widyu.fcm.repository.MemberNotificationSettingRepository;
+import com.widyu.global.error.BusinessException;
+import com.widyu.global.error.ErrorCode;
+import com.widyu.global.util.MemberUtil;
+import com.widyu.member.Member;
+import com.widyu.member.MemberType;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("NotificationSettingService 예외 처리 단위 테스트")
+class NotificationSettingServiceTest {
+
+    @Mock private MemberNotificationSettingRepository notificationSettingRepository;
+    @Mock private MemberUtil memberUtil;
+
+    @InjectMocks
+    private NotificationSettingService notificationSettingService;
+
+    @Test
+    @DisplayName("알림 그룹이 null이면 INVALID_FCM_CATEGORY 예외를 던진다")
+    void 알림_그룹이_null이면_예외가_발생한다() {
+        // given
+        given(memberUtil.getCurrentMember()).willReturn(member());
+
+        // when & then
+        assertThatThrownBy(() -> notificationSettingService.updateNotificationSetting(
+                new UpdateNotificationSettingRequest(null, true)))
+                .isInstanceOf(BusinessException.class)
+                .hasFieldOrPropertyWithValue("errorCode", ErrorCode.INVALID_FCM_CATEGORY)
+                .hasMessageContaining("유효하지 않은 알림 카테고리입니다.");
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 알림 그룹이면 INVALID_FCM_CATEGORY 예외를 던진다")
+    void 존재하지_않는_알림_그룹이면_예외가_발생한다() {
+        // given
+        given(memberUtil.getCurrentMember()).willReturn(member());
+
+        // when & then
+        assertThatThrownBy(() -> notificationSettingService.updateNotificationSetting(
+                new UpdateNotificationSettingRequest("UNKNOWN", true)))
+                .isInstanceOf(BusinessException.class)
+                .hasFieldOrPropertyWithValue("errorCode", ErrorCode.INVALID_FCM_CATEGORY)
+                .hasMessageContaining("유효하지 않은 알림 카테고리입니다.");
+    }
+
+    private Member member() {
+        Member member = Member.createMember(MemberType.GUARDIAN, "보호자", "01011112222");
+        ReflectionTestUtils.setField(member, "id", 1L);
+        return member;
+    }
+}

--- a/backend/widyu-api/src/test/java/com/widyu/fcm/event/album/listener/AlbumNotificationListenerTest.java
+++ b/backend/widyu-api/src/test/java/com/widyu/fcm/event/album/listener/AlbumNotificationListenerTest.java
@@ -1,0 +1,111 @@
+package com.widyu.fcm.event.album.listener;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.Mockito.never;
+
+import com.widyu.album.Album;
+import com.widyu.album.repository.AlbumRepository;
+import com.widyu.album.repository.AlbumViewRepository;
+import com.widyu.fcm.application.FcmService;
+import com.widyu.fcm.dto.FcmSendDto;
+import com.widyu.fcm.event.album.dto.AlbumCommentedEvent;
+import com.widyu.fcm.event.album.dto.AlbumCreatedEvent;
+import com.widyu.fcm.event.album.dto.AlbumUnlockedEvent;
+import com.widyu.global.error.BusinessException;
+import com.widyu.global.error.ErrorCode;
+import com.widyu.member.Member;
+import com.widyu.member.MemberType;
+import com.widyu.member.repository.FamilyMembershipRepository;
+import com.widyu.member.repository.MemberRepository;
+import com.widyu.member.repository.SeniorProfileRepository;
+import java.util.Optional;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("AlbumNotificationListener 예외 처리 단위 테스트")
+class AlbumNotificationListenerTest {
+
+    @Mock private FcmService fcmService;
+    @Mock private FamilyMembershipRepository familyMembershipRepository;
+    @Mock private SeniorProfileRepository seniorProfileRepository;
+    @Mock private MemberRepository memberRepository;
+    @Mock private AlbumViewRepository albumViewRepository;
+    @Mock private AlbumRepository albumRepository;
+
+    @InjectMocks
+    private AlbumNotificationListener albumNotificationListener;
+
+    @Test
+    @DisplayName("앨범 생성 이벤트 작성자가 없으면 NOTIFICATION_MEMBER_NOT_FOUND 예외를 던지고 FCM을 전송하지 않는다")
+    void 앨범_생성_작성자가_없으면_예외가_발생한다() {
+        // given
+        given(memberRepository.findById(1L)).willReturn(Optional.empty());
+
+        // when & then
+        assertThatThrownBy(() -> albumNotificationListener.handleAlbumCreated(new AlbumCreatedEvent(10L, 1L)))
+                .isInstanceOf(BusinessException.class)
+                .hasFieldOrPropertyWithValue("errorCode", ErrorCode.NOTIFICATION_MEMBER_NOT_FOUND)
+                .hasMessageContaining("회원을 찾을 수 없습니다.");
+        then(fcmService).should(never()).sendMessageToUser(anyLong(), any(FcmSendDto.class));
+    }
+
+    @Test
+    @DisplayName("댓글 작성자가 없으면 NOTIFICATION_MEMBER_NOT_FOUND 예외를 던지고 FCM을 전송하지 않는다")
+    void 댓글_작성자가_없으면_예외가_발생한다() {
+        // given
+        given(memberRepository.findById(1L)).willReturn(Optional.empty());
+
+        // when & then
+        assertThatThrownBy(() -> albumNotificationListener.handleAlbumCommented(new AlbumCommentedEvent(10L, 1L, 2L)))
+                .isInstanceOf(BusinessException.class)
+                .hasFieldOrPropertyWithValue("errorCode", ErrorCode.NOTIFICATION_MEMBER_NOT_FOUND)
+                .hasMessageContaining("회원을 찾을 수 없습니다.");
+        then(fcmService).should(never()).sendMessageToUser(anyLong(), any(FcmSendDto.class));
+    }
+
+    @Test
+    @DisplayName("잠금해제 이벤트 앨범이 없으면 ALBUM_NOT_FOUND 예외를 던지고 FCM을 전송하지 않는다")
+    void 잠금해제_앨범이_없으면_예외가_발생한다() {
+        // given
+        Member parent = member(1L);
+        given(memberRepository.findById(1L)).willReturn(Optional.of(parent));
+        given(albumRepository.findById(10L)).willReturn(Optional.empty());
+
+        // when & then
+        assertThatThrownBy(() -> albumNotificationListener.handleAlbumUnlocked(new AlbumUnlockedEvent(10L, 1L)))
+                .isInstanceOf(BusinessException.class)
+                .hasFieldOrPropertyWithValue("errorCode", ErrorCode.ALBUM_NOT_FOUND)
+                .hasMessageContaining("앨범을 찾을 수 없습니다.");
+        then(fcmService).should(never()).sendMessageToUser(anyLong(), any(FcmSendDto.class));
+    }
+
+    @Test
+    @DisplayName("본인 댓글 이벤트는 FCM을 전송하지 않는다")
+    void 본인_댓글_이벤트는_FCM을_전송하지_않는다() {
+        // given
+        Member member = member(1L);
+        given(memberRepository.findById(1L)).willReturn(Optional.of(member));
+
+        // when
+        albumNotificationListener.handleAlbumCommented(new AlbumCommentedEvent(10L, 1L, 1L));
+
+        // then
+        then(fcmService).should(never()).sendMessageToUser(anyLong(), any(FcmSendDto.class));
+    }
+
+    private Member member(Long id) {
+        Member member = Member.createMember(MemberType.GUARDIAN, "보호자", "01011112222");
+        ReflectionTestUtils.setField(member, "id", id);
+        return member;
+    }
+}

--- a/backend/widyu-api/src/test/java/com/widyu/fcm/event/safezone/listener/SafeZoneNotificationListenerTest.java
+++ b/backend/widyu-api/src/test/java/com/widyu/fcm/event/safezone/listener/SafeZoneNotificationListenerTest.java
@@ -1,0 +1,65 @@
+package com.widyu.fcm.event.safezone.listener;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.Mockito.never;
+
+import com.widyu.fcm.application.FcmService;
+import com.widyu.fcm.dto.FcmSendDto;
+import com.widyu.fcm.event.safezone.dto.SafeZoneExitEvent;
+import com.widyu.global.error.BusinessException;
+import com.widyu.global.error.ErrorCode;
+import com.widyu.member.Member;
+import com.widyu.member.MemberType;
+import com.widyu.member.repository.FamilyMembershipRepository;
+import com.widyu.member.repository.MemberRepository;
+import java.util.Optional;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("SafeZoneNotificationListener 예외 처리 단위 테스트")
+class SafeZoneNotificationListenerTest {
+
+    @Mock private FcmService fcmService;
+    @Mock private MemberRepository memberRepository;
+    @Mock private FamilyMembershipRepository familyMembershipRepository;
+
+    @InjectMocks
+    private SafeZoneNotificationListener safeZoneNotificationListener;
+
+    @Test
+    @DisplayName("안전구역 이탈 시니어 회원이 없으면 MEMBER_NOT_FOUND 예외를 던지고 FCM을 전송하지 않는다")
+    void 안전구역_이탈_시니어_회원이_없으면_예외가_발생한다() {
+        // given
+        given(memberRepository.findById(1L)).willReturn(Optional.empty());
+
+        // when & then
+        assertThatThrownBy(() -> safeZoneNotificationListener.handleSafeZoneExit(new SafeZoneExitEvent(1L)))
+                .isInstanceOf(BusinessException.class)
+                .hasFieldOrPropertyWithValue("errorCode", ErrorCode.MEMBER_NOT_FOUND)
+                .hasMessageContaining("회원을 찾을 수 없습니다.");
+        then(fcmService).should(never()).sendMessageToUser(anyLong(), any(FcmSendDto.class));
+    }
+
+    @Test
+    @DisplayName("시니어 프로필이 없으면 FCM을 전송하지 않는다")
+    void 시니어_프로필이_없으면_FCM을_전송하지_않는다() {
+        // given
+        Member senior = Member.createMember(MemberType.SENIOR, "부모님", "01011112222");
+        given(memberRepository.findById(1L)).willReturn(Optional.of(senior));
+
+        // when
+        safeZoneNotificationListener.handleSafeZoneExit(new SafeZoneExitEvent(1L));
+
+        // then
+        then(fcmService).should(never()).sendMessageToUser(anyLong(), any(FcmSendDto.class));
+    }
+}

--- a/backend/widyu-api/src/test/java/com/widyu/global/aspect/FamilyAccessAspectTest.java
+++ b/backend/widyu-api/src/test/java/com/widyu/global/aspect/FamilyAccessAspectTest.java
@@ -1,0 +1,154 @@
+package com.widyu.global.aspect;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+
+import com.widyu.global.annotation.ValidateFamilyAccess;
+import com.widyu.global.error.BusinessException;
+import com.widyu.global.error.ErrorCode;
+import com.widyu.global.util.MemberUtil;
+import com.widyu.member.Family;
+import com.widyu.member.Member;
+import com.widyu.member.MemberType;
+import com.widyu.member.SeniorProfile;
+import com.widyu.member.repository.FamilyMembershipRepository;
+import com.widyu.member.repository.MemberRepository;
+import java.lang.reflect.Method;
+import java.time.LocalDate;
+import java.util.Optional;
+import org.aspectj.lang.JoinPoint;
+import org.aspectj.lang.reflect.MethodSignature;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("FamilyAccessAspect 예외 처리 단위 테스트")
+class FamilyAccessAspectTest {
+
+    @Mock private MemberUtil memberUtil;
+    @Mock private MemberRepository memberRepository;
+    @Mock private FamilyMembershipRepository familyMembershipRepository;
+
+    @InjectMocks
+    private FamilyAccessAspect familyAccessAspect;
+
+    @Test
+    @DisplayName("검증 대상 파라미터가 없으면 BAD_REQUEST 예외를 던진다")
+    void 검증_대상_파라미터가_없으면_예외가_발생한다() throws Exception {
+        // given
+        Member guardian = member(1L, MemberType.GUARDIAN);
+        given(memberUtil.getCurrentMember()).willReturn(guardian);
+
+        Method method = DummyController.class.getDeclaredMethod("missingParam", Long.class);
+        JoinPoint joinPoint = joinPoint(method, 2L);
+        ValidateFamilyAccess annotation = method.getAnnotation(ValidateFamilyAccess.class);
+
+        // when & then
+        assertThatThrownBy(() -> familyAccessAspect.validateFamilyAccess(joinPoint, annotation))
+                .isInstanceOf(BusinessException.class)
+                .hasFieldOrPropertyWithValue("errorCode", ErrorCode.BAD_REQUEST)
+                .hasMessageContaining("파라미터 'memberId'를 찾을 수 없습니다.");
+    }
+
+    @Test
+    @DisplayName("시니어가 다른 회원 리소스 접근 시 FORBIDDEN 예외를 던진다")
+    void 시니어가_다른_회원_리소스_접근_시_예외가_발생한다() throws Exception {
+        // given
+        Member senior = member(1L, MemberType.SENIOR);
+        given(memberUtil.getCurrentMember()).willReturn(senior);
+
+        Method method = DummyController.class.getDeclaredMethod("withMemberId", Long.class);
+        JoinPoint joinPoint = joinPoint(method, 2L);
+
+        // when & then
+        assertThatThrownBy(() -> familyAccessAspect.validateFamilyAccess(
+                joinPoint, method.getAnnotation(ValidateFamilyAccess.class)))
+                .isInstanceOf(BusinessException.class)
+                .hasFieldOrPropertyWithValue("errorCode", ErrorCode.FORBIDDEN)
+                .hasMessageContaining("보호자만 다른 사용자의 리소스에 접근할 수 있습니다.");
+        then(memberRepository).should(never()).findById(2L);
+    }
+
+    @Test
+    @DisplayName("대상 회원이 없으면 BAD_REQUEST 예외를 던진다")
+    void 대상_회원이_없으면_예외가_발생한다() throws Exception {
+        // given
+        Member guardian = member(1L, MemberType.GUARDIAN);
+        given(memberUtil.getCurrentMember()).willReturn(guardian);
+        given(memberRepository.findById(2L)).willReturn(Optional.empty());
+
+        Method method = DummyController.class.getDeclaredMethod("withMemberId", Long.class);
+
+        // when & then
+        assertThatThrownBy(() -> familyAccessAspect.validateFamilyAccess(
+                joinPoint(method, 2L), method.getAnnotation(ValidateFamilyAccess.class)))
+                .isInstanceOf(BusinessException.class)
+                .hasFieldOrPropertyWithValue("errorCode", ErrorCode.BAD_REQUEST)
+                .hasMessageContaining("존재하지 않는 사용자입니다.");
+    }
+
+    @Test
+    @DisplayName("가족으로 연결되지 않은 시니어 접근 시 FORBIDDEN 예외를 던진다")
+    void 가족으로_연결되지_않은_시니어_접근_시_예외가_발생한다() throws Exception {
+        // given
+        Member guardian = member(1L, MemberType.GUARDIAN);
+        Member senior = member(2L, MemberType.SENIOR);
+        SeniorProfile seniorProfile = seniorProfile(10L, senior);
+        given(memberUtil.getCurrentMember()).willReturn(guardian);
+        given(memberRepository.findById(2L)).willReturn(Optional.of(senior));
+        given(familyMembershipRepository.existsByGuardianIdAndSeniorProfileId(1L, 10L)).willReturn(false);
+
+        Method method = DummyController.class.getDeclaredMethod("withMemberId", Long.class);
+
+        // when & then
+        assertThatThrownBy(() -> familyAccessAspect.validateFamilyAccess(
+                joinPoint(method, 2L), method.getAnnotation(ValidateFamilyAccess.class)))
+                .isInstanceOf(BusinessException.class)
+                .hasFieldOrPropertyWithValue("errorCode", ErrorCode.FORBIDDEN)
+                .hasMessageContaining("가족으로 연결된 시니어만 접근할 수 있습니다.");
+        then(familyMembershipRepository).should().existsByGuardianIdAndSeniorProfileId(1L, seniorProfile.getId());
+    }
+
+    private JoinPoint joinPoint(Method method, Object... args) {
+        MethodSignature signature = mock(MethodSignature.class);
+        given(signature.getMethod()).willReturn(method);
+
+        JoinPoint joinPoint = mock(JoinPoint.class);
+        given(joinPoint.getSignature()).willReturn(signature);
+        given(joinPoint.getArgs()).willReturn(args);
+        return joinPoint;
+    }
+
+    private Member member(Long id, MemberType type) {
+        Member member = Member.createMember(type, type.name(), "01011112222");
+        ReflectionTestUtils.setField(member, "id", id);
+        return member;
+    }
+
+    private SeniorProfile seniorProfile(Long id, Member member) {
+        SeniorProfile seniorProfile = SeniorProfile.createSeniorProfile(
+                member, Family.createFamily("ABC123"), "서울시", "INV1234", LocalDate.of(1950, 1, 1));
+        ReflectionTestUtils.setField(seniorProfile, "id", id);
+        ReflectionTestUtils.setField(member, "seniorProfile", seniorProfile);
+        return seniorProfile;
+    }
+
+    static class DummyController {
+
+        @ValidateFamilyAccess(memberIdParam = "memberId")
+        void withMemberId(Long memberId) {
+        }
+
+        @ValidateFamilyAccess(memberIdParam = "memberId")
+        void missingParam(Long seniorId) {
+        }
+    }
+}

--- a/backend/widyu-api/src/test/java/com/widyu/global/error/GlobalExceptionHandlerTest.java
+++ b/backend/widyu-api/src/test/java/com/widyu/global/error/GlobalExceptionHandlerTest.java
@@ -126,6 +126,24 @@ class GlobalExceptionHandlerTest {
     }
 
     @Test
+    @DisplayName("파일 검증 BusinessException은 400과 명시적 메시지를 반환한다")
+    void 파일_검증_비즈니스_예외는_400과_메시지를_반환한다() throws Exception {
+        mockMvc.perform(get("/test/business/invalid-file-type"))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.code").value(ErrorCode.INVALID_FILE_TYPE.getCode()))
+                .andExpect(jsonPath("$.message").value(ErrorCode.INVALID_FILE_TYPE.getMessage()));
+    }
+
+    @Test
+    @DisplayName("상세 메시지가 있는 BusinessException은 응답 메시지에 상세 내용을 포함한다")
+    void 상세_메시지_비즈니스_예외는_응답에_상세_내용을_포함한다() throws Exception {
+        mockMvc.perform(get("/test/business/file-too-large"))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.code").value(ErrorCode.FILE_TOO_LARGE.getCode()))
+                .andExpect(jsonPath("$.message").value("파일 크기가 너무 큽니다. - 사진은 최대 10MB까지 업로드 가능합니다."));
+    }
+
+    @Test
     @DisplayName("업로드 파일 크기를 초과하면 413을 반환한다")
     void 파일_크기_초과() {
         GlobalExceptionHandler handler = new GlobalExceptionHandler();
@@ -176,6 +194,16 @@ class GlobalExceptionHandlerTest {
         @GetMapping("/test/business/naver")
         void naver() {
             throw new BusinessException(ErrorCode.NAVER_COMMUNICATION_ERROR);
+        }
+
+        @GetMapping("/test/business/invalid-file-type")
+        void invalidFileType() {
+            throw new BusinessException(ErrorCode.INVALID_FILE_TYPE);
+        }
+
+        @GetMapping("/test/business/file-too-large")
+        void fileTooLarge() {
+            throw new BusinessException(ErrorCode.FILE_TOO_LARGE, "사진은 최대 10MB까지 업로드 가능합니다.");
         }
     }
 

--- a/backend/widyu-api/src/test/java/com/widyu/global/security/JwtTokenProviderTest.java
+++ b/backend/widyu-api/src/test/java/com/widyu/global/security/JwtTokenProviderTest.java
@@ -1,0 +1,84 @@
+package com.widyu.global.security;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.BDDMockito.given;
+
+import com.widyu.auth.dto.RefreshTokenDto;
+import com.widyu.auth.repository.RefreshTokenRepository;
+import com.widyu.global.error.BusinessException;
+import com.widyu.global.error.ErrorCode;
+import com.widyu.global.util.JwtUtil;
+import io.jsonwebtoken.ExpiredJwtException;
+import java.util.Optional;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("JwtTokenProvider 예외 처리 단위 테스트")
+class JwtTokenProviderTest {
+
+    @Mock private JwtUtil jwtUtil;
+    @Mock private RefreshTokenRepository refreshTokenRepository;
+
+    @InjectMocks
+    private JwtTokenProvider jwtTokenProvider;
+
+    @Test
+    @DisplayName("만료된 액세스 토큰은 EXPIRED_ACCESS_TOKEN 예외를 던진다")
+    void 만료된_액세스_토큰은_예외가_발생한다() {
+        // given
+        given(jwtUtil.parseAccessToken("expired-token"))
+                .willThrow(new ExpiredJwtException(null, null, "expired"));
+
+        // when & then
+        assertThatThrownBy(() -> jwtTokenProvider.retrieveAccessToken("expired-token"))
+                .isInstanceOf(BusinessException.class)
+                .hasFieldOrPropertyWithValue("errorCode", ErrorCode.EXPIRED_ACCESS_TOKEN)
+                .hasMessageContaining("액세스 토큰이 만료되었습니다.");
+    }
+
+    @Test
+    @DisplayName("파싱 결과가 없는 액세스 토큰은 INVALID_ACCESS_TOKEN 예외를 던진다")
+    void 파싱_결과가_없는_액세스_토큰은_예외가_발생한다() {
+        // given
+        given(jwtUtil.parseAccessToken("invalid-token")).willReturn(null);
+
+        // when & then
+        assertThatThrownBy(() -> jwtTokenProvider.retrieveAccessToken("invalid-token"))
+                .isInstanceOf(BusinessException.class)
+                .hasFieldOrPropertyWithValue("errorCode", ErrorCode.INVALID_ACCESS_TOKEN)
+                .hasMessageContaining("유효하지 않은 액세스 토큰입니다.");
+    }
+
+    @Test
+    @DisplayName("저장소에 없는 리프레시 토큰은 INVALID_REFRESH_TOKEN 예외를 던진다")
+    void 저장소에_없는_리프레시_토큰은_예외가_발생한다() {
+        // given
+        given(jwtUtil.parseRefreshToken("refresh-token"))
+                .willReturn(new RefreshTokenDto(1L, "refresh-token", 3600L));
+        given(refreshTokenRepository.findById(1L)).willReturn(Optional.empty());
+
+        // when & then
+        assertThatThrownBy(() -> jwtTokenProvider.retrieveRefreshToken("refresh-token"))
+                .isInstanceOf(BusinessException.class)
+                .hasFieldOrPropertyWithValue("errorCode", ErrorCode.INVALID_REFRESH_TOKEN)
+                .hasMessageContaining("리프레시 토큰이 유효하지 않습니다.");
+    }
+
+    @Test
+    @DisplayName("파싱 결과가 없는 소셜 임시 토큰은 INVALID_TEMPORARY_TOKEN 예외를 던진다")
+    void 파싱_결과가_없는_소셜_임시_토큰은_예외가_발생한다() {
+        // given
+        given(jwtUtil.parseSocialTemporaryToken("invalid-social-token")).willReturn(null);
+
+        // when & then
+        assertThatThrownBy(() -> jwtTokenProvider.retrieveSocialTemporaryToken("invalid-social-token"))
+                .isInstanceOf(BusinessException.class)
+                .hasFieldOrPropertyWithValue("errorCode", ErrorCode.INVALID_TEMPORARY_TOKEN)
+                .hasMessageContaining("유효하지 않은 임시 토큰입니다.");
+    }
+}

--- a/backend/widyu-api/src/test/java/com/widyu/global/util/MemberUtilTest.java
+++ b/backend/widyu-api/src/test/java/com/widyu/global/util/MemberUtilTest.java
@@ -1,0 +1,53 @@
+package com.widyu.global.util;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.BDDMockito.given;
+
+import com.widyu.global.error.BusinessException;
+import com.widyu.global.error.ErrorCode;
+import com.widyu.member.repository.MemberRepository;
+import java.util.Optional;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("MemberUtil 예외 처리 단위 테스트")
+class MemberUtilTest {
+
+    @Mock private SecurityUtil securityUtil;
+    @Mock private MemberRepository memberRepository;
+
+    @InjectMocks
+    private MemberUtil memberUtil;
+
+    @Test
+    @DisplayName("현재 회원을 찾을 수 없으면 MEMBER_NOT_FOUND 예외를 던진다")
+    void 현재_회원을_찾을_수_없으면_예외가_발생한다() {
+        // given
+        given(securityUtil.getCurrentMemberId()).willReturn(1L);
+        given(memberRepository.findById(1L)).willReturn(Optional.empty());
+
+        // when & then
+        assertThatThrownBy(memberUtil::getCurrentMember)
+                .isInstanceOf(BusinessException.class)
+                .hasFieldOrPropertyWithValue("errorCode", ErrorCode.MEMBER_NOT_FOUND)
+                .hasMessageContaining("회원을 찾을 수 없습니다.");
+    }
+
+    @Test
+    @DisplayName("권한 정보가 없으면 UNAUTHORIZED 예외를 던진다")
+    void 권한_정보가_없으면_예외가_발생한다() {
+        // given
+        given(securityUtil.getCurrentMemberRole()).willReturn(null);
+
+        // when & then
+        assertThatThrownBy(memberUtil::getMemberRole)
+                .isInstanceOf(BusinessException.class)
+                .hasFieldOrPropertyWithValue("errorCode", ErrorCode.UNAUTHORIZED)
+                .hasMessageContaining("인증이 필요합니다.");
+    }
+}

--- a/backend/widyu-api/src/test/java/com/widyu/global/util/SecurityUtilTest.java
+++ b/backend/widyu-api/src/test/java/com/widyu/global/util/SecurityUtilTest.java
@@ -1,0 +1,45 @@
+package com.widyu.global.util;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.widyu.global.error.BusinessException;
+import com.widyu.global.error.ErrorCode;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextHolder;
+
+@DisplayName("SecurityUtil 예외 처리 단위 테스트")
+class SecurityUtilTest {
+
+    private final SecurityUtil securityUtil = new SecurityUtil();
+
+    @AfterEach
+    void tearDown() {
+        SecurityContextHolder.clearContext();
+    }
+
+    @Test
+    @DisplayName("인증 정보가 없으면 현재 회원 ID 조회 시 UNAUTHORIZED 예외를 던진다")
+    void 인증_정보가_없으면_회원_ID_조회_시_예외가_발생한다() {
+        assertThatThrownBy(securityUtil::getCurrentMemberId)
+                .isInstanceOf(BusinessException.class)
+                .hasFieldOrPropertyWithValue("errorCode", ErrorCode.UNAUTHORIZED)
+                .hasMessageContaining("인증이 필요합니다.");
+    }
+
+    @Test
+    @DisplayName("권한 정보가 없으면 현재 회원 권한 조회 시 UNAUTHORIZED 예외를 던진다")
+    void 권한_정보가_없으면_회원_권한_조회_시_예외가_발생한다() {
+        // given
+        SecurityContextHolder.getContext().setAuthentication(
+                new UsernamePasswordAuthenticationToken("1", null, java.util.List.of()));
+
+        // when & then
+        assertThatThrownBy(securityUtil::getCurrentMemberRole)
+                .isInstanceOf(BusinessException.class)
+                .hasFieldOrPropertyWithValue("errorCode", ErrorCode.UNAUTHORIZED)
+                .hasMessageContaining("인증이 필요합니다.");
+    }
+}

--- a/backend/widyu-api/src/test/java/com/widyu/global/util/TemporaryMemberUtilTest.java
+++ b/backend/widyu-api/src/test/java/com/widyu/global/util/TemporaryMemberUtilTest.java
@@ -1,0 +1,89 @@
+package com.widyu.global.util;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.BDDMockito.given;
+
+import com.widyu.auth.dto.TemporaryTokenDto;
+import com.widyu.auth.repository.TemporaryMemberRepository;
+import com.widyu.global.error.BusinessException;
+import com.widyu.global.error.ErrorCode;
+import com.widyu.member.MemberRole;
+import jakarta.servlet.http.HttpServletRequest;
+import java.util.Optional;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpHeaders;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("TemporaryMemberUtil 예외 처리 단위 테스트")
+class TemporaryMemberUtilTest {
+
+    @Mock private JwtUtil jwtUtil;
+    @Mock private TemporaryMemberRepository temporaryMemberRepository;
+    @Mock private HttpServletRequest request;
+
+    @InjectMocks
+    private TemporaryMemberUtil temporaryMemberUtil;
+
+    @Test
+    @DisplayName("임시 토큰 헤더가 없으면 UNAUTHORIZED 예외를 던진다")
+    void 임시_토큰_헤더가_없으면_예외가_발생한다() {
+        // given
+        given(request.getHeader(HttpHeaders.AUTHORIZATION)).willReturn(null);
+
+        // when & then
+        assertThatThrownBy(() -> temporaryMemberUtil.getTemporaryMemberFromRequest(request))
+                .isInstanceOf(BusinessException.class)
+                .hasFieldOrPropertyWithValue("errorCode", ErrorCode.UNAUTHORIZED)
+                .hasMessageContaining("인증이 필요합니다.");
+    }
+
+    @Test
+    @DisplayName("JWT 파싱 결과가 없으면 UNAUTHORIZED 예외를 던진다")
+    void JWT_파싱_결과가_없으면_예외가_발생한다() {
+        // given
+        given(request.getHeader(HttpHeaders.AUTHORIZATION)).willReturn("Bearer token");
+        given(jwtUtil.parseTemporaryToken("token")).willReturn(null);
+
+        // when & then
+        assertThatThrownBy(() -> temporaryMemberUtil.getTemporaryMemberFromRequest(request))
+                .isInstanceOf(BusinessException.class)
+                .hasFieldOrPropertyWithValue("errorCode", ErrorCode.UNAUTHORIZED)
+                .hasMessageContaining("인증이 필요합니다.");
+    }
+
+    @Test
+    @DisplayName("임시 토큰 역할이 아니면 UNAUTHORIZED 예외를 던진다")
+    void 임시_토큰_역할이_아니면_예외가_발생한다() {
+        // given
+        given(request.getHeader(HttpHeaders.AUTHORIZATION)).willReturn("Bearer token");
+        given(jwtUtil.parseTemporaryToken("token"))
+                .willReturn(new TemporaryTokenDto("temp-id", MemberRole.USER, "token", 1800L));
+
+        // when & then
+        assertThatThrownBy(() -> temporaryMemberUtil.getTemporaryMemberFromRequest(request))
+                .isInstanceOf(BusinessException.class)
+                .hasFieldOrPropertyWithValue("errorCode", ErrorCode.UNAUTHORIZED)
+                .hasMessageContaining("인증이 필요합니다.");
+    }
+
+    @Test
+    @DisplayName("임시 회원 저장 정보가 없으면 MEMBER_NOT_FOUND 예외를 던진다")
+    void 임시_회원_저장_정보가_없으면_예외가_발생한다() {
+        // given
+        given(request.getHeader(HttpHeaders.AUTHORIZATION)).willReturn("Bearer token");
+        given(jwtUtil.parseTemporaryToken("token"))
+                .willReturn(new TemporaryTokenDto("temp-id", MemberRole.TEMPORARY, "token", 1800L));
+        given(temporaryMemberRepository.findById("temp-id")).willReturn(Optional.empty());
+
+        // when & then
+        assertThatThrownBy(() -> temporaryMemberUtil.getTemporaryMemberFromRequest(request))
+                .isInstanceOf(BusinessException.class)
+                .hasFieldOrPropertyWithValue("errorCode", ErrorCode.MEMBER_NOT_FOUND)
+                .hasMessageContaining("회원을 찾을 수 없습니다.");
+    }
+}

--- a/backend/widyu-api/src/test/java/com/widyu/goal/healthschedule/application/HealthScheduleRewardServiceTest.java
+++ b/backend/widyu-api/src/test/java/com/widyu/goal/healthschedule/application/HealthScheduleRewardServiceTest.java
@@ -1,0 +1,40 @@
+package com.widyu.goal.healthschedule.application;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.BDDMockito.given;
+
+import com.widyu.global.error.BusinessException;
+import com.widyu.global.error.ErrorCode;
+import com.widyu.goal.healthschedule.dto.request.HealthSchedulePointGetRequest;
+import com.widyu.goal.healthschedule.repository.HealthScheduleRepository;
+import java.util.Optional;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("HealthScheduleRewardService 예외 처리 단위 테스트")
+class HealthScheduleRewardServiceTest {
+
+    @Mock private HealthScheduleRepository healthScheduleRepository;
+
+    @InjectMocks
+    private HealthScheduleRewardService healthScheduleRewardService;
+
+    @Test
+    @DisplayName("포인트 적립 대상 건강 일정이 없으면 BAD_REQUEST 예외를 던진다")
+    void 포인트_적립_대상_건강_일정이_없으면_예외가_발생한다() {
+        // given
+        given(healthScheduleRepository.findById(1L)).willReturn(Optional.empty());
+
+        // when & then
+        assertThatThrownBy(() -> healthScheduleRewardService.accumulateHealthSchedulePoints(
+                new HealthSchedulePointGetRequest(1L)))
+                .isInstanceOf(BusinessException.class)
+                .hasFieldOrPropertyWithValue("errorCode", ErrorCode.BAD_REQUEST)
+                .hasMessageContaining("건강 일정을 찾을 수 없습니다.");
+    }
+}

--- a/backend/widyu-api/src/test/java/com/widyu/goal/healthschedule/application/HealthScheduleServiceTest.java
+++ b/backend/widyu-api/src/test/java/com/widyu/goal/healthschedule/application/HealthScheduleServiceTest.java
@@ -1,0 +1,164 @@
+package com.widyu.goal.healthschedule.application;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.Mockito.never;
+
+import com.widyu.global.error.BusinessException;
+import com.widyu.global.error.ErrorCode;
+import com.widyu.global.util.MemberUtil;
+import com.widyu.goal.healthschedule.dto.request.HealthScheduleCreateForSeniorRequest;
+import com.widyu.goal.healthschedule.dto.request.HealthScheduleUpdateRequest;
+import com.widyu.goal.healthschedule.repository.HealthScheduleRepository;
+import com.widyu.healthschedule.HealthSchedule;
+import com.widyu.healthschedule.ProgressStatus;
+import com.widyu.member.Family;
+import com.widyu.member.Member;
+import com.widyu.member.MemberType;
+import com.widyu.member.SeniorProfile;
+import com.widyu.member.repository.FamilyMembershipRepository;
+import com.widyu.member.repository.MemberRepository;
+import com.widyu.member.repository.SeniorProfileRepository;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.Optional;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("HealthScheduleService 예외 처리 단위 테스트")
+class HealthScheduleServiceTest {
+
+    @Mock private HealthScheduleRepository healthScheduleRepository;
+    @Mock private MemberRepository memberRepository;
+    @Mock private SeniorProfileRepository seniorProfileRepository;
+    @Mock private FamilyMembershipRepository familyMembershipRepository;
+    @Mock private MemberUtil memberUtil;
+
+    @InjectMocks
+    private HealthScheduleService healthScheduleService;
+
+    @Test
+    @DisplayName("보호자가 존재하지 않는 시니어 일정 생성 시 BAD_REQUEST 예외를 던지고 저장하지 않는다")
+    void 존재하지_않는_시니어_일정_생성_시_예외가_발생한다() {
+        // given
+        Member guardian = member(1L, MemberType.GUARDIAN);
+        given(memberUtil.getCurrentMember()).willReturn(guardian);
+        given(memberRepository.findById(2L)).willReturn(Optional.empty());
+
+        // when & then
+        assertThatThrownBy(() -> healthScheduleService.createHealthScheduleForSenior(createRequest(2L)))
+                .isInstanceOf(BusinessException.class)
+                .hasFieldOrPropertyWithValue("errorCode", ErrorCode.BAD_REQUEST)
+                .hasMessageContaining("시니어를 찾을 수 없습니다.");
+        then(healthScheduleRepository).should(never()).save(any(HealthSchedule.class));
+    }
+
+    @Test
+    @DisplayName("보호자가 프로필 없는 시니어 일정 생성 시 SENIOR_PROFILE_NOT_FOUND 예외를 던지고 저장하지 않는다")
+    void 프로필_없는_시니어_일정_생성_시_예외가_발생한다() {
+        // given
+        Member guardian = member(1L, MemberType.GUARDIAN);
+        Member senior = member(2L, MemberType.SENIOR);
+        given(memberUtil.getCurrentMember()).willReturn(guardian);
+        given(memberRepository.findById(2L)).willReturn(Optional.of(senior));
+        given(seniorProfileRepository.findByMemberId(2L)).willReturn(Optional.empty());
+
+        // when & then
+        assertThatThrownBy(() -> healthScheduleService.createHealthScheduleForSenior(createRequest(2L)))
+                .isInstanceOf(BusinessException.class)
+                .hasFieldOrPropertyWithValue("errorCode", ErrorCode.SENIOR_PROFILE_NOT_FOUND)
+                .hasMessageContaining("시니어 프로필을 찾을 수 없습니다.");
+        then(healthScheduleRepository).should(never()).save(any(HealthSchedule.class));
+    }
+
+    @Test
+    @DisplayName("연결되지 않은 보호자가 시니어 일정 생성 시 FORBIDDEN 예외를 던지고 저장하지 않는다")
+    void 연결되지_않은_보호자_일정_생성_시_예외가_발생한다() {
+        // given
+        Member guardian = member(1L, MemberType.GUARDIAN);
+        Member senior = member(2L, MemberType.SENIOR);
+        SeniorProfile seniorProfile = seniorProfile(10L, senior);
+        given(memberUtil.getCurrentMember()).willReturn(guardian);
+        given(memberRepository.findById(2L)).willReturn(Optional.of(senior));
+        given(seniorProfileRepository.findByMemberId(2L)).willReturn(Optional.of(seniorProfile));
+        given(familyMembershipRepository.existsByGuardianIdAndSeniorProfileId(1L, 10L)).willReturn(false);
+
+        // when & then
+        assertThatThrownBy(() -> healthScheduleService.createHealthScheduleForSenior(createRequest(2L)))
+                .isInstanceOf(BusinessException.class)
+                .hasFieldOrPropertyWithValue("errorCode", ErrorCode.FORBIDDEN)
+                .hasMessageContaining("해당 시니어의 일정을 생성할 권한이 없습니다.");
+        then(healthScheduleRepository).should(never()).save(any(HealthSchedule.class));
+    }
+
+    @Test
+    @DisplayName("시니어가 타인 일정 수정 시 FORBIDDEN 예외를 던진다")
+    void 시니어가_타인_일정_수정_시_예외가_발생한다() {
+        // given
+        Member currentSenior = member(1L, MemberType.SENIOR);
+        Member otherSenior = member(2L, MemberType.SENIOR);
+        HealthSchedule schedule = schedule(otherSenior);
+        given(memberUtil.getCurrentMember()).willReturn(currentSenior);
+        given(healthScheduleRepository.findById(100L)).willReturn(Optional.of(schedule));
+
+        // when & then
+        assertThatThrownBy(() -> healthScheduleService.updateHealthSchedule(100L, updateRequest()))
+                .isInstanceOf(BusinessException.class)
+                .hasFieldOrPropertyWithValue("errorCode", ErrorCode.FORBIDDEN)
+                .hasMessageContaining("해당 일정에 접근할 권한이 없습니다.");
+    }
+
+    @Test
+    @DisplayName("보호자가 연결되지 않은 시니어의 날짜별 일정 조회 시 FORBIDDEN 예외를 던진다")
+    void 보호자가_연결되지_않은_시니어_날짜별_조회_시_예외가_발생한다() {
+        // given
+        Member guardian = member(1L, MemberType.GUARDIAN);
+        Member senior = member(2L, MemberType.SENIOR);
+        SeniorProfile seniorProfile = seniorProfile(10L, senior);
+        given(memberUtil.getCurrentMember()).willReturn(guardian);
+        given(seniorProfileRepository.findByMemberId(2L)).willReturn(Optional.of(seniorProfile));
+        given(familyMembershipRepository.existsByGuardianIdAndSeniorProfileId(1L, 10L)).willReturn(false);
+
+        // when & then
+        assertThatThrownBy(() -> healthScheduleService.getHealthSchedulesByDateForSenior(2L, LocalDate.now()))
+                .isInstanceOf(BusinessException.class)
+                .hasFieldOrPropertyWithValue("errorCode", ErrorCode.FORBIDDEN)
+                .hasMessageContaining("해당 시니어의 일정을 조회할 권한이 없습니다.");
+    }
+
+    private HealthScheduleCreateForSeniorRequest createRequest(Long memberId) {
+        return new HealthScheduleCreateForSeniorRequest(
+                memberId, "병원 방문", "서울시 강남구", 37.5, 127.0, LocalDateTime.now().plusDays(1));
+    }
+
+    private HealthScheduleUpdateRequest updateRequest() {
+        return new HealthScheduleUpdateRequest("수정", "서울시 서초구", 37.4, 127.1,
+                LocalDateTime.now().plusDays(2), ProgressStatus.UPCOMING);
+    }
+
+    private Member member(Long id, MemberType type) {
+        Member member = Member.createMember(type, type.name(), "01011112222");
+        ReflectionTestUtils.setField(member, "id", id);
+        return member;
+    }
+
+    private SeniorProfile seniorProfile(Long id, Member member) {
+        SeniorProfile seniorProfile = SeniorProfile.createSeniorProfile(
+                member, Family.createFamily("ABC123"), "서울시", "INV1234", LocalDate.of(1950, 1, 1));
+        ReflectionTestUtils.setField(seniorProfile, "id", id);
+        ReflectionTestUtils.setField(member, "seniorProfile", seniorProfile);
+        return seniorProfile;
+    }
+
+    private HealthSchedule schedule(Member member) {
+        return HealthSchedule.create(member, "병원 방문", "서울시", 37.5, 127.0, LocalDateTime.now().plusDays(1));
+    }
+}

--- a/backend/widyu-api/src/test/java/com/widyu/heart/application/HeartMessageServiceTest.java
+++ b/backend/widyu-api/src/test/java/com/widyu/heart/application/HeartMessageServiceTest.java
@@ -1,0 +1,72 @@
+package com.widyu.heart.application;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.Mockito.never;
+
+import com.widyu.fcm.application.FcmService;
+import com.widyu.fcm.dto.FcmSendDto;
+import com.widyu.global.error.BusinessException;
+import com.widyu.global.error.ErrorCode;
+import com.widyu.global.util.MemberUtil;
+import com.widyu.heart.dto.request.HeartMessageRequest;
+import com.widyu.member.Member;
+import com.widyu.member.MemberType;
+import com.widyu.member.repository.FamilyMembershipRepository;
+import com.widyu.member.repository.MemberRepository;
+import java.util.Optional;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("HeartMessageService 예외 처리 단위 테스트")
+class HeartMessageServiceTest {
+
+    @Mock private MemberUtil memberUtil;
+    @Mock private MemberRepository memberRepository;
+    @Mock private FamilyMembershipRepository familyMembershipRepository;
+    @Mock private FcmService fcmService;
+
+    @InjectMocks
+    private HeartMessageService heartMessageService;
+
+    @Test
+    @DisplayName("수신자를 찾을 수 없으면 MEMBER_NOT_FOUND 예외를 던지고 FCM을 전송하지 않는다")
+    void 수신자를_찾을_수_없으면_예외가_발생한다() {
+        // given
+        Member sender = Member.createMember(MemberType.GUARDIAN, "보호자", "01011112222");
+        given(memberUtil.getCurrentMember()).willReturn(sender);
+        given(memberRepository.findById(2L)).willReturn(Optional.empty());
+
+        // when & then
+        assertThatThrownBy(() -> heartMessageService.sendHeartMessage(new HeartMessageRequest(2L, "괜찮으세요?")))
+                .isInstanceOf(BusinessException.class)
+                .hasFieldOrPropertyWithValue("errorCode", ErrorCode.MEMBER_NOT_FOUND)
+                .hasMessageContaining("회원을 찾을 수 없습니다.");
+        then(fcmService).should(never()).sendMessageToUser(anyLong(), any(FcmSendDto.class));
+    }
+
+    @Test
+    @DisplayName("같은 유형 회원에게 하트 메시지를 보내면 FORBIDDEN 예외를 던지고 FCM을 전송하지 않는다")
+    void 같은_유형_회원에게_보내면_예외가_발생한다() {
+        // given
+        Member sender = Member.createMember(MemberType.GUARDIAN, "보호자1", "01011112222");
+        Member receiver = Member.createMember(MemberType.GUARDIAN, "보호자2", "01033334444");
+        given(memberUtil.getCurrentMember()).willReturn(sender);
+        given(memberRepository.findById(2L)).willReturn(Optional.of(receiver));
+
+        // when & then
+        assertThatThrownBy(() -> heartMessageService.sendHeartMessage(new HeartMessageRequest(2L, "괜찮으세요?")))
+                .isInstanceOf(BusinessException.class)
+                .hasFieldOrPropertyWithValue("errorCode", ErrorCode.FORBIDDEN)
+                .hasMessageContaining("접근 권한이 없습니다.");
+        then(fcmService).should(never()).sendMessageToUser(anyLong(), any(FcmSendDto.class));
+    }
+}

--- a/backend/widyu-api/src/test/java/com/widyu/heart/application/HeartRateAnomalyDetectorTest.java
+++ b/backend/widyu-api/src/test/java/com/widyu/heart/application/HeartRateAnomalyDetectorTest.java
@@ -1,0 +1,79 @@
+package com.widyu.heart.application;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.widyu.global.error.BusinessException;
+import com.widyu.global.error.ErrorCode;
+import com.widyu.global.properties.AiProperties;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.web.client.RestClientException;
+import org.springframework.web.client.RestTemplate;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("HeartRateAnomalyDetector 예외 처리 단위 테스트")
+class HeartRateAnomalyDetectorTest {
+
+    @Mock private RestTemplate aiRestTemplate;
+
+    @Test
+    @DisplayName("심박수 데이터가 15개가 아니면 BAD_REQUEST 예외를 던진다")
+    void 심박수_데이터가_15개가_아니면_예외가_발생한다() {
+        // given
+        HeartRateAnomalyDetector detector = detector();
+
+        // when & then
+        assertThatThrownBy(() -> detector.detectAnomaly(List.of(70, 71, 72)))
+                .isInstanceOf(BusinessException.class)
+                .hasFieldOrPropertyWithValue("errorCode", ErrorCode.BAD_REQUEST)
+                .hasMessageContaining("심박수 데이터는 정확히 15개여야 합니다.");
+    }
+
+    @Test
+    @DisplayName("AI 서버 통신 실패 시 INTERNAL_SERVER_ERROR 예외를 던진다")
+    void AI_서버_통신_실패_시_예외가_발생한다() {
+        // given
+        HeartRateAnomalyDetector detector = detector();
+        given(aiRestTemplate.postForObject(eq("http://ai-server/check"), any(), eq(String.class)))
+                .willThrow(new RestClientException("connection refused"));
+
+        // when & then
+        assertThatThrownBy(() -> detector.detectAnomaly(fifteenHeartRates()))
+                .isInstanceOf(BusinessException.class)
+                .hasFieldOrPropertyWithValue("errorCode", ErrorCode.INTERNAL_SERVER_ERROR)
+                .hasMessageContaining("AI 서버와의 통신에 실패했습니다.");
+    }
+
+    @Test
+    @DisplayName("AI 서버가 Abnormal을 반환하면 이상 상태로 판단한다")
+    void AI_서버가_Abnormal을_반환하면_이상_상태로_판단한다() {
+        // given
+        HeartRateAnomalyDetector detector = detector();
+        given(aiRestTemplate.postForObject(eq("http://ai-server/check"), any(), eq(String.class)))
+                .willReturn("{\"result\":\"Abnormal\"}");
+
+        // when
+        boolean result = detector.detectAnomaly(fifteenHeartRates());
+
+        // then
+        assertThat(result).isTrue();
+    }
+
+    private HeartRateAnomalyDetector detector() {
+        AiProperties properties = new AiProperties(new AiProperties.Server("http://ai-server"));
+        return new HeartRateAnomalyDetector(aiRestTemplate, properties, new ObjectMapper());
+    }
+
+    private List<Integer> fifteenHeartRates() {
+        return List.of(70, 71, 72, 73, 74, 75, 76, 77, 78, 79, 80, 81, 82, 83, 84);
+    }
+}

--- a/backend/widyu-api/src/test/java/com/widyu/heart/application/HeartRateServiceTest.java
+++ b/backend/widyu-api/src/test/java/com/widyu/heart/application/HeartRateServiceTest.java
@@ -1,0 +1,64 @@
+package com.widyu.heart.application;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.Mockito.never;
+
+import com.widyu.global.error.BusinessException;
+import com.widyu.global.error.ErrorCode;
+import com.widyu.heart.HeartRateEvent;
+import com.widyu.heart.HeartRateResult;
+import com.widyu.heart.dto.request.HeartRateMeasurement;
+import com.widyu.heart.dto.request.HeartRateSendRequest;
+import com.widyu.heart.repository.HeartRateEmergencyRepository;
+import com.widyu.heart.repository.HeartRateEventRepository;
+import com.widyu.heart.repository.HeartRateResultRepository;
+import com.widyu.member.repository.MemberRepository;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("HeartRateService 예외 처리 단위 테스트")
+class HeartRateServiceTest {
+
+    @Mock private HeartRateAnomalyDetector heartRateAnomalyDetector;
+    @Mock private HeartRateResultRepository heartRateResultRepository;
+    @Mock private HeartRateEventRepository heartRateEventRepository;
+    @Mock private HeartRateEmergencyRepository heartRateEmergencyRepository;
+    @Mock private MemberRepository memberRepository;
+
+    @InjectMocks
+    private HeartRateService heartRateService;
+
+    @Test
+    @DisplayName("심박수 처리 대상 회원이 없으면 MEMBER_NOT_FOUND 예외를 던지고 분석/저장을 하지 않는다")
+    void 심박수_처리_대상_회원이_없으면_예외가_발생한다() {
+        // given
+        given(memberRepository.findById(1L)).willReturn(Optional.empty());
+
+        // when & then
+        assertThatThrownBy(() -> heartRateService.processHeartRates(1L, request()))
+                .isInstanceOf(BusinessException.class)
+                .hasFieldOrPropertyWithValue("errorCode", ErrorCode.MEMBER_NOT_FOUND)
+                .hasMessageContaining("회원을 찾을 수 없습니다.");
+        then(heartRateAnomalyDetector).should(never()).detectAnomaly(any());
+        then(heartRateResultRepository).should(never()).save(any(HeartRateResult.class));
+        then(heartRateEventRepository).should(never()).saveAll(any());
+    }
+
+    private HeartRateSendRequest request() {
+        List<HeartRateMeasurement> measurements = java.util.stream.IntStream.range(0, 15)
+                .mapToObj(i -> new HeartRateMeasurement(70 + i, LocalDateTime.now().plusSeconds(i)))
+                .toList();
+        return new HeartRateSendRequest(measurements, "서울시");
+    }
+}

--- a/backend/widyu-api/src/test/java/com/widyu/location/parentlocation/application/ParentLocationServiceTest.java
+++ b/backend/widyu-api/src/test/java/com/widyu/location/parentlocation/application/ParentLocationServiceTest.java
@@ -1,0 +1,119 @@
+package com.widyu.location.parentlocation.application;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.Mockito.never;
+
+import com.widyu.global.error.BusinessException;
+import com.widyu.global.error.ErrorCode;
+import com.widyu.global.util.MemberUtil;
+import com.widyu.location.parentlocation.dto.request.ParentLocationCreateRequest;
+import com.widyu.location.parentlocation.dto.request.ParentLocationUpdateRequest;
+import com.widyu.location.parentlocation.repository.ParentLocationRepository;
+import com.widyu.member.Member;
+import com.widyu.member.MemberType;
+import com.widyu.member.repository.FamilyMembershipRepository;
+import com.widyu.member.repository.MemberRepository;
+import com.widyu.member.repository.SeniorProfileRepository;
+import com.widyu.parentlocation.LocationType;
+import com.widyu.parentlocation.ParentLocation;
+import java.util.Optional;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("ParentLocationService 예외 처리 단위 테스트")
+class ParentLocationServiceTest {
+
+    @Mock private ParentLocationRepository parentLocationRepository;
+    @Mock private MemberRepository memberRepository;
+    @Mock private FamilyMembershipRepository familyMembershipRepository;
+    @Mock private SeniorProfileRepository seniorProfileRepository;
+    @Mock private MemberUtil memberUtil;
+
+    @InjectMocks
+    private ParentLocationService parentLocationService;
+
+    @Test
+    @DisplayName("HOME 타입 장소 생성 시 BAD_REQUEST 예외를 던지고 저장하지 않는다")
+    void HOME_타입_장소_생성_시_예외가_발생한다() {
+        // given
+        ParentLocationCreateRequest request = new ParentLocationCreateRequest(
+                1L, LocationType.HOME, "서울시 강남구", 37.5, 127.0, "집");
+
+        // when & then
+        assertThatThrownBy(() -> parentLocationService.create(request))
+                .isInstanceOf(BusinessException.class)
+                .hasFieldOrPropertyWithValue("errorCode", ErrorCode.BAD_REQUEST)
+                .hasMessageContaining("집 주소는 마이페이지에서만 수정할 수 있습니다.");
+        then(parentLocationRepository).should(never()).save(any(ParentLocation.class));
+    }
+
+    @Test
+    @DisplayName("이미 등록된 주소 생성 시 BAD_REQUEST 예외를 던지고 저장하지 않는다")
+    void 이미_등록된_주소_생성_시_예외가_발생한다() {
+        // given
+        Member senior = Member.createMember(MemberType.SENIOR, "부모님", "01011112222");
+        ParentLocationCreateRequest request = new ParentLocationCreateRequest(
+                1L, LocationType.OTHER, "서울시 강남구", 37.5, 127.0, "병원");
+
+        given(memberRepository.findById(1L)).willReturn(Optional.of(senior));
+        given(parentLocationRepository.existsByMemberAndPlaceAddress(senior, "서울시 강남구")).willReturn(true);
+
+        // when & then
+        assertThatThrownBy(() -> parentLocationService.create(request))
+                .isInstanceOf(BusinessException.class)
+                .hasFieldOrPropertyWithValue("errorCode", ErrorCode.BAD_REQUEST)
+                .hasMessageContaining("이미 등록된 주소입니다.");
+        then(parentLocationRepository).should(never()).save(any(ParentLocation.class));
+    }
+
+    @Test
+    @DisplayName("HOME 타입 장소 삭제 시 BAD_REQUEST 예외를 던지고 삭제하지 않는다")
+    void HOME_타입_장소_삭제_시_예외가_발생한다() {
+        // given
+        Member senior = Member.createMember(MemberType.SENIOR, "부모님", "01011112222");
+        ParentLocation home = ParentLocation.builder()
+                .member(senior)
+                .locationType(LocationType.HOME)
+                .placeAddress("서울시 강남구")
+                .latitude(37.5)
+                .longitude(127.0)
+                .name("집")
+                .build();
+
+        given(memberRepository.findById(1L)).willReturn(Optional.of(senior));
+        given(parentLocationRepository.findByIdAndMember(10L, senior)).willReturn(Optional.of(home));
+
+        // when & then
+        assertThatThrownBy(() -> parentLocationService.delete(1L, 10L))
+                .isInstanceOf(BusinessException.class)
+                .hasFieldOrPropertyWithValue("errorCode", ErrorCode.BAD_REQUEST)
+                .hasMessageContaining("집 주소는 마이페이지에서만 수정할 수 있습니다.");
+        then(parentLocationRepository).should(never()).delete(any(ParentLocation.class));
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 장소 수정 시 BAD_REQUEST 예외를 던진다")
+    void 존재하지_않는_장소_수정_시_예외가_발생한다() {
+        // given
+        Member senior = Member.createMember(MemberType.SENIOR, "부모님", "01011112222");
+        ParentLocationUpdateRequest request = new ParentLocationUpdateRequest(
+                1L, LocationType.OTHER, "서울시 강남구", 37.5, 127.0, "병원");
+
+        given(memberRepository.findById(1L)).willReturn(Optional.of(senior));
+        given(parentLocationRepository.findByIdAndMember(10L, senior)).willReturn(Optional.empty());
+
+        // when & then
+        assertThatThrownBy(() -> parentLocationService.update(10L, request))
+                .isInstanceOf(BusinessException.class)
+                .hasFieldOrPropertyWithValue("errorCode", ErrorCode.BAD_REQUEST)
+                .hasMessageContaining("존재하지 않는 장소입니다.");
+    }
+}

--- a/backend/widyu-api/src/test/java/com/widyu/location/realtime/application/RealtimeLocationServiceTest.java
+++ b/backend/widyu-api/src/test/java/com/widyu/location/realtime/application/RealtimeLocationServiceTest.java
@@ -1,0 +1,138 @@
+package com.widyu.location.realtime.application;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.Mockito.never;
+
+import com.widyu.global.error.BusinessException;
+import com.widyu.global.error.ErrorCode;
+import com.widyu.location.realtime.dto.LocationUpdateRequest;
+import com.widyu.location.realtime.repository.SeniorLocationRepository;
+import com.widyu.location.parentlocation.repository.ParentLocationRepository;
+import com.widyu.member.Family;
+import com.widyu.member.Member;
+import com.widyu.member.MemberType;
+import com.widyu.member.SeniorProfile;
+import com.widyu.member.repository.FamilyMembershipRepository;
+import com.widyu.member.repository.SeniorProfileRepository;
+import java.time.LocalDate;
+import java.util.Optional;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.ValueOperations;
+import org.springframework.messaging.simp.SimpMessagingTemplate;
+import org.springframework.test.util.ReflectionTestUtils;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("RealtimeLocationService 예외 처리 단위 테스트")
+class RealtimeLocationServiceTest {
+
+    @Mock private SeniorLocationRepository seniorLocationRepository;
+    @Mock private FamilyMembershipRepository familyMembershipRepository;
+    @Mock private SeniorProfileRepository seniorProfileRepository;
+    @Mock private ParentLocationRepository parentLocationRepository;
+    @Mock private SimpMessagingTemplate messagingTemplate;
+    @Mock private RedisTemplate<String, Object> redisTemplate;
+    @Mock private ValueOperations<String, Object> valueOperations;
+    @Mock private ApplicationEventPublisher eventPublisher;
+
+    @InjectMocks
+    private RealtimeLocationService realtimeLocationService;
+
+    @Test
+    @DisplayName("인증 회원과 요청 회원이 다르면 FORBIDDEN 예외를 던지고 위치를 저장하지 않는다")
+    void 인증_회원과_요청_회원이_다르면_예외가_발생한다() {
+        // given
+        LocationUpdateRequest request = new LocationUpdateRequest(2L, 37.5, 127.0, null);
+
+        // when & then
+        assertThatThrownBy(() -> realtimeLocationService.updateAndBroadcast(request, 1L))
+                .isInstanceOf(BusinessException.class)
+                .hasFieldOrPropertyWithValue("errorCode", ErrorCode.FORBIDDEN)
+                .hasMessageContaining("본인의 위치만 업데이트할 수 있습니다.");
+        then(seniorLocationRepository).should(never()).save(org.mockito.ArgumentMatchers.any());
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 시니어 위치 업데이트 시 BAD_REQUEST 예외를 던진다")
+    void 존재하지_않는_시니어_위치_업데이트_시_예외가_발생한다() {
+        // given
+        LocationUpdateRequest request = new LocationUpdateRequest(1L, 37.5, 127.0, null);
+        given(seniorProfileRepository.findByMemberId(1L)).willReturn(Optional.empty());
+
+        // when & then
+        assertThatThrownBy(() -> realtimeLocationService.updateAndBroadcast(request, 1L))
+                .isInstanceOf(BusinessException.class)
+                .hasFieldOrPropertyWithValue("errorCode", ErrorCode.BAD_REQUEST)
+                .hasMessageContaining("존재하지 않는 시니어입니다.");
+    }
+
+    @Test
+    @DisplayName("연결되지 않은 보호자가 마지막 위치 조회 시 FORBIDDEN 예외를 던진다")
+    void 연결되지_않은_보호자_마지막_위치_조회_시_예외가_발생한다() {
+        // given
+        SeniorProfile seniorProfile = seniorProfile(10L, member(2L));
+        given(seniorProfileRepository.findByMemberId(2L)).willReturn(Optional.of(seniorProfile));
+        given(familyMembershipRepository.existsByGuardianIdAndSeniorProfileId(1L, 10L)).willReturn(false);
+
+        // when & then
+        assertThatThrownBy(() -> realtimeLocationService.getLastLocation(2L, 1L))
+                .isInstanceOf(BusinessException.class)
+                .hasFieldOrPropertyWithValue("errorCode", ErrorCode.FORBIDDEN)
+                .hasMessageContaining("해당 시니어의 위치를 조회할 권한이 없습니다.");
+    }
+
+    @Test
+    @DisplayName("최근 위치와 체류 정보가 모두 없으면 NOT_FOUND 예외를 던진다")
+    void 최근_위치와_체류_정보가_모두_없으면_예외가_발생한다() {
+        // given
+        SeniorProfile seniorProfile = seniorProfile(10L, member(2L));
+        given(seniorProfileRepository.findByMemberId(2L)).willReturn(Optional.of(seniorProfile));
+        given(familyMembershipRepository.existsByGuardianIdAndSeniorProfileId(1L, 10L)).willReturn(true);
+        given(redisTemplate.opsForValue()).willReturn(valueOperations);
+        given(valueOperations.get("location:stay:2")).willReturn(null);
+        given(seniorLocationRepository.findBySeniorId(2L)).willReturn(Optional.empty());
+
+        // when & then
+        assertThatThrownBy(() -> realtimeLocationService.getLastLocation(2L, 1L))
+                .isInstanceOf(BusinessException.class)
+                .hasFieldOrPropertyWithValue("errorCode", ErrorCode.NOT_FOUND)
+                .hasMessageContaining("최근 위치 정보가 없습니다.");
+    }
+
+    @Test
+    @DisplayName("연결되지 않은 보호자가 이동 경로 조회 시 FORBIDDEN 예외를 던진다")
+    void 연결되지_않은_보호자_이동_경로_조회_시_예외가_발생한다() {
+        // given
+        SeniorProfile seniorProfile = seniorProfile(10L, member(2L));
+        given(seniorProfileRepository.findByMemberId(2L)).willReturn(Optional.of(seniorProfile));
+        given(familyMembershipRepository.existsByGuardianIdAndSeniorProfileId(1L, 10L)).willReturn(false);
+
+        // when & then
+        assertThatThrownBy(() -> realtimeLocationService.getLocationTrail(2L, 1L))
+                .isInstanceOf(BusinessException.class)
+                .hasFieldOrPropertyWithValue("errorCode", ErrorCode.FORBIDDEN)
+                .hasMessageContaining("해당 시니어의 위치를 조회할 권한이 없습니다.");
+    }
+
+    private Member member(Long id) {
+        Member member = Member.createMember(MemberType.SENIOR, "부모님", "01011112222");
+        ReflectionTestUtils.setField(member, "id", id);
+        return member;
+    }
+
+    private SeniorProfile seniorProfile(Long id, Member member) {
+        SeniorProfile seniorProfile = SeniorProfile.createSeniorProfile(
+                member, Family.createFamily("ABC123"), "서울시", "INV1234", LocalDate.of(1950, 1, 1));
+        ReflectionTestUtils.setField(seniorProfile, "id", id);
+        ReflectionTestUtils.setField(member, "seniorProfile", seniorProfile);
+        return seniorProfile;
+    }
+}

--- a/backend/widyu-api/src/test/java/com/widyu/member/application/FamilyConnectionServiceTest.java
+++ b/backend/widyu-api/src/test/java/com/widyu/member/application/FamilyConnectionServiceTest.java
@@ -1,0 +1,95 @@
+package com.widyu.member.application;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.Mockito.never;
+
+import com.widyu.global.error.BusinessException;
+import com.widyu.global.error.ErrorCode;
+import com.widyu.global.util.MemberUtil;
+import com.widyu.member.Family;
+import com.widyu.member.FamilyMembership;
+import com.widyu.member.Member;
+import com.widyu.member.MemberType;
+import com.widyu.member.dto.request.FamilyJoinRequest;
+import com.widyu.member.repository.FamilyMembershipRepository;
+import com.widyu.member.repository.FamilyRepository;
+import com.widyu.member.repository.SeniorProfileRepository;
+import java.util.Optional;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("FamilyConnectionService 예외 처리 단위 테스트")
+class FamilyConnectionServiceTest {
+
+    @Mock private MemberUtil memberUtil;
+    @Mock private FamilyRepository familyRepository;
+    @Mock private FamilyMembershipRepository familyMembershipRepository;
+    @Mock private SeniorProfileRepository seniorProfileRepository;
+
+    @InjectMocks
+    private FamilyConnectionService familyConnectionService;
+
+    @Test
+    @DisplayName("시니어가 가족 참여 시 FORBIDDEN 예외를 던진다")
+    void 시니어가_가족_참여_시_예외가_발생한다() {
+        // given
+        given(memberUtil.getCurrentMember()).willReturn(member(1L, MemberType.SENIOR));
+
+        // when & then
+        assertThatThrownBy(() -> familyConnectionService.joinFamily(new FamilyJoinRequest("ABC123")))
+                .isInstanceOf(BusinessException.class)
+                .hasFieldOrPropertyWithValue("errorCode", ErrorCode.FORBIDDEN)
+                .hasMessageContaining("보호자 회원만 초대코드로 가족에 참여할 수 있습니다.");
+        then(familyMembershipRepository).should(never()).save(any(FamilyMembership.class));
+    }
+
+    @Test
+    @DisplayName("가족 코드가 없으면 INVITE_CODE_NOT_FOUND 예외를 던진다")
+    void 가족_코드가_없으면_예외가_발생한다() {
+        // given
+        given(memberUtil.getCurrentMember()).willReturn(member(1L, MemberType.GUARDIAN));
+        given(familyRepository.findByFamilyCode("ABC123")).willReturn(Optional.empty());
+
+        // when & then
+        assertThatThrownBy(() -> familyConnectionService.joinFamily(new FamilyJoinRequest("ABC123")))
+                .isInstanceOf(BusinessException.class)
+                .hasFieldOrPropertyWithValue("errorCode", ErrorCode.INVITE_CODE_NOT_FOUND)
+                .hasMessageContaining("초대코드를 찾을 수 없습니다.");
+        then(familyMembershipRepository).should(never()).save(any(FamilyMembership.class));
+    }
+
+    @Test
+    @DisplayName("이미 가족에 연결된 보호자는 ALREADY_CONNECTED_TO_FAMILY 예외를 던진다")
+    void 이미_가족에_연결된_보호자는_예외가_발생한다() {
+        // given
+        Member guardian = member(1L, MemberType.GUARDIAN);
+        Family family = Family.createFamily("ABC123");
+        ReflectionTestUtils.setField(family, "id", 10L);
+        given(memberUtil.getCurrentMember()).willReturn(guardian);
+        given(familyRepository.findByFamilyCode("ABC123")).willReturn(Optional.of(family));
+        given(familyMembershipRepository.findByGuardianId(1L))
+                .willReturn(Optional.of(FamilyMembership.createMembership(family, guardian)));
+
+        // when & then
+        assertThatThrownBy(() -> familyConnectionService.joinFamily(new FamilyJoinRequest("ABC123")))
+                .isInstanceOf(BusinessException.class)
+                .hasFieldOrPropertyWithValue("errorCode", ErrorCode.ALREADY_CONNECTED_TO_FAMILY)
+                .hasMessageContaining("이미 가족에 소속되어 있습니다.");
+        then(familyMembershipRepository).should(never()).save(any(FamilyMembership.class));
+    }
+
+    private Member member(Long id, MemberType type) {
+        Member member = Member.createMember(type, type.name(), "01011112222");
+        ReflectionTestUtils.setField(member, "id", id);
+        return member;
+    }
+}

--- a/backend/widyu-api/src/test/java/com/widyu/member/application/SeniorProfileServiceTest.java
+++ b/backend/widyu-api/src/test/java/com/widyu/member/application/SeniorProfileServiceTest.java
@@ -1,0 +1,91 @@
+package com.widyu.member.application;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.Mockito.never;
+
+import com.widyu.album.repository.AlbumUnlockRepository;
+import com.widyu.global.error.BusinessException;
+import com.widyu.global.error.ErrorCode;
+import com.widyu.global.util.MemberUtil;
+import com.widyu.member.Family;
+import com.widyu.member.Member;
+import com.widyu.member.MemberType;
+import com.widyu.member.PointHistory;
+import com.widyu.member.SeniorProfile;
+import com.widyu.member.repository.PointHistoryRepository;
+import com.widyu.member.repository.SeniorProfileRepository;
+import java.time.LocalDate;
+import java.util.Optional;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("SeniorProfileService 예외 처리 단위 테스트")
+class SeniorProfileServiceTest {
+
+    @Mock private MemberUtil memberUtil;
+    @Mock private AlbumUnlockRepository albumUnlockRepository;
+    @Mock private SeniorProfileRepository seniorProfileRepository;
+    @Mock private PointHistoryRepository pointHistoryRepository;
+
+    @InjectMocks
+    private SeniorProfileService seniorProfileService;
+
+    @Test
+    @DisplayName("보호자가 포인트 조회 시 FORBIDDEN 예외를 던진다")
+    void 보호자가_포인트_조회_시_예외가_발생한다() {
+        // given
+        given(memberUtil.getCurrentMember()).willReturn(member(1L, MemberType.GUARDIAN));
+
+        // when & then
+        assertThatThrownBy(seniorProfileService::getLeftPoints)
+                .isInstanceOf(BusinessException.class)
+                .hasFieldOrPropertyWithValue("errorCode", ErrorCode.FORBIDDEN)
+                .hasMessageContaining("시니어 회원만 접근할 수 있습니다.");
+    }
+
+    @Test
+    @DisplayName("포인트 적립 대상 시니어 프로필이 없으면 SENIOR_PROFILE_NOT_FOUND 예외를 던진다")
+    void 포인트_적립_대상_프로필이_없으면_예외가_발생한다() {
+        // given
+        given(seniorProfileRepository.findByMemberId(1L)).willReturn(Optional.empty());
+
+        // when & then
+        assertThatThrownBy(() -> seniorProfileService.addPointsToMember(1L, 100L))
+                .isInstanceOf(BusinessException.class)
+                .hasFieldOrPropertyWithValue("errorCode", ErrorCode.SENIOR_PROFILE_NOT_FOUND)
+                .hasMessageContaining("시니어 프로필을 찾을 수 없습니다.");
+        then(pointHistoryRepository).should(never()).save(any(PointHistory.class));
+    }
+
+    @Test
+    @DisplayName("차감 포인트가 부족하면 BAD_REQUEST 예외를 던지고 이력을 저장하지 않는다")
+    void 차감_포인트가_부족하면_예외가_발생한다() {
+        // given
+        SeniorProfile seniorProfile = SeniorProfile.createSeniorProfile(
+                member(1L, MemberType.SENIOR), Family.createFamily("ABC123"), "서울시", "INV1234", LocalDate.of(1950, 1, 1));
+        ReflectionTestUtils.setField(seniorProfile, "points", 10L);
+        given(seniorProfileRepository.findByMemberId(1L)).willReturn(Optional.of(seniorProfile));
+
+        // when & then
+        assertThatThrownBy(() -> seniorProfileService.deductPointsFromMember(1L, 50L, "취소"))
+                .isInstanceOf(BusinessException.class)
+                .hasFieldOrPropertyWithValue("errorCode", ErrorCode.BAD_REQUEST)
+                .hasMessageContaining("결제 취소에 필요한 포인트가 부족합니다.");
+        then(pointHistoryRepository).should(never()).save(any(PointHistory.class));
+    }
+
+    private Member member(Long id, MemberType type) {
+        Member member = Member.createMember(type, type.name(), "01011112222");
+        ReflectionTestUtils.setField(member, "id", id);
+        return member;
+    }
+}


### PR DESCRIPTION
## 개요
예외 처리 경로에서 비즈니스 오류 코드와 메시지가 유지되는지 검증하는 테스트를 보강합니다.
위치 조회, 미디어 업로드, 토큰 검증, 알림, 심박수 처리 등에서 실패 시 원치 않는 500 응답이나 부수효과가 발생하지 않도록 일부 예외 흐름을 보완합니다.

## 관련 문서
- LLD: docs/lld/LLD-0001-websocket-realtime-location.md
- ADR: docs/adr/ADR-0004-media-upload-strategy.md

## 관련 이슈
Closes #389

## 변경 사항
- 변경 모듈: widyu-api
- `BusinessException`의 `errorCode`와 응답 메시지를 검증하는 단위 테스트를 추가합니다.
- 위치, 건강 일정, 심박수, 알림, 관리자, OAuth, 회원, 가족 연결, 앨범 파일 업로드 예외 경로 테스트를 보강합니다.
- 파일 업로드 중 발생한 `BusinessException`이 `FILE_UPLOAD_FAILED`로 덮이지 않도록 보존합니다.
- 토큰 파싱 실패, 임시 토큰 파싱 실패, 인증 권한 누락, AOP 파라미터 누락, 알림 그룹 누락이 명시적 비즈니스 예외로 처리되도록 보완합니다.
- 심박수 처리 대상 회원이 없으면 AI 분석과 저장 전에 중단되도록 순서를 조정합니다.

## 테스트
- `./gradlew :backend:widyu-api:test`: 통과

## 체크리스트
- [x] 엔티티 변경이 없어 `./gradlew compileJava`가 필요하지 않습니다.
- [x] MySQL ENUM 변경이 없습니다.
- [x] `@Async` 메서드 변경이 없습니다.
- [x] 관련 예외 경로의 오류 코드와 메시지 검증을 보강했습니다.

## Open Questions (LLD 미결정 사항)
없습니다.

## 비고
외부 인프라 어댑터 성격의 S3, FFmpeg, FCM 클라이언트 세부 실패 경로는 별도 통합 테스트 범위로 분리하는 것이 적절합니다.
