### PR TITLE
fix(location): 안전구역 CUD 가족 소속 권한 검증 추가 (ARCH-013)

### DIFF
--- a/backend/widyu-api/src/main/java/com/widyu/location/parentlocation/application/ParentLocationService.java
+++ b/backend/widyu-api/src/main/java/com/widyu/location/parentlocation/application/ParentLocationService.java
@@ -12,6 +12,7 @@ import com.widyu.location.parentlocation.repository.ParentLocationRepository;
 import com.widyu.member.FamilyMembership;
 import com.widyu.member.Member;
 import com.widyu.member.SeniorProfile;
+import com.widyu.member.application.FamilyAccessService;
 import com.widyu.member.repository.FamilyMembershipRepository;
 import com.widyu.member.repository.MemberRepository;
 import com.widyu.member.repository.SeniorProfileRepository;
@@ -33,6 +34,7 @@ public class ParentLocationService {
     private final FamilyMembershipRepository familyMembershipRepository;
     private final SeniorProfileRepository seniorProfileRepository;
     private final MemberUtil memberUtil;
+    private final FamilyAccessService familyAccessService;
 
     public List<SeniorWithLocationsResponse> findAllByGuardianId() {
         Long guardianId = memberUtil.getCurrentMember().getId();
@@ -65,6 +67,9 @@ public class ParentLocationService {
             throw new BusinessException(ErrorCode.BAD_REQUEST, "집 주소는 마이페이지에서만 수정할 수 있습니다.");
         }
 
+        Long guardianId = memberUtil.getCurrentMember().getId();
+        familyAccessService.verifyFamilyAccess(guardianId, request.memberId());
+
         Member seniorMember = memberRepository.findById(request.memberId())
                 .orElseThrow(() -> new BusinessException(ErrorCode.BAD_REQUEST, "존재하지 않는 회원입니다."));
 
@@ -77,6 +82,9 @@ public class ParentLocationService {
 
     @Transactional
     public void delete(Long memberId, Long parentLocationId) {
+        Long guardianId = memberUtil.getCurrentMember().getId();
+        familyAccessService.verifyFamilyAccess(guardianId, memberId);
+
         Member seniorMember = memberRepository.findById(memberId)
                 .orElseThrow(() -> new BusinessException(ErrorCode.BAD_REQUEST, "존재하지 않는 회원입니다."));
 
@@ -95,6 +103,9 @@ public class ParentLocationService {
         if (request.locationType() == LocationType.HOME) {
             throw new BusinessException(ErrorCode.BAD_REQUEST, "집 주소는 마이페이지에서만 수정할 수 있습니다.");
         }
+
+        Long guardianId = memberUtil.getCurrentMember().getId();
+        familyAccessService.verifyFamilyAccess(guardianId, request.memberId());
 
         Member seniorMember = memberRepository.findById(request.memberId())
                 .orElseThrow(() -> new BusinessException(ErrorCode.BAD_REQUEST, "존재하지 않는 회원입니다."));

--- a/backend/widyu-api/src/test/java/com/widyu/location/parentlocation/application/ParentLocationServiceTest.java
+++ b/backend/widyu-api/src/test/java/com/widyu/location/parentlocation/application/ParentLocationServiceTest.java
@@ -2,8 +2,11 @@ package com.widyu.location.parentlocation.application;
 
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.then;
+import static org.mockito.BDDMockito.willThrow;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 
 import com.widyu.global.error.BusinessException;
@@ -14,6 +17,7 @@ import com.widyu.location.parentlocation.dto.request.ParentLocationUpdateRequest
 import com.widyu.location.parentlocation.repository.ParentLocationRepository;
 import com.widyu.member.Member;
 import com.widyu.member.MemberType;
+import com.widyu.member.application.FamilyAccessService;
 import com.widyu.member.repository.FamilyMembershipRepository;
 import com.widyu.member.repository.MemberRepository;
 import com.widyu.member.repository.SeniorProfileRepository;
@@ -36,6 +40,7 @@ class ParentLocationServiceTest {
     @Mock private FamilyMembershipRepository familyMembershipRepository;
     @Mock private SeniorProfileRepository seniorProfileRepository;
     @Mock private MemberUtil memberUtil;
+    @Mock private FamilyAccessService familyAccessService;
 
     @InjectMocks
     private ParentLocationService parentLocationService;
@@ -59,6 +64,10 @@ class ParentLocationServiceTest {
     @DisplayName("이미 등록된 주소 생성 시 BAD_REQUEST 예외를 던지고 저장하지 않는다")
     void 이미_등록된_주소_생성_시_예외가_발생한다() {
         // given
+        Member guardian = mock(Member.class);
+        given(guardian.getId()).willReturn(100L);
+        given(memberUtil.getCurrentMember()).willReturn(guardian);
+
         Member senior = Member.createMember(MemberType.SENIOR, "부모님", "01011112222");
         ParentLocationCreateRequest request = new ParentLocationCreateRequest(
                 1L, LocationType.OTHER, "서울시 강남구", 37.5, 127.0, "병원");
@@ -78,6 +87,10 @@ class ParentLocationServiceTest {
     @DisplayName("HOME 타입 장소 삭제 시 BAD_REQUEST 예외를 던지고 삭제하지 않는다")
     void HOME_타입_장소_삭제_시_예외가_발생한다() {
         // given
+        Member guardian = mock(Member.class);
+        given(guardian.getId()).willReturn(100L);
+        given(memberUtil.getCurrentMember()).willReturn(guardian);
+
         Member senior = Member.createMember(MemberType.SENIOR, "부모님", "01011112222");
         ParentLocation home = ParentLocation.builder()
                 .member(senior)
@@ -103,6 +116,10 @@ class ParentLocationServiceTest {
     @DisplayName("존재하지 않는 장소 수정 시 BAD_REQUEST 예외를 던진다")
     void 존재하지_않는_장소_수정_시_예외가_발생한다() {
         // given
+        Member guardian = mock(Member.class);
+        given(guardian.getId()).willReturn(100L);
+        given(memberUtil.getCurrentMember()).willReturn(guardian);
+
         Member senior = Member.createMember(MemberType.SENIOR, "부모님", "01011112222");
         ParentLocationUpdateRequest request = new ParentLocationUpdateRequest(
                 1L, LocationType.OTHER, "서울시 강남구", 37.5, 127.0, "병원");
@@ -115,5 +132,86 @@ class ParentLocationServiceTest {
                 .isInstanceOf(BusinessException.class)
                 .hasFieldOrPropertyWithValue("errorCode", ErrorCode.BAD_REQUEST)
                 .hasMessageContaining("존재하지 않는 장소입니다.");
+    }
+
+    @Test
+    @DisplayName("가족으로 연결되지 않은 보호자가 안전구역 생성 시 FORBIDDEN 예외가 발생한다")
+    void 연결되지_않은_보호자가_안전구역_생성_시_FORBIDDEN_예외가_발생한다() {
+        // given
+        Member guardian = mock(Member.class);
+        given(guardian.getId()).willReturn(100L);
+        given(memberUtil.getCurrentMember()).willReturn(guardian);
+
+        ParentLocationCreateRequest request = new ParentLocationCreateRequest(
+                1L, LocationType.OTHER, "서울시 강남구", 37.5, 127.0, "병원");
+
+        willThrow(new BusinessException(ErrorCode.FORBIDDEN, "가족으로 연결된 시니어만 접근할 수 있습니다."))
+                .given(familyAccessService).verifyFamilyAccess(anyLong(), anyLong());
+
+        // when & then
+        assertThatThrownBy(() -> parentLocationService.create(request))
+                .isInstanceOf(BusinessException.class)
+                .hasFieldOrPropertyWithValue("errorCode", ErrorCode.FORBIDDEN);
+        then(parentLocationRepository).should(never()).save(any(ParentLocation.class));
+    }
+
+    @Test
+    @DisplayName("가족으로 연결되지 않은 보호자가 안전구역 삭제 시 FORBIDDEN 예외가 발생한다")
+    void 연결되지_않은_보호자가_안전구역_삭제_시_FORBIDDEN_예외가_발생한다() {
+        // given
+        Member guardian = mock(Member.class);
+        given(guardian.getId()).willReturn(100L);
+        given(memberUtil.getCurrentMember()).willReturn(guardian);
+
+        willThrow(new BusinessException(ErrorCode.FORBIDDEN, "가족으로 연결된 시니어만 접근할 수 있습니다."))
+                .given(familyAccessService).verifyFamilyAccess(anyLong(), anyLong());
+
+        // when & then
+        assertThatThrownBy(() -> parentLocationService.delete(1L, 10L))
+                .isInstanceOf(BusinessException.class)
+                .hasFieldOrPropertyWithValue("errorCode", ErrorCode.FORBIDDEN);
+        then(parentLocationRepository).should(never()).delete(any(ParentLocation.class));
+    }
+
+    @Test
+    @DisplayName("가족으로 연결되지 않은 보호자가 안전구역 수정 시 FORBIDDEN 예외가 발생한다")
+    void 연결되지_않은_보호자가_안전구역_수정_시_FORBIDDEN_예외가_발생한다() {
+        // given
+        Member guardian = mock(Member.class);
+        given(guardian.getId()).willReturn(100L);
+        given(memberUtil.getCurrentMember()).willReturn(guardian);
+
+        ParentLocationUpdateRequest request = new ParentLocationUpdateRequest(
+                1L, LocationType.OTHER, "서울시 강남구", 37.5, 127.0, "병원");
+
+        willThrow(new BusinessException(ErrorCode.FORBIDDEN, "가족으로 연결된 시니어만 접근할 수 있습니다."))
+                .given(familyAccessService).verifyFamilyAccess(anyLong(), anyLong());
+
+        // when & then
+        assertThatThrownBy(() -> parentLocationService.update(10L, request))
+                .isInstanceOf(BusinessException.class)
+                .hasFieldOrPropertyWithValue("errorCode", ErrorCode.FORBIDDEN);
+    }
+
+    @Test
+    @DisplayName("가족으로 연결된 보호자가 안전구역 생성 시 정상 저장된다")
+    void 연결된_보호자가_안전구역_생성_시_정상_저장된다() {
+        // given
+        Member guardian = mock(Member.class);
+        given(guardian.getId()).willReturn(100L);
+        given(memberUtil.getCurrentMember()).willReturn(guardian);
+
+        Member senior = Member.createMember(MemberType.SENIOR, "부모님", "01011112222");
+        ParentLocationCreateRequest request = new ParentLocationCreateRequest(
+                1L, LocationType.OTHER, "서울시 강남구", 37.5, 127.0, "병원");
+
+        given(memberRepository.findById(1L)).willReturn(Optional.of(senior));
+        given(parentLocationRepository.existsByMemberAndPlaceAddress(senior, "서울시 강남구")).willReturn(false);
+
+        // when
+        parentLocationService.create(request);
+
+        // then
+        then(parentLocationRepository).should().save(any(ParentLocation.class));
     }
 }


### PR DESCRIPTION
## 왜 바꾸는가

`ParentLocationService`의 create / delete / update 메서드에 가족 소속 검증이 없어,
가족으로 연결되지 않은 보호자가 임의의 시니어 안전구역을 무단 생성·삭제·수정할 수 있는
미인가 접근 취약점(ARCH-013)이 존재했습니다.

## 무엇을 바꿨는가

- `ParentLocationService`에 `FamilyAccessService` 주입
- `create` / `delete` / `update` 세 메서드 진입 시 `verifyFamilyAccess(guardianId, targetMemberId)` 호출
  - 비가족: `FORBIDDEN` 예외로 즉시 차단
  - 가족: 기존 로직 그대로 수행
- `ParentLocationServiceTest`에 TEST-009 테스트 4건 추가
  - 비가족 보호자 create / delete / update → FORBIDDEN 검증
  - 연결된 보호자 create → 정상 저장 검증
- 기존 테스트 3건(`이미_등록된_주소`, `HOME_타입_삭제`, `존재하지_않는_장소_수정`)에 `memberUtil` 스텁 추가

## 의도적으로 안 한 것

- Read 경로(`findAllByGuardianId`)는 이미 보호자 본인 ID 기준으로 조회하므로 변경 없음
- `FamilyAccessService` 구현 내부 로직 변경 없음

## 리뷰어 집중 포인트

`delete()`는 HOME 타입 체크보다 **앞에** `verifyFamilyAccess`를 호출합니다.
비가족 보호자가 HOME 타입 장소에 접근 시 BAD_REQUEST 전에 FORBIDDEN을 먼저 받게 되는데,
이 순서가 의도에 맞는지 확인 부탁드립니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)