### PR TITLE
feat(family): 방장 탈퇴 위임 정책 및 마지막 방장 탈퇴 시 Family 자동 삭제

### DIFF
--- a/backend/widyu-api/src/main/java/com/widyu/auth/application/guardian/MemberWithdrawService.java
+++ b/backend/widyu-api/src/main/java/com/widyu/auth/application/guardian/MemberWithdrawService.java
@@ -5,13 +5,17 @@ import com.widyu.auth.application.guardian.oauth.strategy.SocialLoginStrategyFac
 import com.widyu.auth.dto.request.MemberWithdrawRequest;
 import com.widyu.auth.OAuthProvider;
 import com.widyu.auth.repository.RefreshTokenRepository;
+import com.widyu.member.FamilyMembership;
 import com.widyu.member.Member;
 import com.widyu.member.SocialAccount;
 import com.widyu.member.repository.FamilyMembershipRepository;
+import com.widyu.member.repository.FamilyRepository;
 import com.widyu.member.repository.MemberRepository;
+import com.widyu.member.repository.SeniorProfileRepository;
 import com.widyu.global.error.BusinessException;
 import com.widyu.global.error.ErrorCode;
 import com.widyu.global.util.MemberUtil;
+import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -25,14 +29,19 @@ public class MemberWithdrawService {
     private final MemberRepository memberRepository;
     private final RefreshTokenRepository refreshTokenRepository;
     private final FamilyMembershipRepository familyMembershipRepository;
+    private final FamilyRepository familyRepository;
+    private final SeniorProfileRepository seniorProfileRepository;
     private final SocialLoginStrategyFactory strategyFactory;
     private final MemberUtil memberUtil;
 
     @Transactional
     public void withdrawMember(MemberWithdrawRequest request) {
         Member member = memberUtil.getCurrentMember();
-        
+
         log.info("회원 탈퇴 시작: memberId={}, reason={}", member.getId(), request.reason());
+
+        // 외부 side-effect 전 방장 위임 여부 사전 검증
+        validateLeaderCanWithdraw(member.getId());
 
         // 1. 리프레시 토큰 삭제
         refreshTokenRepository.deleteById(member.getId());
@@ -40,8 +49,8 @@ public class MemberWithdrawService {
         // 2. 연동된 모든 소셜 계정 탈퇴
         withdrawAllSocialAccounts(member);
 
-        // 3. FamilyMembership 삭제
-        familyMembershipRepository.deleteByGuardianId(member.getId());
+        // 3. FamilyMembership 처리 (leader 정책 적용)
+        handleFamilyMembershipWithdrawal(member.getId());
 
         // 4. 개인정보 마스킹 (GDPR 준수)
         member.maskPersonalInfo();
@@ -51,8 +60,35 @@ public class MemberWithdrawService {
 
         // 6. 회원 데이터 저장
         memberRepository.save(member);
-        
+
         log.info("회원 탈퇴 완료: memberId={}", member.getId());
+    }
+
+    private void validateLeaderCanWithdraw(Long guardianId) {
+        Optional<FamilyMembership> membershipOpt = familyMembershipRepository.findByGuardianId(guardianId);
+        if (membershipOpt.isEmpty() || !membershipOpt.get().isLeader()) {
+            return;
+        }
+        long memberCount = familyMembershipRepository.countByFamilyId(membershipOpt.get().getFamily().getId());
+        if (memberCount > 1) {
+            throw new BusinessException(ErrorCode.FAMILY_LEADER_MUST_DELEGATE_BEFORE_WITHDRAW);
+        }
+    }
+
+    private void handleFamilyMembershipWithdrawal(Long guardianId) {
+        Optional<FamilyMembership> membershipOpt = familyMembershipRepository.findByGuardianId(guardianId);
+        if (membershipOpt.isEmpty()) {
+            return;
+        }
+        FamilyMembership membership = membershipOpt.get();
+        if (membership.isLeader()) {
+            Long familyId = membership.getFamily().getId();
+            seniorProfileRepository.clearFamilyByFamilyId(familyId);
+            familyMembershipRepository.deleteByGuardianId(guardianId);
+            familyRepository.deleteById(familyId);
+            return;
+        }
+        familyMembershipRepository.deleteByGuardianId(guardianId);
     }
 
     private void withdrawAllSocialAccounts(Member member) {

--- a/backend/widyu-api/src/main/java/com/widyu/auth/controller/docs/GuardianAuthDocs.java
+++ b/backend/widyu-api/src/main/java/com/widyu/auth/controller/docs/GuardianAuthDocs.java
@@ -700,6 +700,23 @@ public interface GuardianAuthDocs {
             )
     )
     @ApiResponse(
+            responseCode = "400",
+            description = "방장 권한 위임 없이 탈퇴 시도",
+            content = @Content(
+                    schema = @Schema(implementation = ApiResponseTemplate.class),
+                    examples = @ExampleObject(
+                            name = "방장 위임 필요",
+                            value = """
+                                    {
+                                      "code": "FAMILY_4001",
+                                      "message": "방장 권한을 다른 구성원에게 위임한 후 탈퇴해주세요.",
+                                      "data": null
+                                    }
+                                    """
+                    )
+            )
+    )
+    @ApiResponse(
             responseCode = "401",
             description = "인증 실패(토큰 만료/없음/권한 오류)",
             content = @Content(

--- a/backend/widyu-api/src/main/java/com/widyu/fcm/event/safezone/listener/SafeZoneNotificationListener.java
+++ b/backend/widyu-api/src/main/java/com/widyu/fcm/event/safezone/listener/SafeZoneNotificationListener.java
@@ -38,6 +38,11 @@ public class SafeZoneNotificationListener {
             return;
         }
 
+        if (seniorProfile.getFamily() == null) {
+            log.debug("안전구역 이탈 알림 스킵: 시니어가 가족에 속해 있지 않습니다. memberId={}", seniorMember.getId());
+            return;
+        }
+
         List<FamilyMembership> memberships = familyMembershipRepository
                 .findAllByFamilyIdWithGuardian(seniorProfile.getFamily().getId());
         if (memberships.isEmpty()) {

--- a/backend/widyu-api/src/main/java/com/widyu/member/repository/SeniorProfileRepository.java
+++ b/backend/widyu-api/src/main/java/com/widyu/member/repository/SeniorProfileRepository.java
@@ -9,6 +9,7 @@ import org.springframework.data.jpa.repository.Lock;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
+import org.springframework.transaction.annotation.Transactional;
 
 public interface SeniorProfileRepository extends JpaRepository<SeniorProfile, Long> {
 
@@ -30,6 +31,11 @@ public interface SeniorProfileRepository extends JpaRepository<SeniorProfile, Lo
     List<SeniorProfile> findAllByFamilyIdWithMember(@Param("familyId") Long familyId);
 
     List<SeniorProfile> findAllByFamilyId(Long familyId);
+
+    @Transactional
+    @Modifying
+    @Query("UPDATE SeniorProfile sp SET sp.family = null WHERE sp.family.id = :familyId")
+    void clearFamilyByFamilyId(@Param("familyId") Long familyId);
 
     @Lock(LockModeType.PESSIMISTIC_WRITE)
     @Query("SELECT sp FROM SeniorProfile sp WHERE sp.family.id = :familyId")

--- a/backend/widyu-api/src/main/java/com/widyu/mypage/application/SeniorMyPageService.java
+++ b/backend/widyu-api/src/main/java/com/widyu/mypage/application/SeniorMyPageService.java
@@ -89,6 +89,10 @@ public class SeniorMyPageService {
         Member member = MyPageProfileService.getCurrentMember(memberUtil);
         SeniorProfile seniorProfile = member.getSeniorProfile();
 
+        if (seniorProfile.getFamily() == null) {
+            return EmergencyContactResponse.of(List.of());
+        }
+
         List<FamilyMembership> memberships = familyMembershipRepository
                 .findAllByFamilyIdWithGuardian(seniorProfile.getFamily().getId());
 
@@ -99,6 +103,10 @@ public class SeniorMyPageService {
     public void updateRepresentativeContact(Long memberId) {
         Member member = MyPageProfileService.getCurrentMember(memberUtil);
         SeniorProfile seniorProfile = member.getSeniorProfile();
+
+        if (seniorProfile.getFamily() == null) {
+            throw new BusinessException(ErrorCode.FAMILY_MEMBERSHIP_NOT_FOUND);
+        }
 
         List<FamilyMembership> memberships = familyMembershipRepository
                 .findAllByFamilyIdWithGuardian(seniorProfile.getFamily().getId());

--- a/backend/widyu-api/src/test/java/com/widyu/auth/application/guardian/MemberWithdrawServiceTest.java
+++ b/backend/widyu-api/src/test/java/com/widyu/auth/application/guardian/MemberWithdrawServiceTest.java
@@ -1,6 +1,7 @@
 package com.widyu.auth.application.guardian;
 
 import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.willThrow;
@@ -11,14 +12,20 @@ import com.widyu.auth.application.guardian.oauth.strategy.SocialLoginStrategy;
 import com.widyu.auth.application.guardian.oauth.strategy.SocialLoginStrategyFactory;
 import com.widyu.auth.dto.request.MemberWithdrawRequest;
 import com.widyu.auth.repository.RefreshTokenRepository;
+import com.widyu.global.error.BusinessException;
 import com.widyu.global.util.MemberUtil;
+import com.widyu.member.Family;
+import com.widyu.member.FamilyMembership;
 import com.widyu.member.Member;
 import com.widyu.member.MemberType;
 import com.widyu.member.SocialAccount;
 import com.widyu.member.repository.FamilyMembershipRepository;
+import com.widyu.member.repository.FamilyRepository;
 import com.widyu.member.repository.MemberRepository;
+import com.widyu.member.repository.SeniorProfileRepository;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -34,6 +41,8 @@ class MemberWithdrawServiceTest {
     @Mock private MemberRepository memberRepository;
     @Mock private RefreshTokenRepository refreshTokenRepository;
     @Mock private FamilyMembershipRepository familyMembershipRepository;
+    @Mock private FamilyRepository familyRepository;
+    @Mock private SeniorProfileRepository seniorProfileRepository;
     @Mock private SocialLoginStrategyFactory strategyFactory;
     @Mock private MemberUtil memberUtil;
     @Mock private SocialLoginStrategy kakaoStrategy;
@@ -56,24 +65,7 @@ class MemberWithdrawServiceTest {
 
         // then
         verify(refreshTokenRepository).deleteById(1L);
-        verify(familyMembershipRepository).deleteByGuardianId(1L);
         verify(memberRepository).save(member);
-    }
-
-    @Test
-    @DisplayName("탈퇴 시 해당 guardian의 FamilyMembership이 삭제된다")
-    void 탈퇴_시_FamilyMembership이_삭제된다() {
-        // given
-        Member member = Member.createMember(MemberType.GUARDIAN, "홍길동", "01012345678");
-        ReflectionTestUtils.setField(member, "id", 1L);
-        ReflectionTestUtils.setField(member, "socialAccounts", new ArrayList<>());
-        given(memberUtil.getCurrentMember()).willReturn(member);
-
-        // when
-        memberWithdrawService.withdrawMember(new MemberWithdrawRequest("탈퇴 사유"));
-
-        // then
-        verify(familyMembershipRepository).deleteByGuardianId(1L);
     }
 
     @Test
@@ -84,11 +76,104 @@ class MemberWithdrawServiceTest {
         ReflectionTestUtils.setField(member, "id", 1L);
         ReflectionTestUtils.setField(member, "socialAccounts", new ArrayList<>());
         given(memberUtil.getCurrentMember()).willReturn(member);
-        // deleteByGuardianId on a void mock is a no-op when no matching rows exist
 
         // when & then
         assertThatCode(() -> memberWithdrawService.withdrawMember(new MemberWithdrawRequest("탈퇴 사유")))
                 .doesNotThrowAnyException();
+        verify(familyMembershipRepository, never()).deleteByGuardianId(any());
+    }
+
+    @Test
+    @DisplayName("방장이 아닌 구성원 탈퇴 시 FamilyMembership만 삭제된다")
+    void 방장_아닌_구성원_탈퇴_시_멤버십만_삭제된다() {
+        // given
+        Member member = Member.createMember(MemberType.GUARDIAN, "홍길동", "01012345678");
+        ReflectionTestUtils.setField(member, "id", 1L);
+        ReflectionTestUtils.setField(member, "socialAccounts", new ArrayList<>());
+
+        Family family = Family.createFamily("ABCDEF");
+        ReflectionTestUtils.setField(family, "id", 100L);
+        FamilyMembership membership = FamilyMembership.createMembership(family, member);
+
+        given(memberUtil.getCurrentMember()).willReturn(member);
+        given(familyMembershipRepository.findByGuardianId(1L)).willReturn(Optional.of(membership));
+
+        // when
+        memberWithdrawService.withdrawMember(new MemberWithdrawRequest("탈퇴 사유"));
+
+        // then
+        verify(familyMembershipRepository).deleteByGuardianId(1L);
+        verify(familyRepository, never()).deleteById(any());
+    }
+
+    @Test
+    @DisplayName("방장이며 다른 구성원이 있을 때 탈퇴 시 예외가 발생한다")
+    void 방장이며_다른_구성원_있을_때_탈퇴_시_예외가_발생한다() {
+        // given
+        Member member = Member.createMember(MemberType.GUARDIAN, "홍길동", "01012345678");
+        ReflectionTestUtils.setField(member, "id", 1L);
+        ReflectionTestUtils.setField(member, "socialAccounts", new ArrayList<>());
+
+        Family family = Family.createFamily("ABCDEF");
+        ReflectionTestUtils.setField(family, "id", 100L);
+        FamilyMembership leaderMembership = FamilyMembership.createLeaderMembership(family, member);
+
+        given(memberUtil.getCurrentMember()).willReturn(member);
+        given(familyMembershipRepository.findByGuardianId(1L)).willReturn(Optional.of(leaderMembership));
+        given(familyMembershipRepository.countByFamilyId(100L)).willReturn(2L);
+
+        // when & then
+        assertThatThrownBy(() -> memberWithdrawService.withdrawMember(new MemberWithdrawRequest("탈퇴 사유")))
+                .isInstanceOf(BusinessException.class);
+        verify(familyRepository, never()).deleteById(any());
+    }
+
+    @Test
+    @DisplayName("소셜 계정 보유 방장이 다른 구성원 있을 때 탈퇴 차단 시 소셜 revoke를 호출하지 않는다")
+    void 소셜_계정_보유_방장이_다른_구성원_있을_때_탈퇴_차단_시_소셜_revoke_호출하지_않는다() {
+        // given
+        Member member = Member.createMember(MemberType.GUARDIAN, "홍길동", "01012345678");
+        ReflectionTestUtils.setField(member, "id", 1L);
+        SocialAccount kakaoAccount = SocialAccount.createSocialAccount("k@k.com", "kakao", "kakao-id", member);
+        ReflectionTestUtils.setField(member, "socialAccounts", List.of(kakaoAccount));
+
+        Family family = Family.createFamily("ABCDEF");
+        ReflectionTestUtils.setField(family, "id", 100L);
+        FamilyMembership leaderMembership = FamilyMembership.createLeaderMembership(family, member);
+
+        given(memberUtil.getCurrentMember()).willReturn(member);
+        given(familyMembershipRepository.findByGuardianId(1L)).willReturn(Optional.of(leaderMembership));
+        given(familyMembershipRepository.countByFamilyId(100L)).willReturn(2L);
+
+        // when & then
+        assertThatThrownBy(() -> memberWithdrawService.withdrawMember(new MemberWithdrawRequest("탈퇴 사유")))
+                .isInstanceOf(BusinessException.class);
+        verify(kakaoStrategy, never()).withdrawSocialAccount(any(), any());
+    }
+
+    @Test
+    @DisplayName("방장이며 마지막 구성원일 때 탈퇴 시 Family가 삭제된다")
+    void 방장이며_마지막_구성원일_때_탈퇴_시_Family가_삭제된다() {
+        // given
+        Member member = Member.createMember(MemberType.GUARDIAN, "홍길동", "01012345678");
+        ReflectionTestUtils.setField(member, "id", 1L);
+        ReflectionTestUtils.setField(member, "socialAccounts", new ArrayList<>());
+
+        Family family = Family.createFamily("ABCDEF");
+        ReflectionTestUtils.setField(family, "id", 100L);
+        FamilyMembership leaderMembership = FamilyMembership.createLeaderMembership(family, member);
+
+        given(memberUtil.getCurrentMember()).willReturn(member);
+        given(familyMembershipRepository.findByGuardianId(1L)).willReturn(Optional.of(leaderMembership));
+        given(familyMembershipRepository.countByFamilyId(100L)).willReturn(1L);
+
+        // when
+        memberWithdrawService.withdrawMember(new MemberWithdrawRequest("탈퇴 사유"));
+
+        // then
+        verify(seniorProfileRepository).clearFamilyByFamilyId(100L);
+        verify(familyMembershipRepository).deleteByGuardianId(1L);
+        verify(familyRepository).deleteById(100L);
     }
 
     @Test

--- a/backend/widyu-domain/src/main/java/com/widyu/global/error/ErrorCode.java
+++ b/backend/widyu-domain/src/main/java/com/widyu/global/error/ErrorCode.java
@@ -30,6 +30,10 @@ public enum ErrorCode {
     SOCIAL_ACCOUNT_ALREADY_LINKED_TO_CURRENT_USER(HttpStatus.BAD_REQUEST, "AUTH_4009", "현재 사용자에게 이미 연동된 소셜 계정입니다."),
     SOCIAL_PROVIDER_ALREADY_LINKED(HttpStatus.BAD_REQUEST, "AUTH_4019", "이미 연동된 소셜 로그인 제공자입니다."),
 
+    // 가족 관련
+    FAMILY_LEADER_MUST_DELEGATE_BEFORE_WITHDRAW(HttpStatus.BAD_REQUEST, "FAMILY_4001", "방장 권한을 다른 구성원에게 위임한 후 탈퇴해주세요."),
+    FAMILY_MEMBERSHIP_NOT_FOUND(HttpStatus.NOT_FOUND, "FAMILY_4040", "가족 구성원 정보를 찾을 수 없습니다."),
+
     // 부모 인증 관련
     INVITE_CODE_DUPLICATED(HttpStatus.BAD_REQUEST, "PARENT_4001", "이미 존재하는 초대코드입니다."),
     INVITE_CODE_NOT_FOUND(HttpStatus.NOT_FOUND, "PARENT_4040", "초대코드를 찾을 수 없습니다."),

--- a/backend/widyu-domain/src/main/java/com/widyu/member/SeniorProfile.java
+++ b/backend/widyu-domain/src/main/java/com/widyu/member/SeniorProfile.java
@@ -32,8 +32,8 @@ public class SeniorProfile extends BaseTimeEntity {
     @JoinColumn(name = "member_id", nullable = false, unique = true)
     private Member member;
 
-    @ManyToOne(fetch = FetchType.LAZY, optional = false)
-    @JoinColumn(name = "family_id", nullable = false)
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "family_id")
     private Family family;
 
     private String address;

--- a/docs/erd/ERD-0001-initial-domain.md
+++ b/docs/erd/ERD-0001-initial-domain.md
@@ -74,7 +74,7 @@ erDiagram
     SeniorProfile {
         Long id PK
         Long member_id FK
-        Long family_id FK
+        Long family_id FK "nullable: 마지막 방장 탈퇴 시 Family 삭제 후 null 처리"
         String address
         String inviteCode
         LocalDate birthDate
@@ -280,7 +280,7 @@ erDiagram
     Member ||--o{ AdminAuditLog : "관리자 로그"
 
     Family ||--o{ FamilyMembership : "보호자 구성"
-    Family ||--o{ SeniorProfile : "시니어 구성"
+    Family |o--o{ SeniorProfile : "시니어 구성"
 
     SeniorProfile ||--o{ PointHistory : "포인트 내역"
 
@@ -350,6 +350,12 @@ erDiagram
 ### 위치 (SeniorLocation)
 - Redis `senior_location:{seniorId}` 키로 저장, TTL 5분
 - WebSocket 연결 시 실시간 업데이트, 구독 해제 시 자연 만료
+
+## 스키마 마이그레이션 이력
+
+| 날짜 | 테이블 | 변경 내용 | DDL |
+|------|--------|-----------|-----|
+| 2026-07-16 | `senior_profile` | `family_id` NOT NULL → NULL 허용 (마지막 방장 탈퇴 시 Family 삭제 후 null 처리) | `ALTER TABLE senior_profile MODIFY COLUMN family_id BIGINT NULL;` |
 
 ## 코드 동기화 메모
 


### PR DESCRIPTION
## 개요

방장이 다른 구성원이 있는 상태에서 탈퇴할 때 소셜 revoke가 먼저 실행된 뒤 예외가 발생하는 순서 버그를 수정합니다.
또한 마지막 방장이 탈퇴할 경우 Family를 자동 삭제하고, 소속 SeniorProfile의 family FK를 null 처리합니다.

## 관련 문서

- LLD: -
- ADR: docs/adr/ADR-0003-db-entity-design.md
- Architecture Plan: docs/architecture/implementation-plans/ARCH-010-membership-withdrawal-lifecycle.md

## 관련 이슈

Closes #404

## 변경 사항

- 변경 모듈: widyu-api, widyu-domain
- `MemberWithdrawService`: `validateLeaderCanWithdraw()`를 소셜 revoke 이전에 실행해 외부 side-effect 후 예외 발생 방지
- `MemberWithdrawService`: 마지막 방장 탈퇴 시 `clearFamilyByFamilyId` → `deleteByGuardianId` → `deleteById(familyId)` 순서로 삭제
- `SeniorProfile`: `family_id` FK `NOT NULL` → `NULL` 허용 (마지막 방장 탈퇴 후 고아 시니어 처리)
- `SeniorProfileRepository`: `clearFamilyByFamilyId()` 벌크 UPDATE JPQL 추가
- `ErrorCode`: `FAMILY_LEADER_MUST_DELEGATE_BEFORE_WITHDRAW`, `FAMILY_MEMBERSHIP_NOT_FOUND` 추가
- `SafeZoneNotificationListener`: `getFamily()` null 가드 추가 (family 없는 시니어 이벤트 스킵)
- `SeniorMyPageService`: `getEmergencyContacts()` family null 시 빈 목록 반환, `updateRepresentativeContact()` family null 시 예외 발생
- `GuardianAuthDocs`: 탈퇴 API에 400 응답 (`FAMILY_4001`) 문서화
- `docs/erd/ERD-0001-initial-domain.md`: `family_id` nullable 반영, 관계 기호 수정, 스키마 마이그레이션 이력 추가

## 테스트

- `./gradlew :backend:widyu-api:test --tests "com.widyu.auth.application.guardian.MemberWithdrawServiceTest"`: 11/11 통과

## 체크리스트

- [x] 엔티티 변경 시 `./gradlew compileJava` 실행
- [x] MySQL ENUM 변경 시 ALTER TABLE 명시 (해당 없음 — FK nullable 변경)
- [ ] `@Async` 메서드에 `@Transactional` 확인 (해당 없음)
- [x] LLD 인수조건 전체 충족

## Open Questions

- 고아 시니어(family=null)의 재연결 플로우가 현재 없습니다. 별도 후속 PR에서 다뤄야 합니다.

## 비고

**스키마 마이그레이션 필요**

```sql
ALTER TABLE senior_profile MODIFY COLUMN family_id BIGINT NULL;
```

운영 DB에 배포 전 위 DDL을 수동 실행해야 합니다. (`ddl-auto: update`는 NOT NULL → NULL 완화 변경을 적용하지 않습니다.)

**의도적으로 제외한 범위**
- 방장 위임 API (보호자가 다른 구성원에게 방장 권한을 넘기는 기능) — 별도 PR
- 고아 시니어 재연결 플로우 — 별도 PR