### PR TITLE
fix(auth): SENIOR 회원의 시니어 등록 API를 GUARDIAN 타입 검증으로 차단합니다

### DIFF
--- a/backend/widyu-api/src/main/java/com/widyu/auth/application/senior/SeniorAuthService.java
+++ b/backend/widyu-api/src/main/java/com/widyu/auth/application/senior/SeniorAuthService.java
@@ -52,6 +52,7 @@ public class SeniorAuthService {
     @Transactional
     public void seniorSignUpBulk(List<SeniorSignUpRequest> requests) {
         Member guardian = memberUtil.getCurrentMember();
+        validateIsGuardian(guardian);
 
         validateRequestsNotEmpty(requests);
 
@@ -99,6 +100,12 @@ public class SeniorAuthService {
     private void validateRequestsNotEmpty(List<SeniorSignUpRequest> requests) {
         if (requests == null || requests.isEmpty()) {
             throw new BusinessException(ErrorCode.SENIOR_SIGNUP_REQUEST_EMPTY);
+        }
+    }
+
+    private void validateIsGuardian(Member member) {
+        if (member.getType() != MemberType.GUARDIAN) {
+            throw new BusinessException(ErrorCode.FORBIDDEN);
         }
     }
 

--- a/backend/widyu-api/src/main/java/com/widyu/auth/controller/docs/SeniorAuthDocs.java
+++ b/backend/widyu-api/src/main/java/com/widyu/auth/controller/docs/SeniorAuthDocs.java
@@ -42,7 +42,8 @@ public interface SeniorAuthDocs {
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "시니어 일괄 회원가입 성공"),
             @ApiResponse(responseCode = "400", description = "잘못된 요청 (빈 리스트, 유효하지 않은 주소 등)"),
-            @ApiResponse(responseCode = "401", description = "인증 실패")
+            @ApiResponse(responseCode = "401", description = "인증 실패"),
+            @ApiResponse(responseCode = "403", description = "보호자(GUARDIAN) 타입 회원만 시니어 등록 가능")
     })
     ApiResponseTemplate<Void> seniorSignUpBulk(@RequestBody @Valid List<SeniorSignUpRequest> requests);
 

--- a/backend/widyu-api/src/test/java/com/widyu/auth/application/senior/SeniorAuthServiceTest.java
+++ b/backend/widyu-api/src/test/java/com/widyu/auth/application/senior/SeniorAuthServiceTest.java
@@ -290,4 +290,21 @@ class SeniorAuthServiceTest {
         // then
         verify(memberRepository).saveAll(anyList());
     }
+
+    @Test
+    @DisplayName("시니어 타입 회원이 시니어 등록을 시도하면 FORBIDDEN 예외가 발생한다")
+    void 시니어_타입_회원이_시니어_등록을_시도하면_FORBIDDEN_예외가_발생한다() {
+        // given — SENIOR 타입 Member
+        Member senior = Member.createMember(MemberType.SENIOR, "시니어", "01011112222");
+        given(memberUtil.getCurrentMember()).willReturn(senior);
+
+        List<SeniorSignUpRequest> requests = List.of(
+                new SeniorSignUpRequest("부모님", LocalDate.of(1950, 1, 1), "01011112222", "서울", "1234567")
+        );
+
+        // when & then
+        assertThatThrownBy(() -> seniorAuthService.seniorSignUpBulk(requests))
+                .isInstanceOf(BusinessException.class)
+                .hasFieldOrPropertyWithValue("errorCode", ErrorCode.FORBIDDEN);
+    }
 }

--- a/docs/architecture/WIDYU_ARCHITECTURE_REVIEW_AND_REFACTORING_PLAN.md
+++ b/docs/architecture/WIDYU_ARCHITECTURE_REVIEW_AND_REFACTORING_PLAN.md
@@ -39,7 +39,7 @@
 | ARCH-006 | Controller 외부 API 직접 호출 예외 | Medium | 분석 중 | auth | 검토 예정 | Naver 테스트 연동 계층 정리 |
 | ARCH-007 | 아키텍처 경계 자동 검증 부재 | Low | 작업 예정 | 전체 | TEST-005 | 아키텍처 경계 테스트 |
 | ARCH-008 | Refresh Token 회전 검증 누락 | Critical | 완료 | auth | TEST-001 | Refresh Token rotation 검증 수정 |
-| ARCH-009 | Senior 가입 행위자 타입 검증 누락 | High | 작업 예정 | auth/family | TEST-002 | 시니어 등록 행위자 검증 |
+| ARCH-009 | Senior 가입 행위자 타입 검증 누락 | High | 완료 | auth/family | TEST-002 | 시니어 등록 행위자 검증 |
 | ARCH-010 | 탈퇴 후 FamilyMembership·leader 상태 잔존 | High | 개선안 제안 | member/family/auth | TEST-003 | 탈퇴-가족 구성원 생명주기 정책 |
 | ARCH-011 | 가족 접근 정책의 AOP·Service 분산 | High | 작업 예정 | member/family/global | TEST-004 | 가족 접근 정책 단일화 |
 | ARCH-012 | 가입 트랜잭션 내부 외부 지오코딩 호출 | Medium | 개선안 제안 | auth/location | TEST-006 | 시니어 가입 지오코딩 경계 |
@@ -638,7 +638,7 @@
 
 ### ARCH-009 Senior 가입 행위자 타입 검증 누락
 
-- **상태:** 작업 예정
+- **상태:** 완료 (2026-07-15, 브랜치 fix/#397, 이슈 #397)
 - **심각도:** High
 - **관련 모듈:** `widyu-api`
 - **관련 패키지 및 파일:** [SeniorAuthService.java](../../backend/widyu-api/src/main/java/com/widyu/auth/application/senior/SeniorAuthService.java), [SecurityConfig.java](../../backend/widyu-api/src/main/java/com/widyu/global/config/SecurityConfig.java)
@@ -652,8 +652,8 @@
 - **예상 영향 범위:** senior 가입 API, Family 초기 생성.
 - **추천 PR 단위:** `시니어 등록 행위자 검증`.
 - **관련 ADR·LLD:** ADR-0002.
-- **결정 이력:** 2026-07-15 리뷰에서 확인.
-- **추가 확인 사항:** admin의 등록 허용 여부는 별도 정책 확인 필요.
+- **결정 이력:** 2026-07-15 리뷰에서 확인. 2026-07-15 구현 완료 — `SeniorAuthService.validateIsGuardian()`이 `seniorSignUpBulk()` 진입 직후 `member.getType() != MemberType.GUARDIAN`이면 `BusinessException(ErrorCode.FORBIDDEN)`으로 거부한다. 설계: [ARCH-009 구현 설계](implementation-plans/ARCH-009-senior-actor-type-guard.md).
+- **추가 확인 사항:** admin의 등록 허용 여부는 별도 정책 확인 필요. 현재는 GUARDIAN만 허용.
 
 ### ARCH-010 탈퇴 후 FamilyMembership·leader 상태 잔존
 
@@ -851,7 +851,7 @@
 | ID | 테스트 대상 | 보호할 동작 | 테스트 유형 | 우선순위 | 상태 | 이후 가능한 리팩터링 |
 | -- | ------ | ------ | ------ | ---- | -- | ----------- |
 | TEST-001 | Refresh Token 재발급 | 최신 토큰만 유효, 재발급 저장 1회 | Redis 통합 테스트 | P0 | 완료 | Refresh Token rotation 단순화 |
-| TEST-002 | SeniorAuthService | guardian만 Family·Senior 등록 가능 | Service 단위 테스트 | P0 | 작업 예정 | 가입 권한 정책 명시 |
+| TEST-002 | SeniorAuthService | guardian만 Family·Senior 등록 가능 | Service 단위 테스트 | P0 | 완료 | 가입 권한 정책 명시 |
 | TEST-003 | MemberWithdrawService + Membership | 탈퇴 guardian이 유효 leader로 남지 않음 | JPA 통합 테스트 | P0 | 작업 예정 | Membership 생명주기 정리 |
 | TEST-004 | FamilyAccessService/Aspect | AOP와 Service 경로의 권한 판정 일치 | 단위 + Controller 통합 테스트 | P1 | 작업 예정 | 정책 추출·패키지 이동 |
 | TEST-005 | 모듈·계층 규칙 | Entity/Repository/Controller 경계 유지 | 아키텍처 경계 테스트 | P1 | 작업 예정 | 모듈 경계 리팩터링 |
@@ -1002,6 +1002,7 @@ query-read-model     # home/mypage/admin 조합 조회
 - **완료 조건:** guardian 외 요청이 일관된 FORBIDDEN으로 거부됨
 - **롤백 가능성:** 높음
 - **추천 PR:** `fix(auth): restrict senior provisioning to guardians`
+- **상태:** 완료 (2026-07-15). 이슈 #397, 브랜치 fix/#397. 완료 조건 충족 — SENIOR 타입 거부(FORBIDDEN)와 GUARDIAN 정상 흐름을 단위 테스트로 검증. 독립 리뷰 APPROVE.
 
 - **작업 ID:** TASK-007
 - **작업:** ParentLocation CUD 가족 소유권 검증
@@ -1296,7 +1297,7 @@ query-read-model     # home/mypage/admin 조합 조회
 | PR 순서 | PR 제목 | 해결할 이슈 | 선행 테스트 | 주요 대상 | 위험도 | 상태 |
 | ----- | ----- | ------ | ------ | ----- | --- | -- |
 | 1 | `fix(auth): validate rotated refresh token value` | ARCH-008 | TEST-001 | auth/global security | 높음 | 리뷰 완료 (구현·독립 리뷰 APPROVE, 커밋·PR 생성은 사용자 지시 대기) |
-| 2 | `fix(auth): restrict senior provisioning to guardians` | ARCH-009 | TEST-002 | auth senior signup | 중간 | 예비 후보 |
+| 2 | `fix(auth): restrict senior provisioning to guardians` | ARCH-009 | TEST-002 | auth senior signup | 중간 | 리뷰 완료 (구현·독립 리뷰 APPROVE, 커밋·PR 생성은 사용자 지시 대기) |
 | 3 | `refactor(member): centralize family access policy` | ARCH-004, ARCH-011 | TEST-004, TEST-005 | member/global/AOP | 중간 | 예비 후보 |
 | 4 | `refactor(member): define membership withdrawal lifecycle` | ARCH-010 | TEST-003, TEST-007 | member/auth withdrawal | 높음 | 예비 후보 |
 | 5 | `test(architecture): enforce module and layer boundaries` | ARCH-007 | TEST-005 | test/CI | 낮음 | 예비 후보 |
@@ -1468,6 +1469,17 @@ query-read-model     # home/mypage/admin 조합 조회
 - **관련 이슈:** ARCH-008~011, ARCH-013~014, ARCH-016, ARCH-019~021, ARCH-023~024, ARCH-026, ARCH-028~030, ARCH-032.
 - **ADR 작성 여부:** 아니오. 각 구현 결정이 확정되면 관련 ADR·LLD를 개별 개정한다.
 
+### 2026-07-15 — ARCH-009 Senior 가입 행위자 타입 검증 구현
+
+- **배경:** TEST-002·TASK-002·PR 2(`fix(auth): restrict senior provisioning to guardians`)를 두 번째 리팩터링 사이클로 구현했다. 이슈 #397, 브랜치 fix/#397.
+- **결정 (검증 위치 및 방식):** `SeniorAuthService.seniorSignUpBulk()` 진입 직후 `validateIsGuardian(member)`를 첫 번째 검증으로 배치한다. `member.getType() != MemberType.GUARDIAN`이면 `BusinessException(ErrorCode.FORBIDDEN)`으로 즉시 거부한다.
+- **검증 순서 결정 근거:** MemberType 위반은 요청 내용과 무관한 행위자 권한 문제이므로 empty-request 검증보다 먼저 차단해야 한다. SENIOR 회원의 빈 요청이 `SENIOR_SIGNUP_REQUEST_EMPTY`(400)로 반환되면 오류 의미가 모호해진다.
+- **에러 코드 재사용:** 새 에러 코드 추가 없이 기존 `ErrorCode.FORBIDDEN`(HTTP 403)을 사용한다.
+- **검토한 대안:** SecurityConfig URL 패턴으로 차단 — Spring Security `USER` role이 GUARDIAN·SENIOR를 구분하지 않아 URL 패턴만으로 차단 불가.
+- **관련 테스트:** `SeniorAuthServiceTest`에 `시니어_타입_회원이_시니어_등록을_시도하면_FORBIDDEN_예외가_발생한다` 1개 추가. 기존 10개 테스트 전부 통과.
+- **영향 범위:** `SeniorAuthService.seniorSignUpBulk()` 1개 메서드만 수정. `seniorSignIn()` 및 admin 경로 미변경.
+- **관련 이슈:** ARCH-009. 후속 후보: admin 직접 호출 정책 결정 시 별도 PR.
+
 ### 2026-07-15 — ARCH-008 Refresh Token 회전 검증 구현
 
 - **배경:** TEST-001·TASK-001·PR 1(`fix(auth): validate rotated refresh token value`)을 첫 리팩터링 사이클로 구현했다. 이슈 #395, 브랜치 fix/#395.
@@ -1496,7 +1508,7 @@ query-read-model     # home/mypage/admin 조합 조회
 
 ## 13. 다음 작업
 
-> 2026-07-15 갱신: PR 1(ARCH-008/TEST-001/TASK-001)은 구현·리뷰 완료. 커밋·PR 생성은 사용자 지시 대기. 다음 구현 후보는 권장 PR 목록 순서상 PR 2 `fix(auth): restrict senior provisioning to guardians` (ARCH-009, TEST-002, TASK-002)다. 아래 기존 계획 항목은 유지한다.
+> 2026-07-15 갱신: PR 1(ARCH-008/TEST-001/TASK-001)·PR 2(ARCH-009/TEST-002/TASK-002) 구현·리뷰 완료. 커밋·PR 생성은 사용자 지시 대기. 다음 구현 후보는 권장 PR 목록 순서상 PR 3 `refactor(member): centralize family access policy` (ARCH-004, ARCH-011)다. 아래 기존 계획 항목은 유지한다.
 
 1. **순서:** 1
    **작업:** 최종 통합 리뷰에서 Critical·High 이슈와 P0 테스트를 기준으로 리팩터링 PR 순서를 확정한다.
@@ -1531,3 +1543,4 @@ query-read-model     # home/mypage/admin 조합 조회
 | 2026-07-15 | home/mypage/admin 및 직접 참조 QueryDSL·Repository 리뷰 반영. ARCH-005 근거 갱신, ARCH-032~034, TEST-027~030, TASK-026~029 등록. | home/mypage/admin 상세 리뷰 |
 | 2026-07-15 | Critical·High 이슈 중심 테스트·ADR·LLD 정합성 리뷰 반영. 새 구조 이슈 추가 없이 TASK-030과 PR 30 후보를 등록하고 테스트·문서 게이트를 확정. | 테스트·ADR·LLD 정합성 리뷰 |
 | 2026-07-15 | ARCH-008 구현 완료 (이슈 #395, 브랜치 fix/#395). Refresh Token Redis 저장값 비교 도입, 재발급 이중 저장 제거. TEST-001 단위 9개 + Redis 통합 4개 + 서비스 3개 테스트 보강, 독립 리뷰 APPROVE, 전체 빌드 통과. ARCH-008·TEST-001·TASK-001 완료, PR 1 리뷰 완료로 상태 변경. 설계 문서 implementation-plans/ARCH-008-refresh-token-rotation.md 추가. | PR 1 `fix(auth): validate rotated refresh token value` |
+| 2026-07-15 | ARCH-009 구현 완료 (이슈 #397, 브랜치 fix/#397). SeniorAuthService.validateIsGuardian() 추가로 SENIOR 타입 회원의 시니어 등록 API 호출을 FORBIDDEN으로 차단. TEST-002 단위 테스트 1개 추가, 기존 10개 전부 통과, 독립 리뷰 APPROVE, 전체 빌드 통과. ARCH-009·TEST-002·TASK-002 완료, PR 2 리뷰 완료로 상태 변경. 설계 문서 implementation-plans/ARCH-009-senior-actor-type-guard.md 추가. | PR 2 `fix(auth): restrict senior provisioning to guardians` |

--- a/docs/architecture/implementation-plans/ARCH-009-senior-actor-type-guard.md
+++ b/docs/architecture/implementation-plans/ARCH-009-senior-actor-type-guard.md
@@ -1,0 +1,139 @@
+# ARCH-009 Senior 가입 행위자 타입 검증 구현 설계
+
+## 1. 문제 정의
+
+### 현재 확인된 동작
+
+- `SeniorAuthService.seniorSignUpBulk()`는 `memberUtil.getCurrentMember()`로 현재 회원을 조회한다.
+- 조회 직후 `member.getType()`을 확인하지 않고, FamilyMembership 존재 여부(`findByGuardianId`)만 검증한다.
+- Spring Security는 GUARDIAN·SENIOR 모두 같은 `USER` role(`MemberRole`)로 처리한다.
+
+### 보안상 문제
+
+- 유효한 JWT를 가진 SENIOR 회원이 `/api/v1/auth/senior/signup` (또는 해당 경로)를 호출하면,
+  Family 생성 → SeniorProfile 저장 → leader FamilyMembership 생성이 모두 수행된다.
+- Family 생성과 leader 등록은 GUARDIAN만 수행해야 한다는 불변식이 서비스 경계에서 보장되지 않는다.
+
+### 깨진 불변식
+
+- Family 생성과 leader FamilyMembership 등록은 MemberType.GUARDIAN 회원만 수행해야 한다.
+
+## 2. 목표
+
+### 변경 후 보장할 불변식
+
+- `seniorSignUpBulk()` 진입 시 현재 회원의 `type`이 `GUARDIAN`이 아니면 `BusinessException(ErrorCode.FORBIDDEN)`으로 거부한다.
+- 거부 에러 코드는 HTTP 403(`FORBIDDEN`) 계열이고, 기존 `ErrorCode.FORBIDDEN`을 재사용한다.
+- GUARDIAN 회원의 기존 정상 등록 흐름(FamilyMembership 중복 확인 → Family 생성 → Senior 저장 → 리더십 부여)은 유지된다.
+
+### 기존에 유지할 동작
+
+- GUARDIAN 회원의 seniorSignUpBulk() 정상 실행 흐름 전체.
+- SENIOR 회원의 시니어 로그인(`seniorSignIn()`)은 이번 변경 범위 외.
+- admin 역할의 직접 호출이 필요할 경우 별도 정책 확인 후 후속 PR에서 처리.
+
+## 3. 변경 설계
+
+### 3.1 변경 파일
+
+| 파일 | 변경 유형 |
+| --- | --- |
+| `backend/widyu-api/src/main/java/com/widyu/auth/application/senior/SeniorAuthService.java` | 수정 |
+| `backend/widyu-api/src/test/java/com/widyu/auth/application/senior/SeniorAuthServiceTest.java` | 수정 (테스트 추가) |
+
+### 3.2 SeniorAuthService 변경
+
+`seniorSignUpBulk()` 메서드에서 `getCurrentMember()` 직후 guardian 타입 검증을 삽입한다.
+
+```java
+@Transactional
+public void seniorSignUpBulk(List<SeniorSignUpRequest> requests) {
+    Member guardian = memberUtil.getCurrentMember();
+    validateIsGuardian(guardian);           // ← 추가
+    validateRequestsNotEmpty(requests);
+    ...
+}
+
+private void validateIsGuardian(Member member) {
+    if (member.getType() != MemberType.GUARDIAN) {
+        throw new BusinessException(ErrorCode.FORBIDDEN);
+    }
+}
+```
+
+**검증 순서 결정**: guardian type 검증을 empty requests 검증보다 앞에 둔다.
+- 이유: MemberType 위반은 요청 내용과 무관한 행위자 권한 문제이므로 가장 먼저 차단해야 한다.
+- empty requests 검증이 앞에 있으면, SENIOR 회원의 빈 요청이 `SENIOR_SIGNUP_REQUEST_EMPTY`(400)로 반환되어 오류 의미가 모호해진다.
+
+### 3.3 허용되는 부수 변경 없음
+
+삼항 연산자, DTO 직접 생성, 기타 CLAUDE.md 위반 사항이 수정 대상 범위에 없다.
+
+## 4. 테스트 시나리오 (TEST-002)
+
+| 번호 | 시나리오 | 유형 | 기대 결과 |
+| --- | --- | --- | --- |
+| T1 | SENIOR 회원이 시니어 등록 API 호출 | 단위 | `BusinessException(FORBIDDEN)` |
+| T2 | GUARDIAN 회원이 정상 등록 (기존 테스트) | 단위 | 정상 저장 완료 |
+| T3 | GUARDIAN 회원이 이미 가족 소속일 때 (기존 테스트) | 단위 | `ALREADY_CONNECTED_TO_FAMILY` |
+
+T2·T3는 기존 테스트에 이미 존재한다. T1만 신규 추가한다.
+
+### T1 상세
+
+```java
+@Test
+@DisplayName("시니어 타입 회원이 시니어 등록을 시도하면 FORBIDDEN 예외가 발생한다")
+void 시니어_타입_회원이_시니어_등록을_시도하면_FORBIDDEN_예외가_발생한다() {
+    // given — SENIOR 타입 Member
+    Member senior = Member.createMember(MemberType.SENIOR, "시니어", "01011112222");
+    given(memberUtil.getCurrentMember()).willReturn(senior);
+
+    List<SeniorSignUpRequest> requests = List.of(
+            new SeniorSignUpRequest("부모님", LocalDate.of(1950, 1, 1), "01011112222", "서울", "1234567")
+    );
+
+    // when & then
+    assertThatThrownBy(() -> seniorAuthService.seniorSignUpBulk(requests))
+            .isInstanceOf(BusinessException.class)
+            .hasFieldOrPropertyWithValue("errorCode", ErrorCode.FORBIDDEN);
+}
+```
+
+### strict stub 주의
+
+기존 테스트 중 `given(memberUtil.getCurrentMember()).willReturn(guardian)`을 선언한 뒤
+`familyMembershipRepository.findByGuardianId`를 stub하지 않은 케이스가 있다면 순서 변경에 주의한다.
+T1에서는 `validateIsGuardian`이 던지므로 `familyMembershipRepository` stub이 불필요하다.
+
+## 5. 구현 순서
+
+1. `SeniorAuthServiceTest.java`에 T1 테스트 추가 → 실패 확인 (RED)
+2. `SeniorAuthService.java`에 `validateIsGuardian` 추가 → 테스트 통과 (GREEN)
+3. 전체 테스트 실행: `./gradlew :backend:widyu-api:test`
+
+## 6. 완료 기준
+
+- SENIOR 타입으로 `seniorSignUpBulk()` 호출 시 `FORBIDDEN` 예외 발생
+- 기존 `SeniorAuthServiceTest` 9개 테스트 전부 통과
+- `./gradlew build` BUILD SUCCESSFUL
+
+## 7. 제외 범위
+
+- `seniorSignIn()` 흐름: 시니어 로그인은 행위자 타입 검증 대상이 아님
+- admin 직접 호출 허용 여부: 별도 정책 결정 후 후속 PR
+- SecurityConfig URL 패턴 변경: 이번 PR에서 수정하지 않음
+
+## 8. 위험·롤백
+
+- **위험**: 현재 SENIOR 토큰으로 seniorSignUpBulk를 호출하던 클라이언트가 있다면 차단됨 — 의도된 보안 강화
+- **롤백 가능성**: 높음. `validateIsGuardian` 한 줄 제거로 이전 동작 복원 가능
+
+## 9. Fable 자가 검증
+
+- [x] 변경 대상 파일 목록 확정 (2개 파일만)
+- [x] 기존 테스트 stub 순서 충돌 없음 확인 (SENIOR stub은 familyMembershipRepository 불필요)
+- [x] `ErrorCode.FORBIDDEN` 재사용 (새 에러 코드 추가 없음)
+- [x] `member.getType()`은 `@Getter` Lombok으로 자동 생성됨 확인
+- [x] 삼항 연산자 없음, early return 패턴 사용
+- [x] 검증 순서: guardian type → empty requests → membership exists (가장 먼저 행위자 차단)


### PR DESCRIPTION
## 개요

`SeniorAuthService.seniorSignUpBulk()`가 요청자의 MemberType을 검증하지 않아 SENIOR 회원도 Family·SeniorProfile·leader FamilyMembership을 생성할 수 있었습니다.
Spring Security는 SENIOR·GUARDIAN을 동일한 `USER` role로 처리하므로 URL 패턴만으로는 차단이 불가능합니다.
서비스 경계에서 `validateIsGuardian()`을 첫 번째 검증으로 추가해 GUARDIAN이 아닌 경우 즉시 FORBIDDEN(403)으로 거부하도록 수정했습니다.

## 관련 문서

- LLD: - (해당 LLD 없음, 구현 설계: docs/architecture/implementation-plans/ARCH-009-senior-actor-type-guard.md)
- ADR: docs/adr/ADR-0002-auth-jwt-family-access.md

## 관련 이슈

Closes #397

## 변경 사항

- 변경 모듈: widyu-api
- `SeniorAuthService.validateIsGuardian(Member)` private 메서드 추가 — MemberType이 GUARDIAN이 아니면 `BusinessException(ErrorCode.FORBIDDEN)` throw
- `seniorSignUpBulk()` 첫 번째 검증으로 `validateIsGuardian(guardian)` 호출 삽입 (empty-request 검증보다 앞에 배치)
- `SeniorAuthDocs.seniorSignUpBulk()`에 `@ApiResponse(responseCode = "403")` 추가
- `SeniorAuthServiceTest`에 T1 테스트 추가: SENIOR 타입 회원 호출 시 `FORBIDDEN` 예외 발생 검증

## 테스트

- `./gradlew :backend:widyu-api:test`: 통과 (11/11, 신규 1개 포함)
- `./gradlew build`: BUILD SUCCESSFUL

## 체크리스트

- [x] 엔티티 변경 없음 (compileJava 불필요)
- [x] MySQL ENUM 변경 없음
- [x] `@Async` 메서드 없음
- [x] 인수조건 충족 — SENIOR 회원 FORBIDDEN 거부, GUARDIAN 정상 흐름 유지

## Open Questions

admin 직접 호출 허용 여부는 별도 정책 확인 후 후속 PR에서 처리합니다.

## 비고

- 검증 순서: guardian type 검증 → empty-request 검증 → membership 중복 검증 순으로 배치했습니다. SENIOR 회원의 빈 요청이 `SENIOR_SIGNUP_REQUEST_EMPTY`(400)로 반환되면 오류 의미가 모호해지므로 행위자 권한을 가장 먼저 차단합니다.
- 롤백: `validateIsGuardian` 호출 한 줄 제거로 이전 동작 복원 가능합니다.
- 후속 PR 후보: ARCH-004·ARCH-011 (가족 접근 정책 단일화)