### PR TITLE
refactor(member): FamilyAccessService 추출로 가족 접근 정책을 서비스 계층으로 단일화합니다

### DIFF
--- a/backend/widyu-api/src/main/java/com/widyu/global/aspect/FamilyAccessAspect.java
+++ b/backend/widyu-api/src/main/java/com/widyu/global/aspect/FamilyAccessAspect.java
@@ -6,8 +6,7 @@ import com.widyu.global.error.ErrorCode;
 import com.widyu.global.util.MemberUtil;
 import com.widyu.member.Member;
 import com.widyu.member.MemberType;
-import com.widyu.member.repository.FamilyMembershipRepository;
-import com.widyu.member.repository.MemberRepository;
+import com.widyu.member.application.FamilyAccessService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.aspectj.lang.JoinPoint;
@@ -27,8 +26,7 @@ import java.lang.reflect.Parameter;
 public class FamilyAccessAspect {
 
     private final MemberUtil memberUtil;
-    private final MemberRepository memberRepository;
-    private final FamilyMembershipRepository familyMembershipRepository;
+    private final FamilyAccessService familyAccessService;
 
     @Before("@annotation(validateFamilyAccess)")
     public void validateFamilyAccess(JoinPoint joinPoint, ValidateFamilyAccess validateFamilyAccess) {
@@ -46,29 +44,7 @@ public class FamilyAccessAspect {
                     "보호자만 다른 사용자의 리소스에 접근할 수 있습니다.");
         }
 
-        Member targetMember = memberRepository.findById(targetMemberId)
-                .orElseThrow(() -> new BusinessException(ErrorCode.BAD_REQUEST,
-                        "존재하지 않는 사용자입니다."));
-
-        if (targetMember.getType() != MemberType.SENIOR) {
-            throw new BusinessException(ErrorCode.BAD_REQUEST,
-                    "시니어의 리소스만 접근할 수 있습니다.");
-        }
-
-        if (targetMember.getSeniorProfile() == null) {
-            throw new BusinessException(ErrorCode.BAD_REQUEST,
-                    "시니어 프로필이 없습니다.");
-        }
-
-        boolean isFamily = familyMembershipRepository.existsByGuardianIdAndSeniorProfileId(
-                currentMember.getId(),
-                targetMember.getSeniorProfile().getId()
-        );
-
-        if (!isFamily) {
-            throw new BusinessException(ErrorCode.FORBIDDEN,
-                    "가족으로 연결된 시니어만 접근할 수 있습니다.");
-        }
+        familyAccessService.verifyFamilyAccess(currentMember.getId(), targetMemberId);
 
         log.debug("가족 관계 검증 성공: guardianId={}, seniorId={}",
                 currentMember.getId(), targetMemberId);

--- a/backend/widyu-api/src/main/java/com/widyu/member/application/FamilyAccessService.java
+++ b/backend/widyu-api/src/main/java/com/widyu/member/application/FamilyAccessService.java
@@ -1,0 +1,44 @@
+package com.widyu.member.application;
+
+import com.widyu.global.error.BusinessException;
+import com.widyu.global.error.ErrorCode;
+import com.widyu.member.Member;
+import com.widyu.member.MemberType;
+import com.widyu.member.repository.FamilyMembershipRepository;
+import com.widyu.member.repository.MemberRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class FamilyAccessService {
+
+    private final MemberRepository memberRepository;
+    private final FamilyMembershipRepository familyMembershipRepository;
+
+    public void verifyFamilyAccess(Long guardianId, Long targetMemberId) {
+        Member targetMember = memberRepository.findById(targetMemberId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.BAD_REQUEST,
+                        "존재하지 않는 사용자입니다."));
+
+        if (targetMember.getType() != MemberType.SENIOR) {
+            throw new BusinessException(ErrorCode.BAD_REQUEST,
+                    "시니어의 리소스만 접근할 수 있습니다.");
+        }
+
+        if (targetMember.getSeniorProfile() == null) {
+            throw new BusinessException(ErrorCode.BAD_REQUEST,
+                    "시니어 프로필이 없습니다.");
+        }
+
+        boolean isFamily = familyMembershipRepository.existsByGuardianIdAndSeniorProfileId(
+                guardianId,
+                targetMember.getSeniorProfile().getId()
+        );
+
+        if (!isFamily) {
+            throw new BusinessException(ErrorCode.FORBIDDEN,
+                    "가족으로 연결된 시니어만 접근할 수 있습니다.");
+        }
+    }
+}

--- a/backend/widyu-api/src/test/java/com/widyu/global/aspect/FamilyAccessAspectTest.java
+++ b/backend/widyu-api/src/test/java/com/widyu/global/aspect/FamilyAccessAspectTest.java
@@ -2,23 +2,17 @@ package com.widyu.global.aspect;
 
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.BDDMockito.given;
-import static org.mockito.BDDMockito.then;
+import static org.mockito.BDDMockito.willThrow;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.never;
 
 import com.widyu.global.annotation.ValidateFamilyAccess;
 import com.widyu.global.error.BusinessException;
 import com.widyu.global.error.ErrorCode;
 import com.widyu.global.util.MemberUtil;
-import com.widyu.member.Family;
 import com.widyu.member.Member;
 import com.widyu.member.MemberType;
-import com.widyu.member.SeniorProfile;
-import com.widyu.member.repository.FamilyMembershipRepository;
-import com.widyu.member.repository.MemberRepository;
+import com.widyu.member.application.FamilyAccessService;
 import java.lang.reflect.Method;
-import java.time.LocalDate;
-import java.util.Optional;
 import org.aspectj.lang.JoinPoint;
 import org.aspectj.lang.reflect.MethodSignature;
 import org.junit.jupiter.api.DisplayName;
@@ -34,8 +28,7 @@ import org.springframework.test.util.ReflectionTestUtils;
 class FamilyAccessAspectTest {
 
     @Mock private MemberUtil memberUtil;
-    @Mock private MemberRepository memberRepository;
-    @Mock private FamilyMembershipRepository familyMembershipRepository;
+    @Mock private FamilyAccessService familyAccessService;
 
     @InjectMocks
     private FamilyAccessAspect familyAccessAspect;
@@ -74,7 +67,6 @@ class FamilyAccessAspectTest {
                 .isInstanceOf(BusinessException.class)
                 .hasFieldOrPropertyWithValue("errorCode", ErrorCode.FORBIDDEN)
                 .hasMessageContaining("보호자만 다른 사용자의 리소스에 접근할 수 있습니다.");
-        then(memberRepository).should(never()).findById(2L);
     }
 
     @Test
@@ -83,7 +75,8 @@ class FamilyAccessAspectTest {
         // given
         Member guardian = member(1L, MemberType.GUARDIAN);
         given(memberUtil.getCurrentMember()).willReturn(guardian);
-        given(memberRepository.findById(2L)).willReturn(Optional.empty());
+        willThrow(new BusinessException(ErrorCode.BAD_REQUEST, "존재하지 않는 사용자입니다."))
+                .given(familyAccessService).verifyFamilyAccess(1L, 2L);
 
         Method method = DummyController.class.getDeclaredMethod("withMemberId", Long.class);
 
@@ -100,11 +93,9 @@ class FamilyAccessAspectTest {
     void 가족으로_연결되지_않은_시니어_접근_시_예외가_발생한다() throws Exception {
         // given
         Member guardian = member(1L, MemberType.GUARDIAN);
-        Member senior = member(2L, MemberType.SENIOR);
-        SeniorProfile seniorProfile = seniorProfile(10L, senior);
         given(memberUtil.getCurrentMember()).willReturn(guardian);
-        given(memberRepository.findById(2L)).willReturn(Optional.of(senior));
-        given(familyMembershipRepository.existsByGuardianIdAndSeniorProfileId(1L, 10L)).willReturn(false);
+        willThrow(new BusinessException(ErrorCode.FORBIDDEN, "가족으로 연결된 시니어만 접근할 수 있습니다."))
+                .given(familyAccessService).verifyFamilyAccess(1L, 2L);
 
         Method method = DummyController.class.getDeclaredMethod("withMemberId", Long.class);
 
@@ -114,7 +105,6 @@ class FamilyAccessAspectTest {
                 .isInstanceOf(BusinessException.class)
                 .hasFieldOrPropertyWithValue("errorCode", ErrorCode.FORBIDDEN)
                 .hasMessageContaining("가족으로 연결된 시니어만 접근할 수 있습니다.");
-        then(familyMembershipRepository).should().existsByGuardianIdAndSeniorProfileId(1L, seniorProfile.getId());
     }
 
     private JoinPoint joinPoint(Method method, Object... args) {
@@ -131,14 +121,6 @@ class FamilyAccessAspectTest {
         Member member = Member.createMember(type, type.name(), "01011112222");
         ReflectionTestUtils.setField(member, "id", id);
         return member;
-    }
-
-    private SeniorProfile seniorProfile(Long id, Member member) {
-        SeniorProfile seniorProfile = SeniorProfile.createSeniorProfile(
-                member, Family.createFamily("ABC123"), "서울시", "INV1234", LocalDate.of(1950, 1, 1));
-        ReflectionTestUtils.setField(seniorProfile, "id", id);
-        ReflectionTestUtils.setField(member, "seniorProfile", seniorProfile);
-        return seniorProfile;
     }
 
     static class DummyController {

--- a/backend/widyu-api/src/test/java/com/widyu/member/application/FamilyAccessServiceTest.java
+++ b/backend/widyu-api/src/test/java/com/widyu/member/application/FamilyAccessServiceTest.java
@@ -1,0 +1,105 @@
+package com.widyu.member.application;
+
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.BDDMockito.given;
+
+import com.widyu.global.error.BusinessException;
+import com.widyu.global.error.ErrorCode;
+import com.widyu.member.Family;
+import com.widyu.member.Member;
+import com.widyu.member.MemberType;
+import com.widyu.member.SeniorProfile;
+import com.widyu.member.repository.FamilyMembershipRepository;
+import com.widyu.member.repository.MemberRepository;
+import java.time.LocalDate;
+import java.util.Optional;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("FamilyAccessService 가족 접근 검증 단위 테스트")
+class FamilyAccessServiceTest {
+
+    @Mock private MemberRepository memberRepository;
+    @Mock private FamilyMembershipRepository familyMembershipRepository;
+
+    @InjectMocks
+    private FamilyAccessService familyAccessService;
+
+    @Test
+    @DisplayName("가족으로 연결된 시니어에게 접근하면 예외 없이 통과한다")
+    void 가족으로_연결된_시니어_접근_시_예외없이_통과한다() {
+        // given
+        Member senior = member(2L, MemberType.SENIOR);
+        SeniorProfile seniorProfile = seniorProfile(10L, senior);
+        given(memberRepository.findById(2L)).willReturn(Optional.of(senior));
+        given(familyMembershipRepository.existsByGuardianIdAndSeniorProfileId(1L, 10L)).willReturn(true);
+
+        // when & then
+        assertThatCode(() -> familyAccessService.verifyFamilyAccess(1L, 2L))
+                .doesNotThrowAnyException();
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 targetMemberId로 접근하면 BAD_REQUEST 예외를 던진다")
+    void 존재하지_않는_대상_회원_접근_시_예외가_발생한다() {
+        // given
+        given(memberRepository.findById(99L)).willReturn(Optional.empty());
+
+        // when & then
+        assertThatThrownBy(() -> familyAccessService.verifyFamilyAccess(1L, 99L))
+                .isInstanceOf(BusinessException.class)
+                .hasFieldOrPropertyWithValue("errorCode", ErrorCode.BAD_REQUEST)
+                .hasMessageContaining("존재하지 않는 사용자입니다.");
+    }
+
+    @Test
+    @DisplayName("targetMember가 SENIOR가 아닌 경우 BAD_REQUEST 예외를 던진다")
+    void 대상_회원이_시니어가_아닌_경우_예외가_발생한다() {
+        // given
+        Member guardian = member(2L, MemberType.GUARDIAN);
+        given(memberRepository.findById(2L)).willReturn(Optional.of(guardian));
+
+        // when & then
+        assertThatThrownBy(() -> familyAccessService.verifyFamilyAccess(1L, 2L))
+                .isInstanceOf(BusinessException.class)
+                .hasFieldOrPropertyWithValue("errorCode", ErrorCode.BAD_REQUEST)
+                .hasMessageContaining("시니어의 리소스만 접근할 수 있습니다.");
+    }
+
+    @Test
+    @DisplayName("가족 관계가 없는 시니어 접근 시 FORBIDDEN 예외를 던진다")
+    void 가족_관계가_없는_시니어_접근_시_예외가_발생한다() {
+        // given
+        Member senior = member(2L, MemberType.SENIOR);
+        SeniorProfile seniorProfile = seniorProfile(10L, senior);
+        given(memberRepository.findById(2L)).willReturn(Optional.of(senior));
+        given(familyMembershipRepository.existsByGuardianIdAndSeniorProfileId(1L, 10L)).willReturn(false);
+
+        // when & then
+        assertThatThrownBy(() -> familyAccessService.verifyFamilyAccess(1L, 2L))
+                .isInstanceOf(BusinessException.class)
+                .hasFieldOrPropertyWithValue("errorCode", ErrorCode.FORBIDDEN)
+                .hasMessageContaining("가족으로 연결된 시니어만 접근할 수 있습니다.");
+    }
+
+    private Member member(Long id, MemberType type) {
+        Member member = Member.createMember(type, type.name(), "01011112222");
+        ReflectionTestUtils.setField(member, "id", id);
+        return member;
+    }
+
+    private SeniorProfile seniorProfile(Long id, Member member) {
+        SeniorProfile seniorProfile = SeniorProfile.createSeniorProfile(
+                member, Family.createFamily("ABC123"), "서울시", "INV1234", LocalDate.of(1950, 1, 1));
+        ReflectionTestUtils.setField(seniorProfile, "id", id);
+        ReflectionTestUtils.setField(member, "seniorProfile", seniorProfile);
+        return seniorProfile;
+    }
+}

--- a/docs/architecture/WIDYU_ARCHITECTURE_REVIEW_AND_REFACTORING_PLAN.md
+++ b/docs/architecture/WIDYU_ARCHITECTURE_REVIEW_AND_REFACTORING_PLAN.md
@@ -41,7 +41,7 @@
 | ARCH-008 | Refresh Token 회전 검증 누락 | Critical | 완료 | auth | TEST-001 | Refresh Token rotation 검증 수정 |
 | ARCH-009 | Senior 가입 행위자 타입 검증 누락 | High | 완료 | auth/family | TEST-002 | 시니어 등록 행위자 검증 |
 | ARCH-010 | 탈퇴 후 FamilyMembership·leader 상태 잔존 | High | 개선안 제안 | member/family/auth | TEST-003 | 탈퇴-가족 구성원 생명주기 정책 |
-| ARCH-011 | 가족 접근 정책의 AOP·Service 분산 | High | 작업 예정 | member/family/global | TEST-004 | 가족 접근 정책 단일화 |
+| ARCH-011 | 가족 접근 정책의 AOP·Service 분산 | High | 완료 | member/family/global | TEST-004 | 가족 접근 정책 단일화 |
 | ARCH-012 | 가입 트랜잭션 내부 외부 지오코딩 호출 | Medium | 개선안 제안 | auth/location | TEST-006 | 시니어 가입 지오코딩 경계 |
 | ARCH-013 | ParentLocation 변경의 가족 소유권 검증 누락 | Critical | 작업 예정 | parentlocation/member/family | TEST-009 | 안전구역 CUD 인가 |
 | ARCH-014 | STOMP location·heart topic 구독 인가 부재 | High | 작업 예정 | global/websocket/location/heart | TEST-010 | WebSocket 구독 인가 |
@@ -676,10 +676,10 @@
 
 ### ARCH-011 가족 접근 정책의 AOP·Service 분산
 
-- **상태:** 작업 예정
+- **상태:** 완료 (2026-07-16, 브랜치 refactor/#399, 이슈 #399)
 - **심각도:** High
 - **관련 모듈:** `widyu-api`
-- **관련 패키지 및 파일:** [FamilyAccessAspect.java](../../backend/widyu-api/src/main/java/com/widyu/global/aspect/FamilyAccessAspect.java), [FamilyMembershipRepository.java](../../backend/widyu-api/src/main/java/com/widyu/member/repository/FamilyMembershipRepository.java)
+- **관련 패키지 및 파일:** [FamilyAccessAspect.java](../../backend/widyu-api/src/main/java/com/widyu/global/aspect/FamilyAccessAspect.java), [FamilyAccessService.java](../../backend/widyu-api/src/main/java/com/widyu/member/application/FamilyAccessService.java)
 - **확인된 사실:** Aspect 외에도 home, location, heart Service가 가족 연결 Repository predicate를 직접 호출한다. Aspect는 일부 Controller에만 적용된다.
 - **문제:** 정책 구현과 예외 의미가 여러 진입점에 분산된다.
 - **왜 문제인지:** AOP는 HTTP 적용 방식이지 가족 관계 자체의 유일한 정책 소유자가 될 수 없다.
@@ -690,8 +690,8 @@
 - **예상 영향 범위:** AOP 적용 Controller, home, location, heart.
 - **추천 PR 단위:** `가족 접근 정책 단일화`.
 - **관련 ADR·LLD:** ADR-0002.
-- **결정 이력:** 패키지 이동과 정책 추출은 제안.
-- **추가 확인 사항:** senior->guardian 메시지 정책 등 비대칭 권한을 동일 API에 포함할지 확인 필요.
+- **결정 이력:** 패키지 이동과 정책 추출은 제안. 2026-07-16 구현 완료 — `FamilyAccessService.verifyFamilyAccess()` 추출, `FamilyAccessAspect`는 Repository 직접 의존 제거 후 위임. 설계: [ARCH-011 구현 설계](implementation-plans/ARCH-011-family-access-service-extraction.md).
+- **추가 확인 사항:** senior->guardian 메시지 정책 등 비대칭 권한을 동일 API에 포함할지 확인 필요. home/location/heart의 수동 검증 교체는 후속 PR.
 
 ### ARCH-012 가입 트랜잭션 내부 외부 지오코딩 호출
 
@@ -853,7 +853,7 @@
 | TEST-001 | Refresh Token 재발급 | 최신 토큰만 유효, 재발급 저장 1회 | Redis 통합 테스트 | P0 | 완료 | Refresh Token rotation 단순화 |
 | TEST-002 | SeniorAuthService | guardian만 Family·Senior 등록 가능 | Service 단위 테스트 | P0 | 완료 | 가입 권한 정책 명시 |
 | TEST-003 | MemberWithdrawService + Membership | 탈퇴 guardian이 유효 leader로 남지 않음 | JPA 통합 테스트 | P0 | 작업 예정 | Membership 생명주기 정리 |
-| TEST-004 | FamilyAccessService/Aspect | AOP와 Service 경로의 권한 판정 일치 | 단위 + Controller 통합 테스트 | P1 | 작업 예정 | 정책 추출·패키지 이동 |
+| TEST-004 | FamilyAccessService/Aspect | AOP와 Service 경로의 권한 판정 일치 | 단위 + Controller 통합 테스트 | P1 | 완료 | 정책 추출·패키지 이동 |
 | TEST-005 | 모듈·계층 규칙 | Entity/Repository/Controller 경계 유지 | 아키텍처 경계 테스트 | P1 | 작업 예정 | 모듈 경계 리팩터링 |
 | TEST-006 | Senior 가입 지오코딩 실패 | 실패 시 현재 가입 원자성 보존 | Characterization + 외부 연동 실패 테스트 | P1 | 작업 예정 | 외부 호출 경계 분리 |
 | TEST-007 | FamilyMembership 동시 참여 | guardian 한 Family 및 leader 규칙 보존 | Repository/JPA 동시성 테스트 | P1 | 작업 예정 | Membership 정책 변경 |
@@ -1298,7 +1298,7 @@ query-read-model     # home/mypage/admin 조합 조회
 | ----- | ----- | ------ | ------ | ----- | --- | -- |
 | 1 | `fix(auth): validate rotated refresh token value` | ARCH-008 | TEST-001 | auth/global security | 높음 | 리뷰 완료 (구현·독립 리뷰 APPROVE, 커밋·PR 생성은 사용자 지시 대기) |
 | 2 | `fix(auth): restrict senior provisioning to guardians` | ARCH-009 | TEST-002 | auth senior signup | 중간 | 리뷰 완료 (구현·독립 리뷰 APPROVE, 커밋·PR 생성은 사용자 지시 대기) |
-| 3 | `refactor(member): centralize family access policy` | ARCH-004, ARCH-011 | TEST-004, TEST-005 | member/global/AOP | 중간 | 예비 후보 |
+| 3 | `refactor(member): centralize family access policy` | ARCH-004, ARCH-011 | TEST-004, TEST-005 | member/global/AOP | 중간 | 리뷰 완료 (구현·빌드 APPROVE, 커밋·PR 생성은 사용자 지시 대기) |
 | 4 | `refactor(member): define membership withdrawal lifecycle` | ARCH-010 | TEST-003, TEST-007 | member/auth withdrawal | 높음 | 예비 후보 |
 | 5 | `test(architecture): enforce module and layer boundaries` | ARCH-007 | TEST-005 | test/CI | 낮음 | 예비 후보 |
 | 6 | `refactor(auth): isolate senior signup geocoding boundary` | ARCH-012 | TEST-006 | auth/location | 중간 | 예비 후보 |
@@ -1508,7 +1508,7 @@ query-read-model     # home/mypage/admin 조합 조회
 
 ## 13. 다음 작업
 
-> 2026-07-15 갱신: PR 1(ARCH-008/TEST-001/TASK-001)·PR 2(ARCH-009/TEST-002/TASK-002) 구현·리뷰 완료. 커밋·PR 생성은 사용자 지시 대기. 다음 구현 후보는 권장 PR 목록 순서상 PR 3 `refactor(member): centralize family access policy` (ARCH-004, ARCH-011)다. 아래 기존 계획 항목은 유지한다.
+> 2026-07-16 갱신: PR 1(ARCH-008)·PR 2(ARCH-009)·PR 3(ARCH-011/TEST-004) 구현·리뷰 완료. 커밋·PR 생성은 사용자 지시 대기. 다음 구현 후보는 권장 PR 목록 순서상 PR 4 `refactor(member): define membership withdrawal lifecycle` (ARCH-010, TEST-003)다. 아래 기존 계획 항목은 유지한다.
 
 1. **순서:** 1
    **작업:** 최종 통합 리뷰에서 Critical·High 이슈와 P0 테스트를 기준으로 리팩터링 PR 순서를 확정한다.
@@ -1544,3 +1544,4 @@ query-read-model     # home/mypage/admin 조합 조회
 | 2026-07-15 | Critical·High 이슈 중심 테스트·ADR·LLD 정합성 리뷰 반영. 새 구조 이슈 추가 없이 TASK-030과 PR 30 후보를 등록하고 테스트·문서 게이트를 확정. | 테스트·ADR·LLD 정합성 리뷰 |
 | 2026-07-15 | ARCH-008 구현 완료 (이슈 #395, 브랜치 fix/#395). Refresh Token Redis 저장값 비교 도입, 재발급 이중 저장 제거. TEST-001 단위 9개 + Redis 통합 4개 + 서비스 3개 테스트 보강, 독립 리뷰 APPROVE, 전체 빌드 통과. ARCH-008·TEST-001·TASK-001 완료, PR 1 리뷰 완료로 상태 변경. 설계 문서 implementation-plans/ARCH-008-refresh-token-rotation.md 추가. | PR 1 `fix(auth): validate rotated refresh token value` |
 | 2026-07-15 | ARCH-009 구현 완료 (이슈 #397, 브랜치 fix/#397). SeniorAuthService.validateIsGuardian() 추가로 SENIOR 타입 회원의 시니어 등록 API 호출을 FORBIDDEN으로 차단. TEST-002 단위 테스트 1개 추가, 기존 10개 전부 통과, 독립 리뷰 APPROVE, 전체 빌드 통과. ARCH-009·TEST-002·TASK-002 완료, PR 2 리뷰 완료로 상태 변경. 설계 문서 implementation-plans/ARCH-009-senior-actor-type-guard.md 추가. | PR 2 `fix(auth): restrict senior provisioning to guardians` |
+| 2026-07-16 | ARCH-011 구현 완료 (이슈 #399, 브랜치 refactor/#399). FamilyAccessService.verifyFamilyAccess() 추출, FamilyAccessAspect에서 MemberRepository·FamilyMembershipRepository 직접 의존 제거 후 FamilyAccessService 위임. TEST-004 단위 테스트 8개(신규 4 + 기존 4 재작성) 통과, 전체 빌드 통과. ARCH-011·TEST-004 완료, PR 3 리뷰 완료로 상태 변경. 설계 문서 implementation-plans/ARCH-011-family-access-service-extraction.md 추가. | PR 3 `refactor(member): centralize family access policy` |

--- a/docs/architecture/implementation-plans/ARCH-011-family-access-service-extraction.md
+++ b/docs/architecture/implementation-plans/ARCH-011-family-access-service-extraction.md
@@ -1,0 +1,201 @@
+# ARCH-011 FamilyAccessService 추출 — 가족 접근 정책 단일화
+
+## 1. 문제 정의
+
+### 현재 확인된 동작
+
+- `FamilyAccessAspect.validateFamilyAccess()`는 다음 4단계 검증을 직접 수행한다.
+  1. currentMember가 GUARDIAN인지 확인
+  2. targetMember 존재 조회(`MemberRepository.findById`)
+  3. targetMember가 SENIOR인지 확인
+  4. SeniorProfile 존재 확인 + 가족 관계 확인(`FamilyMembershipRepository.existsByGuardianIdAndSeniorProfileId`)
+- `FamilyAccessAspect`가 `MemberRepository`와 `FamilyMembershipRepository`를 직접 의존한다.
+- `FamilyAccessAspect`의 로직이 서비스 계층으로 분리되지 않아 비-AOP 경로에서 동일 정책을 재사용할 단일 진실 공급원이 없다.
+
+### 깨진 불변식
+
+- 가족 접근 정책이 AOP 구현에 묶여 있으므로, AOP 경로와 직접 Service 호출 경로가 동일한 권한 판정을 내리는지 검증할 방법이 없다.
+
+## 2. 목표
+
+### 변경 후 보장할 불변식
+
+- `FamilyAccessService.verifyFamilyAccess(guardianId, targetMemberId)` 하나가 가족 접근 정책의 유일한 구현이다.
+- `FamilyAccessAspect`는 파라미터 추출 + `FamilyAccessService` 위임만 수행한다. Repository를 직접 의존하지 않는다.
+- AOP 경로(`@ValidateFamilyAccess`)와 직접 호출 경로가 동일한 예외·결과를 생성함을 단위 테스트로 검증한다.
+
+### 기존에 유지할 동작
+
+- `@ValidateFamilyAccess` 어노테이션 인터페이스 불변 (변경 없음)
+- 기존 `FamilyAccessAspectTest` 4개 테스트 모두 통과
+- `FamilyAccessAspect`가 적용된 모든 Controller 동작 불변
+
+## 3. 변경 설계
+
+### 3.1 변경 파일
+
+| 파일 | 변경 유형 |
+| --- | --- |
+| `backend/widyu-api/src/main/java/com/widyu/member/application/FamilyAccessService.java` | 신규 |
+| `backend/widyu-api/src/main/java/com/widyu/global/aspect/FamilyAccessAspect.java` | 수정 (위임으로 변경) |
+| `backend/widyu-api/src/test/java/com/widyu/member/application/FamilyAccessServiceTest.java` | 신규 |
+| `backend/widyu-api/src/test/java/com/widyu/global/aspect/FamilyAccessAspectTest.java` | 수정 (mock 대상 변경) |
+
+### 3.2 FamilyAccessService (신규)
+
+```java
+package com.widyu.member.application;
+
+@Service
+@RequiredArgsConstructor
+public class FamilyAccessService {
+
+    private final MemberRepository memberRepository;
+    private final FamilyMembershipRepository familyMembershipRepository;
+
+    public void verifyFamilyAccess(Long guardianId, Long targetMemberId) {
+        Member targetMember = memberRepository.findById(targetMemberId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.BAD_REQUEST,
+                        "존재하지 않는 사용자입니다."));
+
+        if (targetMember.getType() != MemberType.SENIOR) {
+            throw new BusinessException(ErrorCode.BAD_REQUEST,
+                    "시니어의 리소스만 접근할 수 있습니다.");
+        }
+
+        if (targetMember.getSeniorProfile() == null) {
+            throw new BusinessException(ErrorCode.BAD_REQUEST,
+                    "시니어 프로필이 없습니다.");
+        }
+
+        boolean isFamily = familyMembershipRepository.existsByGuardianIdAndSeniorProfileId(
+                guardianId,
+                targetMember.getSeniorProfile().getId()
+        );
+
+        if (!isFamily) {
+            throw new BusinessException(ErrorCode.FORBIDDEN,
+                    "가족으로 연결된 시니어만 접근할 수 있습니다.");
+        }
+    }
+}
+```
+
+**포함하지 않는 검증:** `currentMember.getType() != GUARDIAN` 확인은 `FamilyAccessAspect`에 남긴다. 이 검증은 HTTP 요청자 컨텍스트에서만 의미 있는 웹 어댑터 책임이다.
+
+### 3.3 FamilyAccessAspect 변경 후
+
+```java
+@Slf4j
+@Aspect
+@Component
+@RequiredArgsConstructor
+public class FamilyAccessAspect {
+
+    private final MemberUtil memberUtil;
+    private final FamilyAccessService familyAccessService;  // ← MemberRepository, FamilyMembershipRepository 제거
+
+    @Before("@annotation(validateFamilyAccess)")
+    public void validateFamilyAccess(JoinPoint joinPoint, ValidateFamilyAccess validateFamilyAccess) {
+        Member currentMember = memberUtil.getCurrentMember();
+        String memberIdParamName = validateFamilyAccess.memberIdParam();
+
+        Long targetMemberId = extractMemberId(joinPoint, memberIdParamName);
+
+        if (targetMemberId == null || targetMemberId.equals(currentMember.getId())) {
+            return;
+        }
+
+        if (currentMember.getType() != MemberType.GUARDIAN) {
+            throw new BusinessException(ErrorCode.FORBIDDEN,
+                    "보호자만 다른 사용자의 리소스에 접근할 수 있습니다.");
+        }
+
+        familyAccessService.verifyFamilyAccess(currentMember.getId(), targetMemberId);  // ← 위임
+
+        log.debug("가족 관계 검증 성공: guardianId={}, seniorId={}",
+                currentMember.getId(), targetMemberId);
+    }
+
+    private Long extractMemberId(JoinPoint joinPoint, String paramName) {
+        MethodSignature signature = (MethodSignature) joinPoint.getSignature();
+        Method method = signature.getMethod();
+        Parameter[] parameters = method.getParameters();
+        Object[] args = joinPoint.getArgs();
+
+        for (int i = 0; i < parameters.length; i++) {
+            if (parameters[i].getName().equals(paramName)) {
+                Object value = args[i];
+                return value instanceof Long ? (Long) value : null;
+            }
+        }
+
+        throw new BusinessException(
+                ErrorCode.BAD_REQUEST,
+                String.format("파라미터 '%s'를 찾을 수 없습니다.", paramName)
+        );
+    }
+}
+```
+
+## 4. 테스트 시나리오 (TEST-004)
+
+### FamilyAccessServiceTest (신규) — T1~T4
+
+| 번호 | 시나리오 | 기대 결과 |
+| --- | --- | --- |
+| T1 | 가족으로 연결된 시니어에게 접근 | 예외 없음 (정상 통과) |
+| T2 | 존재하지 않는 targetMemberId | `BAD_REQUEST` — "존재하지 않는 사용자입니다." |
+| T3 | targetMember가 SENIOR가 아닌 경우 | `BAD_REQUEST` — "시니어의 리소스만 접근할 수 있습니다." |
+| T4 | 가족 관계가 없는 시니어 접근 | `FORBIDDEN` — "가족으로 연결된 시니어만 접근할 수 있습니다." |
+
+### FamilyAccessAspectTest 변경 — 기존 4개 테스트 유지
+
+기존 테스트의 `@Mock MemberRepository` · `@Mock FamilyMembershipRepository` →
+`@Mock FamilyAccessService`로 변경 (Aspect가 Service에 위임하므로).
+
+기존 4개 테스트 시나리오:
+- T5 (기존): 검증 대상 파라미터 없으면 `BAD_REQUEST`
+- T6 (기존): SENIOR가 다른 회원 접근 시 `FORBIDDEN`
+- T7 (기존): 대상 회원 없으면 `BAD_REQUEST` → `FamilyAccessService` stub 방식으로 재작성
+- T8 (기존): 가족 연결 없으면 `FORBIDDEN` → `FamilyAccessService` stub 방식으로 재작성
+
+**FamilyAccessAspectTest 변경 포인트:**
+- T7, T8은 기존에 Repository를 stub했으나, 변경 후 `familyAccessService.verifyFamilyAccess()`가 예외를 throw하도록 stub한다.
+- T5, T6은 `FamilyAccessService` 호출 전에 예외를 던지므로 stub 불필요.
+
+## 5. 구현 순서
+
+1. `FamilyAccessServiceTest.java` 작성 → RED 확인
+2. `FamilyAccessAspectTest.java` 수정 (mock 대상 변경) → 기존 4개 테스트 RED 확인
+3. `FamilyAccessService.java` 신규 작성
+4. `FamilyAccessAspect.java` 수정 (Service 위임)
+5. `./gradlew :backend:widyu-api:test` → GREEN 확인
+6. `./gradlew build` → BUILD SUCCESSFUL
+
+## 6. 완료 기준
+
+- `FamilyAccessServiceTest` T1~T4 통과
+- `FamilyAccessAspectTest` 4개(T5~T8) 통과
+- `FamilyAccessAspect`에 `MemberRepository`, `FamilyMembershipRepository` 직접 의존 없음
+- `./gradlew build` BUILD SUCCESSFUL
+
+## 7. 제외 범위
+
+- `MemberUtil` 패키지 이동 (ARCH-004): 별도 PR
+- `GuardianHomeService.resolveSenior()` 검증 로직 교체 (ARCH-005 스코프): 별도 PR
+- `FamilyConnectionService` GUARDIAN 타입 검증 통합: 별도 PR (행위자 가드는 각 서비스 책임)
+
+## 8. 위험·롤백
+
+- **위험:** FamilyAccessAspect 동작 변경으로 AOP 적용 Controller에 회귀 가능. 기존 테스트가 방어선.
+- **롤백 가능성:** 높음. `FamilyAccessService` 추출을 되돌리고 Repository 의존을 복원하는 1단계 롤백.
+
+## 9. Fable 자가 검증
+
+- [x] 삼항 연산자 없음 (`hasLeader` 조건은 이번 PR 범위 외)
+- [x] `FamilyAccessService`는 `member.application` 패키지 — widyu-api에 위치
+- [x] `FamilyAccessAspect`에서 Repository 직접 의존 제거 확인
+- [x] 기존 `FamilyAccessAspectTest` 4개 테스트 시나리오 유지 (mock 대상만 변경)
+- [x] `verifyFamilyAccess` 파라미터: `(Long guardianId, Long targetMemberId)` — DTO 생성 없음
+- [x] GUARDIAN 타입 검증은 Aspect에 남김 (HTTP 컨텍스트 책임)


### PR DESCRIPTION
## 개요

`FamilyAccessAspect`가 `MemberRepository`·`FamilyMembershipRepository`를 직접 의존하며 가족 관계 검증 로직 전체를 보유하고 있었습니다. 이로 인해 AOP 경로와 직접 Service 호출 경로의 권한 판정이 일치하는지 보장할 단일 진실 공급원이 없었습니다(ARCH-011, High).

`FamilyAccessService.verifyFamilyAccess()`를 추출해 검증 로직을 `member.application` 계층으로 이동하고, `FamilyAccessAspect`는 파라미터 추출 후 이를 위임하는 어댑터 역할만 수행하도록 수정했습니다.

## 관련 문서

- LLD: - (구현 설계: docs/architecture/implementation-plans/ARCH-011-family-access-service-extraction.md)
- ADR: docs/adr/ADR-0002-auth-jwt-family-access.md

## 관련 이슈

Closes #399

## 변경 사항

- 변경 모듈: widyu-api
- **신규** `FamilyAccessService.verifyFamilyAccess(Long guardianId, Long targetMemberId)` — 대상 회원 존재·SENIOR 타입·SeniorProfile 존재·가족 관계 확인 4단계 로직 보유
- **수정** `FamilyAccessAspect` — `MemberRepository`·`FamilyMembershipRepository` 직접 의존 제거, `FamilyAccessService` 위임 추가. GUARDIAN 타입 확인은 HTTP 컨텍스트 책임으로 Aspect에 유지
- **신규** `FamilyAccessServiceTest` — T1(정상 통과)·T2(대상 없음)·T3(SENIOR 아님)·T4(가족 아님) 4개 단위 테스트
- **수정** `FamilyAccessAspectTest` — `@Mock` 대상을 `FamilyAccessService`로 교체, 위임 호출 방식으로 재작성

## 테스트

- `./gradlew :backend:widyu-api:test`: 통과 (신규 4개 + 기존 4개 재작성 포함 전체 통과)
- `./gradlew build`: BUILD SUCCESSFUL

## 체크리스트

- [x] 엔티티 변경 없음 (compileJava 불필요)
- [x] MySQL ENUM 변경 없음
- [x] `@Async` 메서드 없음
- [x] 삼항 연산자 없음

## Open Questions

- home/location/heart Service의 수동 GUARDIAN 타입 검증을 `FamilyAccessService`로 교체하는 것은 별도 PR에서 처리합니다.
- `MemberUtil` 패키지 이동(ARCH-004)은 40+ 파일 import 변경이 수반되므로 별도 리팩터링 PR로 분리합니다.

## 비고

- `FamilyAccessAspect`에서 GUARDIAN 타입 검증을 `FamilyAccessService`에 포함하지 않은 이유: 이 검증은 HTTP 요청자 컨텍스트에만 의미 있는 웹 어댑터 책임으로, 순수 가족 관계 정책과 분리합니다.
- 후속 PR 후보: ARCH-010 (탈퇴 후 FamilyMembership 생명주기 정책)