### PR TITLE
fix: 최근 심박수 마지막 이벤트 반환

### DIFF
--- a/backend/widyu-api/src/main/java/com/widyu/heart/application/HeartRateService.java
+++ b/backend/widyu-api/src/main/java/com/widyu/heart/application/HeartRateService.java
@@ -83,6 +83,8 @@ public class HeartRateService {
     public HeartRateStatusResponse getHeartRateStatus(Long memberId) {
         return heartRateResultRepository.findByMemberId(memberId)
                 .map(HeartRateStatusResponse::from)
+                .or(() -> heartRateEventRepository.findFirstByMemberIdOrderByMeasuredAtDesc(memberId)
+                        .map(event -> HeartRateStatusResponse.from(memberId, event)))
                 .orElse(HeartRateStatusResponse.unknown(memberId));
     }
 
@@ -94,12 +96,13 @@ public class HeartRateService {
         Integer maxHeartRate = heartRateEventRepository.findMaxHeartRateByMemberId(memberId).orElse(null);
         Integer minHeartRate = heartRateEventRepository.findMinHeartRateByMemberId(memberId).orElse(null);
 
-        HeartGraphCurrentResponse current = buildCurrentForInitial(latest, maxHeartRate, minHeartRate);
+        HeartRateEvent latestEvent = getLatestEvent(allEvents);
+        HeartGraphCurrentResponse current = buildCurrentForInitial(latest, latestEvent, maxHeartRate, minHeartRate);
 
         HeartRateEmergency firstEmergency = heartRateEmergencyRepository.findFirstByMemberIdOrderByMeasuredAtAsc(memberId).orElse(null);
         HeartRateEventResponse firstEmergencyResponse = null;
         if (firstEmergency != null) {
-            firstEmergencyResponse = new HeartRateEventResponse(firstEmergency.getHeartRate(), firstEmergency.getMeasuredAt());
+            firstEmergencyResponse = HeartRateEventResponse.from(firstEmergency);
         }
 
         List<HeartRateEventResponse> eventResponses = allEvents.stream()
@@ -118,10 +121,13 @@ public class HeartRateService {
         Integer maxHeartRate = heartRateEventRepository.findMaxHeartRateByMemberId(memberId).orElse(null);
         Integer minHeartRate = heartRateEventRepository.findMinHeartRateByMemberId(memberId).orElse(null);
 
-        HeartGraphCurrentResponse current = buildCurrentForRefresh(latest, maxHeartRate, minHeartRate);
+        List<HeartRateEvent> recentHeartRateEvents = heartRateEventRepository.findTop5ByMemberIdOrderByMeasuredAtDesc(memberId);
+        HeartRateEvent latestEvent = recentHeartRateEvents.stream()
+                .max(Comparator.comparing(HeartRateEvent::getMeasuredAt))
+                .orElse(null);
+        HeartGraphCurrentResponse current = buildCurrentForRefresh(latest, latestEvent, maxHeartRate, minHeartRate);
 
-        List<HeartRateEventResponse> recentEvents = heartRateEventRepository
-                .findTop5ByMemberIdOrderByMeasuredAtDesc(memberId)
+        List<HeartRateEventResponse> recentEvents = recentHeartRateEvents
                 .stream()
                 .sorted(Comparator.comparing(HeartRateEvent::getMeasuredAt))
                 .map(HeartRateEventResponse::from)
@@ -132,19 +138,68 @@ public class HeartRateService {
         return HeartGraphPageResponse.of(heartGraph, buildEmergencyHistory(memberId));
     }
 
-    private HeartGraphCurrentResponse buildCurrentForInitial(HeartRateResult latest, Integer maxHeartRate, Integer minHeartRate) {
+    private HeartGraphCurrentResponse buildCurrentForInitial(
+            HeartRateResult latest,
+            HeartRateEvent latestEvent,
+            Integer maxHeartRate,
+            Integer minHeartRate
+    ) {
         if (latest == null) {
-            return HeartGraphCurrentResponse.forInitial(null, null, maxHeartRate, minHeartRate, HeartRateStatus.UNKNOWN);
+            return buildCurrentForInitialFromEvent(latestEvent, maxHeartRate, minHeartRate);
         }
         return HeartGraphCurrentResponse.forInitial(
                 latest.getHeartRate(), latest.getMeasuredAt(), maxHeartRate, minHeartRate, latest.getStatus());
     }
 
-    private HeartGraphCurrentResponse buildCurrentForRefresh(HeartRateResult latest, Integer maxHeartRate, Integer minHeartRate) {
+    private HeartGraphCurrentResponse buildCurrentForInitialFromEvent(
+            HeartRateEvent latestEvent,
+            Integer maxHeartRate,
+            Integer minHeartRate
+    ) {
+        if (latestEvent == null) {
+            return HeartGraphCurrentResponse.forInitial(null, null, maxHeartRate, minHeartRate, HeartRateStatus.UNKNOWN);
+        }
+        return HeartGraphCurrentResponse.forInitial(
+                latestEvent.getHeartRate(),
+                latestEvent.getMeasuredAt(),
+                maxHeartRate,
+                minHeartRate,
+                latestEvent.getStatus()
+        );
+    }
+
+    private HeartGraphCurrentResponse buildCurrentForRefresh(
+            HeartRateResult latest,
+            HeartRateEvent latestEvent,
+            Integer maxHeartRate,
+            Integer minHeartRate
+    ) {
         if (latest == null) {
-            return HeartGraphCurrentResponse.forRefresh(null, maxHeartRate, minHeartRate, HeartRateStatus.UNKNOWN);
+            return buildCurrentForRefreshFromEvent(latestEvent, maxHeartRate, minHeartRate);
         }
         return HeartGraphCurrentResponse.forRefresh(latest.getHeartRate(), maxHeartRate, minHeartRate, latest.getStatus());
+    }
+
+    private HeartGraphCurrentResponse buildCurrentForRefreshFromEvent(
+            HeartRateEvent latestEvent,
+            Integer maxHeartRate,
+            Integer minHeartRate
+    ) {
+        if (latestEvent == null) {
+            return HeartGraphCurrentResponse.forRefresh(null, maxHeartRate, minHeartRate, HeartRateStatus.UNKNOWN);
+        }
+        return HeartGraphCurrentResponse.forRefresh(
+                latestEvent.getHeartRate(),
+                maxHeartRate,
+                minHeartRate,
+                latestEvent.getStatus()
+        );
+    }
+
+    private HeartRateEvent getLatestEvent(List<HeartRateEvent> events) {
+        return events.stream()
+                .max(Comparator.comparing(HeartRateEvent::getMeasuredAt))
+                .orElse(null);
     }
 
     private HeartRateStatus resolveStatus(boolean isAbnormal) {
@@ -162,6 +217,6 @@ public class HeartRateService {
                 .stream()
                 .map(EmergencyEventResponse::from)
                 .toList();
-        return new EmergencyHistoryResponse(emergencyCount, totalDuration, emergencyEvents);
+        return EmergencyHistoryResponse.of(emergencyCount, totalDuration, emergencyEvents);
     }
 }

--- a/backend/widyu-api/src/main/java/com/widyu/heart/controller/docs/HeartRateDocs.java
+++ b/backend/widyu-api/src/main/java/com/widyu/heart/controller/docs/HeartRateDocs.java
@@ -20,6 +20,11 @@ public interface HeartRateDocs {
             description = """
                     회원의 가장 최신 심박수 분석 결과를 조회합니다.
 
+                    **조회 우선순위**:
+                    1. 최신 분석 결과 (Redis, 24시간 TTL)
+                    2. 분석 결과가 만료·부재 시: 가장 최근 심박수 이벤트(DB) 값으로 대체 반환
+                    3. 이벤트도 없으면 `UNKNOWN` 반환
+
                     **접근 권한**:
                     - memberId 미입력 시: 본인의 심박수 조회
                     - memberId 입력 시: 가족 관계가 있는 경우에만 조회 가능

--- a/backend/widyu-api/src/main/java/com/widyu/heart/dto/response/EmergencyHistoryResponse.java
+++ b/backend/widyu-api/src/main/java/com/widyu/heart/dto/response/EmergencyHistoryResponse.java
@@ -7,4 +7,7 @@ public record EmergencyHistoryResponse(
         int totalDuration,
         List<EmergencyEventResponse> events
 ) {
+    public static EmergencyHistoryResponse of(long emergencyCount, int totalDuration, List<EmergencyEventResponse> events) {
+        return new EmergencyHistoryResponse(emergencyCount, totalDuration, events);
+    }
 }

--- a/backend/widyu-api/src/main/java/com/widyu/heart/dto/response/HeartRateEventResponse.java
+++ b/backend/widyu-api/src/main/java/com/widyu/heart/dto/response/HeartRateEventResponse.java
@@ -1,5 +1,6 @@
 package com.widyu.heart.dto.response;
 
+import com.widyu.heart.HeartRateEmergency;
 import com.widyu.heart.HeartRateEvent;
 import java.time.LocalDateTime;
 
@@ -9,5 +10,9 @@ public record HeartRateEventResponse(
 ) {
     public static HeartRateEventResponse from(HeartRateEvent event) {
         return new HeartRateEventResponse(event.getHeartRate(), event.getMeasuredAt());
+    }
+
+    public static HeartRateEventResponse from(HeartRateEmergency emergency) {
+        return new HeartRateEventResponse(emergency.getHeartRate(), emergency.getMeasuredAt());
     }
 }

--- a/backend/widyu-api/src/main/java/com/widyu/heart/dto/response/HeartRateStatusResponse.java
+++ b/backend/widyu-api/src/main/java/com/widyu/heart/dto/response/HeartRateStatusResponse.java
@@ -1,5 +1,6 @@
 package com.widyu.heart.dto.response;
 
+import com.widyu.heart.HeartRateEvent;
 import com.widyu.heart.HeartRateResult;
 import com.widyu.heart.HeartRateStatus;
 import java.time.LocalDateTime;
@@ -16,6 +17,15 @@ public record HeartRateStatusResponse(
                 result.getStatus(),
                 result.getHeartRate(),
                 result.getMeasuredAt()
+        );
+    }
+
+    public static HeartRateStatusResponse from(Long memberId, HeartRateEvent event) {
+        return new HeartRateStatusResponse(
+                memberId,
+                event.getStatus(),
+                event.getHeartRate(),
+                event.getMeasuredAt()
         );
     }
 

--- a/backend/widyu-api/src/main/java/com/widyu/heart/repository/HeartRateEventRepository.java
+++ b/backend/widyu-api/src/main/java/com/widyu/heart/repository/HeartRateEventRepository.java
@@ -17,6 +17,8 @@ public interface HeartRateEventRepository extends JpaRepository<HeartRateEvent, 
 
     List<HeartRateEvent> findTop5ByMemberIdOrderByMeasuredAtDesc(Long memberId);
 
+    Optional<HeartRateEvent> findFirstByMemberIdOrderByMeasuredAtDesc(Long memberId);
+
     List<HeartRateEvent> findTop15ByMemberIdOrderByMeasuredAtDesc(Long memberId);
 
     @Query("SELECT MAX(h.heartRate) FROM HeartRateEvent h WHERE h.member.id = :memberId")

--- a/backend/widyu-api/src/test/java/com/widyu/heart/application/HeartRateServiceTest.java
+++ b/backend/widyu-api/src/test/java/com/widyu/heart/application/HeartRateServiceTest.java
@@ -1,5 +1,6 @@
 package com.widyu.heart.application;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
@@ -10,11 +11,16 @@ import com.widyu.global.error.BusinessException;
 import com.widyu.global.error.ErrorCode;
 import com.widyu.heart.HeartRateEvent;
 import com.widyu.heart.HeartRateResult;
+import com.widyu.heart.HeartRateStatus;
 import com.widyu.heart.dto.request.HeartRateMeasurement;
 import com.widyu.heart.dto.request.HeartRateSendRequest;
+import com.widyu.heart.dto.response.HeartGraphPageResponse;
+import com.widyu.heart.dto.response.HeartRateStatusResponse;
 import com.widyu.heart.repository.HeartRateEmergencyRepository;
 import com.widyu.heart.repository.HeartRateEventRepository;
 import com.widyu.heart.repository.HeartRateResultRepository;
+import com.widyu.member.Member;
+import com.widyu.member.MemberType;
 import com.widyu.member.repository.MemberRepository;
 import java.time.LocalDateTime;
 import java.util.List;
@@ -55,10 +61,89 @@ class HeartRateServiceTest {
         then(heartRateEventRepository).should(never()).saveAll(any());
     }
 
+    @Test
+    @DisplayName("최근 심박수 조회 시 최신 결과가 없으면 마지막 이벤트 값을 반환한다")
+    void 최근심박수_조회시_최신결과가_없으면_마지막이벤트를_반환한다() {
+        Long memberId = 1L;
+        LocalDateTime measuredAt = LocalDateTime.now().minusSeconds(31);
+        HeartRateEvent latestEvent = heartRateEvent(78, measuredAt, HeartRateStatus.NORMAL);
+
+        given(heartRateResultRepository.findByMemberId(memberId)).willReturn(Optional.empty());
+        given(heartRateEventRepository.findFirstByMemberIdOrderByMeasuredAtDesc(memberId))
+                .willReturn(Optional.of(latestEvent));
+
+        HeartRateStatusResponse response = heartRateService.getHeartRateStatus(memberId);
+
+        assertThat(response.memberId()).isEqualTo(memberId);
+        assertThat(response.heartRateStatus()).isEqualTo(HeartRateStatus.NORMAL);
+        assertThat(response.heartRate()).isEqualTo(78);
+        assertThat(response.measuredAt()).isEqualTo(measuredAt);
+    }
+
+    @Test
+    @DisplayName("그래프 갱신 시 최신 결과가 없으면 최근 이벤트 중 마지막 값을 현재 심박수로 반환한다")
+    void 그래프갱신시_최신결과가_없으면_최근이벤트_마지막값을_현재심박수로_반환한다() {
+        Long memberId = 1L;
+        LocalDateTime firstMeasuredAt = LocalDateTime.now().minusSeconds(45);
+        LocalDateTime lastMeasuredAt = LocalDateTime.now().minusSeconds(31);
+        HeartRateEvent firstEvent = heartRateEvent(75, firstMeasuredAt, HeartRateStatus.NORMAL);
+        HeartRateEvent latestEvent = heartRateEvent(82, lastMeasuredAt, HeartRateStatus.ANOMALY);
+
+        given(heartRateResultRepository.findByMemberId(memberId)).willReturn(Optional.empty());
+        given(heartRateEventRepository.findMaxHeartRateByMemberId(memberId)).willReturn(Optional.of(82));
+        given(heartRateEventRepository.findMinHeartRateByMemberId(memberId)).willReturn(Optional.of(75));
+        given(heartRateEventRepository.findTop5ByMemberIdOrderByMeasuredAtDesc(memberId))
+                .willReturn(List.of(latestEvent, firstEvent));
+        given(heartRateEmergencyRepository.countByMemberId(memberId)).willReturn(0L);
+        given(heartRateEventRepository.findTotalDurationMinutesByMemberId(memberId)).willReturn(Optional.empty());
+        given(heartRateEmergencyRepository.findByMemberIdOrderByMeasuredAtDesc(memberId)).willReturn(List.of());
+
+        HeartGraphPageResponse response = heartRateService.getHeartGraphRefresh(memberId);
+
+        assertThat(response.heartGraph().current().heartRate()).isEqualTo(82);
+        assertThat(response.heartGraph().current().status()).isEqualTo(HeartRateStatus.ANOMALY);
+        assertThat(response.heartGraph().current().maxHeartRate()).isEqualTo(82);
+        assertThat(response.heartGraph().current().minHeartRate()).isEqualTo(75);
+    }
+
+    @Test
+    @DisplayName("그래프 최초 조회 시 최신 결과가 없으면 전체 이벤트 중 마지막 값을 현재 심박수로 반환한다")
+    void 그래프최초조회시_최신결과가_없으면_전체이벤트_마지막값을_현재심박수로_반환한다() {
+        Long memberId = 1L;
+        LocalDateTime firstMeasuredAt = LocalDateTime.now().minusSeconds(45);
+        LocalDateTime lastMeasuredAt = LocalDateTime.now().minusSeconds(31);
+        HeartRateEvent firstEvent = heartRateEvent(75, firstMeasuredAt, HeartRateStatus.NORMAL);
+        HeartRateEvent latestEvent = heartRateEvent(82, lastMeasuredAt, HeartRateStatus.ANOMALY);
+
+        given(heartRateResultRepository.findByMemberId(memberId)).willReturn(Optional.empty());
+        given(heartRateEventRepository.findByMemberIdOrderByMeasuredAtAsc(memberId))
+                .willReturn(List.of(firstEvent, latestEvent));
+        given(heartRateEventRepository.findMaxHeartRateByMemberId(memberId)).willReturn(Optional.of(82));
+        given(heartRateEventRepository.findMinHeartRateByMemberId(memberId)).willReturn(Optional.of(75));
+        given(heartRateEmergencyRepository.findFirstByMemberIdOrderByMeasuredAtAsc(memberId))
+                .willReturn(Optional.empty());
+        given(heartRateEmergencyRepository.countByMemberId(memberId)).willReturn(0L);
+        given(heartRateEventRepository.findTotalDurationMinutesByMemberId(memberId)).willReturn(Optional.empty());
+        given(heartRateEmergencyRepository.findByMemberIdOrderByMeasuredAtDesc(memberId)).willReturn(List.of());
+
+        HeartGraphPageResponse response = heartRateService.getHeartGraph(memberId);
+
+        assertThat(response.heartGraph().current().heartRate()).isEqualTo(82);
+        assertThat(response.heartGraph().current().measuredAt()).isEqualTo(lastMeasuredAt);
+        assertThat(response.heartGraph().current().status()).isEqualTo(HeartRateStatus.ANOMALY);
+        assertThat(response.heartGraph().current().maxHeartRate()).isEqualTo(82);
+        assertThat(response.heartGraph().current().minHeartRate()).isEqualTo(75);
+    }
+
     private HeartRateSendRequest request() {
         List<HeartRateMeasurement> measurements = java.util.stream.IntStream.range(0, 15)
                 .mapToObj(i -> new HeartRateMeasurement(70 + i, LocalDateTime.now().plusSeconds(i)))
                 .toList();
         return new HeartRateSendRequest(measurements, "서울시");
+    }
+
+    private HeartRateEvent heartRateEvent(Integer heartRate, LocalDateTime measuredAt, HeartRateStatus status) {
+        Member member = Member.createMember(MemberType.SENIOR, "시니어", "01012345678");
+        return HeartRateEvent.of(member, heartRate, measuredAt, status);
     }
 }


### PR DESCRIPTION
## 개요
최근 심박수 조회 시 최신 분석 결과가 없더라도 마지막 심박 이벤트 값이 남아 있으면 해당 값을 응답하도록 수정합니다.
심박수 상태 조회와 그래프 최초 조회 및 갱신에서 마지막 측정값을 확인할 수 있도록 변경합니다.

## 관련 문서
- LLD: -
- ADR: -

## 관련 이슈
Closes #393

## 변경 사항
- 변경 모듈: widyu-api
- 심박수 상태 조회에서 Redis 최신 분석 결과가 없으면 DB의 마지막 심박 이벤트를 fallback으로 반환합니다.
- 심박수 그래프 최초 조회 및 갱신에서 최신 분석 결과가 없으면 마지막 심박 이벤트를 현재 심박수로 사용합니다.
- 심박수 이벤트 및 위급상황 응답 생성을 정적 팩토리로 보강합니다.
- fallback 동작을 검증하는 HeartRateService 단위 테스트를 추가합니다.
- Swagger 문서에 심박수 조회 우선순위를 명시합니다.

## 테스트
- `./gradlew :backend:widyu-api:test --tests com.widyu.heart.application.HeartRateServiceTest`: 통과
- `./gradlew :backend:widyu-api:test`: 통과

## 체크리스트
- [x] 엔티티 변경이 없음을 확인했습니다.
- [x] MySQL ENUM 변경이 없음을 확인했습니다.
- [x] `@Async` 메서드 변경이 없음을 확인했습니다.
- [x] 이슈 완료 조건을 충족했습니다.

## Open Questions (LLD 미결정 사항)
없습니다.

## 비고
배포 시 별도 DB 마이그레이션은 필요하지 않습니다.
