### PR TITLE
fix(websocket): STOMP SUBSCRIBE 목적지 가족 소속 인가 검증 추가

### DIFF
--- a/backend/widyu-api/src/main/java/com/widyu/global/websocket/JwtChannelInterceptor.java
+++ b/backend/widyu-api/src/main/java/com/widyu/global/websocket/JwtChannelInterceptor.java
@@ -3,8 +3,13 @@ package com.widyu.global.websocket;
 import static com.widyu.global.constant.SecurityConstant.TOKEN_PREFIX;
 
 import com.widyu.auth.dto.AccessTokenDto;
+import com.widyu.global.error.BusinessException;
 import com.widyu.global.security.JwtTokenProvider;
 import com.widyu.global.security.PrincipalDetails;
+import com.widyu.member.application.FamilyAccessService;
+import java.util.Map;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.messaging.Message;
@@ -22,33 +27,107 @@ import org.springframework.stereotype.Component;
 @RequiredArgsConstructor
 public class JwtChannelInterceptor implements ChannelInterceptor {
 
-    private final JwtTokenProvider jwtTokenProvider;
+    private static final Pattern LOCATION_TOPIC = Pattern.compile("^/topic/location/(\\d+)$");
+    private static final Pattern HEART_RATE_TOPIC = Pattern.compile("^/topic/heart-rate/(\\d+)$");
 
-    @Override // STOMP CONNECT 메시지 전송 jwt 토큰 검사
+    private final JwtTokenProvider jwtTokenProvider;
+    private final FamilyAccessService familyAccessService;
+
+    @Override
     public Message<?> preSend(Message<?> message, MessageChannel channel) {
         StompHeaderAccessor accessor = MessageHeaderAccessor.getAccessor(message, StompHeaderAccessor.class);
+        if (accessor == null) {
+            return message;
+        }
 
-        if (accessor != null && StompCommand.CONNECT.equals(accessor.getCommand())) {
-            String authHeader = accessor.getFirstNativeHeader("Authorization");
+        if (StompCommand.CONNECT.equals(accessor.getCommand())) {
+            return handleConnect(message, accessor);
+        }
 
-            if (authHeader != null && authHeader.startsWith(TOKEN_PREFIX)) {
-                String token = authHeader.replace(TOKEN_PREFIX, "");
-                AccessTokenDto accessTokenDto = jwtTokenProvider.retrieveAccessToken(token);
+        if (StompCommand.SUBSCRIBE.equals(accessor.getCommand())) {
+            return handleSubscribe(message, accessor);
+        }
 
-                if (accessTokenDto != null && accessTokenDto.memberId() != null) {
-                    PrincipalDetails principal = new PrincipalDetails(
-                            accessTokenDto.memberId(),
-                            accessTokenDto.memberRole()
-                    );
-                    Authentication auth = new UsernamePasswordAuthenticationToken(
-                            principal, null, principal.getAuthorities()
-                    );
-                    accessor.setUser(auth);
-                    log.info("WebSocket CONNECT 인증 성공 - memberId: {}", accessTokenDto.memberId());
-                }
+        return message;
+    }
+
+    private Message<?> handleConnect(Message<?> message, StompHeaderAccessor accessor) {
+        String authHeader = accessor.getFirstNativeHeader("Authorization");
+
+        if (authHeader != null && authHeader.startsWith(TOKEN_PREFIX)) {
+            String token = authHeader.replace(TOKEN_PREFIX, "");
+            AccessTokenDto accessTokenDto = jwtTokenProvider.retrieveAccessToken(token);
+
+            if (accessTokenDto != null && accessTokenDto.memberId() != null) {
+                PrincipalDetails principal = new PrincipalDetails(
+                        accessTokenDto.memberId(),
+                        accessTokenDto.memberRole()
+                );
+                Authentication auth = new UsernamePasswordAuthenticationToken(
+                        principal, null, principal.getAuthorities()
+                );
+                accessor.setUser(auth);
+                log.info("WebSocket CONNECT 인증 성공 - memberId: {}", accessTokenDto.memberId());
             }
         }
 
         return message;
+    }
+
+    private Message<?> handleSubscribe(Message<?> message, StompHeaderAccessor accessor) {
+        String destination = accessor.getDestination();
+        if (destination == null) {
+            return message;
+        }
+
+        Long targetMemberId = extractProtectedMemberId(destination);
+        if (targetMemberId == null) {
+            return message;
+        }
+
+        Long subscriberId = resolveSubscriberId(accessor);
+        if (subscriberId == null) {
+            log.warn("WebSocket SUBSCRIBE 인가 실패 - 인증 정보 없음, destination: {}", destination);
+            return null;
+        }
+
+        try {
+            familyAccessService.verifyFamilyAccess(subscriberId, targetMemberId);
+            log.info("WebSocket SUBSCRIBE 인가 성공 - subscriberId: {}, destination: {}", subscriberId, destination);
+        } catch (BusinessException e) {
+            log.warn("WebSocket SUBSCRIBE 인가 거부 - subscriberId: {}, destination: {}", subscriberId, destination);
+            return null;
+        }
+
+        return message;
+    }
+
+    private Long extractProtectedMemberId(String destination) {
+        Matcher locationMatcher = LOCATION_TOPIC.matcher(destination);
+        if (locationMatcher.matches()) {
+            return Long.parseLong(locationMatcher.group(1));
+        }
+
+        Matcher heartMatcher = HEART_RATE_TOPIC.matcher(destination);
+        if (heartMatcher.matches()) {
+            return Long.parseLong(heartMatcher.group(1));
+        }
+
+        return null;
+    }
+
+    private Long resolveSubscriberId(StompHeaderAccessor accessor) {
+        java.security.Principal user = accessor.getUser();
+        if (user instanceof UsernamePasswordAuthenticationToken auth
+                && auth.getPrincipal() instanceof PrincipalDetails principal) {
+            return principal.getMemberId();
+        }
+
+        Map<String, Object> sessionAttributes = accessor.getSessionAttributes();
+        if (sessionAttributes != null && sessionAttributes.get("memberId") instanceof Long memberId) {
+            return memberId;
+        }
+
+        return null;
     }
 }

--- a/backend/widyu-api/src/test/java/com/widyu/global/websocket/JwtChannelInterceptorTest.java
+++ b/backend/widyu-api/src/test/java/com/widyu/global/websocket/JwtChannelInterceptorTest.java
@@ -1,0 +1,155 @@
+package com.widyu.global.websocket;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.BDDMockito.willThrow;
+
+import com.widyu.global.error.BusinessException;
+import com.widyu.global.error.ErrorCode;
+import com.widyu.global.security.JwtTokenProvider;
+import com.widyu.global.security.PrincipalDetails;
+import com.widyu.member.MemberRole;
+import com.widyu.member.application.FamilyAccessService;
+import java.util.HashMap;
+import java.util.Map;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.messaging.Message;
+import org.springframework.messaging.support.MessageBuilder;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.messaging.simp.stomp.StompCommand;
+import org.springframework.messaging.simp.stomp.StompHeaderAccessor;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("JwtChannelInterceptor SUBSCRIBE 인가 단위 테스트")
+class JwtChannelInterceptorTest {
+
+    @Mock private JwtTokenProvider jwtTokenProvider;
+    @Mock private FamilyAccessService familyAccessService;
+
+    @InjectMocks
+    private JwtChannelInterceptor jwtChannelInterceptor;
+
+    @Test
+    @DisplayName("비보호 목적지 구독 시 메시지를 통과시킨다")
+    void 비보호_목적지_구독_시_메시지를_통과시킨다() {
+        // given
+        Message<?> message = buildSubscribeMessage("/queue/errors", 100L);
+
+        // when
+        Message<?> result = jwtChannelInterceptor.preSend(message, null);
+
+        // then
+        assertThat(result).isNotNull();
+    }
+
+    @Test
+    @DisplayName("가족으로 연결된 보호자가 위치 topic 구독 시 메시지를 통과시킨다")
+    void 가족_보호자가_위치_topic_구독_시_메시지를_통과시킨다() {
+        // given
+        Message<?> message = buildSubscribeMessage("/topic/location/42", 100L);
+
+        // when
+        Message<?> result = jwtChannelInterceptor.preSend(message, null);
+
+        // then
+        assertThat(result).isNotNull();
+    }
+
+    @Test
+    @DisplayName("가족으로 연결되지 않은 보호자가 위치 topic 구독 시 null을 반환한다")
+    void 비가족_보호자가_위치_topic_구독_시_null을_반환한다() {
+        // given
+        Message<?> message = buildSubscribeMessage("/topic/location/42", 100L);
+        willThrow(new BusinessException(ErrorCode.FORBIDDEN, "가족으로 연결된 시니어만 접근할 수 있습니다."))
+                .given(familyAccessService).verifyFamilyAccess(anyLong(), anyLong());
+
+        // when
+        Message<?> result = jwtChannelInterceptor.preSend(message, null);
+
+        // then
+        assertThat(result).isNull();
+    }
+
+    @Test
+    @DisplayName("가족으로 연결되지 않은 보호자가 심박수 topic 구독 시 null을 반환한다")
+    void 비가족_보호자가_심박수_topic_구독_시_null을_반환한다() {
+        // given
+        Message<?> message = buildSubscribeMessage("/topic/heart-rate/42", 100L);
+        willThrow(new BusinessException(ErrorCode.FORBIDDEN, "가족으로 연결된 시니어만 접근할 수 있습니다."))
+                .given(familyAccessService).verifyFamilyAccess(anyLong(), anyLong());
+
+        // when
+        Message<?> result = jwtChannelInterceptor.preSend(message, null);
+
+        // then
+        assertThat(result).isNull();
+    }
+
+    @Test
+    @DisplayName("인증 정보 없이 위치 topic 구독 시 null을 반환한다")
+    void 인증_정보_없이_위치_topic_구독_시_null을_반환한다() {
+        // given
+        Message<?> message = buildSubscribeMessageWithNoAuth("/topic/location/42");
+
+        // when
+        Message<?> result = jwtChannelInterceptor.preSend(message, null);
+
+        // then
+        assertThat(result).isNull();
+    }
+
+    @Test
+    @DisplayName("세션 속성으로 인증된 보호자가 위치 topic 구독 시 메시지를 통과시킨다")
+    void 세션_속성_인증_보호자가_위치_topic_구독_시_메시지를_통과시킨다() {
+        // given
+        Message<?> message = buildSubscribeMessageWithSessionAttrs("/topic/location/42", 100L);
+
+        // when
+        Message<?> result = jwtChannelInterceptor.preSend(message, null);
+
+        // then
+        assertThat(result).isNotNull();
+    }
+
+    private Message<?> buildSubscribeMessage(String destination, Long subscriberId) {
+        StompHeaderAccessor accessor = StompHeaderAccessor.create(StompCommand.SUBSCRIBE);
+        accessor.setDestination(destination);
+        accessor.setSessionId("test-session");
+        accessor.setLeaveMutable(true);
+
+        PrincipalDetails principal = new PrincipalDetails(subscriberId, MemberRole.USER);
+        Authentication auth = new UsernamePasswordAuthenticationToken(
+                principal, null, principal.getAuthorities());
+        accessor.setUser(auth);
+
+        return MessageBuilder.createMessage(new byte[0], accessor.getMessageHeaders());
+    }
+
+    private Message<?> buildSubscribeMessageWithNoAuth(String destination) {
+        StompHeaderAccessor accessor = StompHeaderAccessor.create(StompCommand.SUBSCRIBE);
+        accessor.setDestination(destination);
+        accessor.setSessionId("test-session");
+        accessor.setLeaveMutable(true);
+
+        return MessageBuilder.createMessage(new byte[0], accessor.getMessageHeaders());
+    }
+
+    private Message<?> buildSubscribeMessageWithSessionAttrs(String destination, Long subscriberId) {
+        StompHeaderAccessor accessor = StompHeaderAccessor.create(StompCommand.SUBSCRIBE);
+        accessor.setDestination(destination);
+        accessor.setSessionId("test-session");
+        accessor.setLeaveMutable(true);
+
+        Map<String, Object> sessionAttrs = new HashMap<>();
+        sessionAttrs.put("memberId", subscriberId);
+        accessor.setSessionAttributes(sessionAttrs);
+
+        return MessageBuilder.createMessage(new byte[0], accessor.getMessageHeaders());
+    }
+}


### PR DESCRIPTION
## 왜 바꾸는가

`JwtChannelInterceptor`는 STOMP `CONNECT` 시 JWT 인증만 수행했습니다.
`SUBSCRIBE` 프레임에서는 destination의 memberId와 구독자의 가족 관계를 검증하지 않아,
인증된 회원이 임의 시니어의 `/topic/location/{seniorId}` 또는
`/topic/heart-rate/{memberId}` topic을 구독해 실시간 위치·심박수 데이터를
수신할 수 있는 취약점이 존재했습니다(ARCH-014).

## 무엇을 바꿨는가

- `JwtChannelInterceptor.preSend()`에 `SUBSCRIBE` 프레임 분기 추가
  - `/topic/location/{memberId}`, `/topic/heart-rate/{memberId}` 패턴을 정규식으로 식별
  - JWT Principal 또는 WS-토큰 세션 속성에서 구독자 ID 추출 (`resolveSubscriberId()`)
  - `FamilyAccessService.verifyFamilyAccess()` 호출 — 비가족 시 `null` 반환(구독 드롭)
- CONNECT 처리 로직을 `handleConnect()`로 추출하여 가독성 개선
- `JwtChannelInterceptorTest` 신규 작성 (TEST-010, 6건)
  - 비보호 목적지 → 통과
  - 가족 보호자 위치 topic → 통과
  - 비가족 보호자 위치 topic → null
  - 비가족 보호자 심박수 topic → null
  - 미인증 위치 topic → null
  - 세션 속성 인증 보호자 → 통과

## 의도적으로 안 한 것

- ERROR 프레임을 클라이언트에 전송하지 않음 — null 반환으로 SUBSCRIBE 메시지를 드롭하는 방식 채택 (연결 유지, 조용한 거부)
- `CONNECT` 인증 실패 시 연결을 끊는 로직은 변경 없음
- STOMP 통합 테스트(실서버 구동)는 포함하지 않음 — 채널 인터셉터 단위 테스트로 커버

## 리뷰어 집중 포인트

비인가 구독 요청에 `null`을 반환하는 방식(조용한 드롭) vs. `MessagingException`을 던져 ERROR 프레임을 보내는 방식 중 어느 쪽이 클라이언트 UX에 적합한지 확인 부탁드립니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)