### PR TITLE
refactor(heart): 심박 수집 배치 멱등성 보강 (ARCH-016, TEST-012)

### DIFF
--- a/backend/widyu-api/src/main/java/com/widyu/heart/application/HeartRateService.java
+++ b/backend/widyu-api/src/main/java/com/widyu/heart/application/HeartRateService.java
@@ -20,6 +20,7 @@ import com.widyu.heart.repository.HeartRateEventRepository;
 import com.widyu.heart.repository.HeartRateResultRepository;
 import com.widyu.member.Member;
 import com.widyu.member.repository.MemberRepository;
+import java.time.LocalDateTime;
 import java.util.Comparator;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
@@ -42,6 +43,15 @@ public class HeartRateService {
     public HeartRateStatusResponse processHeartRates(Long memberId, HeartRateSendRequest request) {
         Member member = memberRepository.findById(memberId)
                 .orElseThrow(() -> new BusinessException(ErrorCode.MEMBER_NOT_FOUND));
+
+        LocalDateTime batchStart = request.heartRates().stream()
+                .map(HeartRateMeasurement::measuredAt)
+                .min(Comparator.naturalOrder())
+                .orElseThrow();
+
+        if (heartRateEventRepository.existsByMemberIdAndMeasuredAt(memberId, batchStart)) {
+            return getHeartRateStatus(memberId);
+        }
 
         List<Integer> heartRateValues = request.heartRates().stream()
                 .map(HeartRateMeasurement::heartRate)

--- a/backend/widyu-api/src/main/java/com/widyu/heart/repository/HeartRateEventRepository.java
+++ b/backend/widyu-api/src/main/java/com/widyu/heart/repository/HeartRateEventRepository.java
@@ -13,6 +13,8 @@ import org.springframework.stereotype.Repository;
 @Repository
 public interface HeartRateEventRepository extends JpaRepository<HeartRateEvent, Long> {
 
+    boolean existsByMemberIdAndMeasuredAt(Long memberId, LocalDateTime measuredAt);
+
     List<HeartRateEvent> findByMemberIdOrderByMeasuredAtAsc(Long memberId);
 
     List<HeartRateEvent> findTop5ByMemberIdOrderByMeasuredAtDesc(Long memberId);

--- a/backend/widyu-api/src/test/java/com/widyu/heart/application/HeartRateServiceTest.java
+++ b/backend/widyu-api/src/test/java/com/widyu/heart/application/HeartRateServiceTest.java
@@ -3,6 +3,8 @@ package com.widyu.heart.application;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.then;
 import static org.mockito.Mockito.never;
@@ -133,6 +135,87 @@ class HeartRateServiceTest {
         assertThat(response.heartGraph().current().status()).isEqualTo(HeartRateStatus.ANOMALY);
         assertThat(response.heartGraph().current().maxHeartRate()).isEqualTo(82);
         assertThat(response.heartGraph().current().minHeartRate()).isEqualTo(75);
+    }
+
+    // TEST-012: 심박 수집 배치 멱등성 검증
+
+    @Test
+    @DisplayName("동일 배치(배치 시작 시각 일치)를 재전송하면 저장 없이 기존 상태를 반환한다")
+    void 동일_배치_재전송시_중복_저장_없이_기존상태를_반환한다() {
+        // given
+        Long memberId = 1L;
+        LocalDateTime batchStart = LocalDateTime.of(2026, 1, 1, 10, 0, 0);
+        List<HeartRateMeasurement> measurements = java.util.stream.IntStream.range(0, 15)
+                .mapToObj(i -> new HeartRateMeasurement(70 + i, batchStart.plusSeconds(i)))
+                .toList();
+        HeartRateSendRequest duplicateRequest = new HeartRateSendRequest(measurements, "서울시");
+
+        Member member = Member.createMember(MemberType.SENIOR, "시니어", "01012345678");
+        HeartRateResult existingResult = HeartRateResult.of(memberId, HeartRateStatus.NORMAL, 75, batchStart.plusSeconds(14));
+
+        given(memberRepository.findById(memberId)).willReturn(Optional.of(member));
+        given(heartRateEventRepository.existsByMemberIdAndMeasuredAt(memberId, batchStart)).willReturn(true);
+        given(heartRateResultRepository.findByMemberId(memberId)).willReturn(Optional.of(existingResult));
+
+        // when
+        HeartRateStatusResponse response = heartRateService.processHeartRates(memberId, duplicateRequest);
+
+        // then
+        assertThat(response.heartRateStatus()).isEqualTo(HeartRateStatus.NORMAL);
+        assertThat(response.heartRate()).isEqualTo(75);
+        then(heartRateAnomalyDetector).should(never()).detectAnomaly(any());
+        then(heartRateEventRepository).should(never()).saveAll(any());
+        then(heartRateEmergencyRepository).should(never()).save(any());
+    }
+
+    @Test
+    @DisplayName("신규 배치는 배치 시작 시각이 없으면 정상 처리하고 Event와 Result를 저장한다")
+    void 신규_배치는_정상_처리하고_Event와_Result를_저장한다() {
+        // given
+        Long memberId = 1L;
+        LocalDateTime batchStart = LocalDateTime.of(2026, 1, 1, 11, 0, 0);
+        List<HeartRateMeasurement> measurements = java.util.stream.IntStream.range(0, 15)
+                .mapToObj(i -> new HeartRateMeasurement(70 + i, batchStart.plusSeconds(i)))
+                .toList();
+        HeartRateSendRequest newRequest = new HeartRateSendRequest(measurements, "서울시");
+        Member member = Member.createMember(MemberType.SENIOR, "시니어", "01012345678");
+
+        given(memberRepository.findById(memberId)).willReturn(Optional.of(member));
+        given(heartRateEventRepository.existsByMemberIdAndMeasuredAt(memberId, batchStart)).willReturn(false);
+        given(heartRateAnomalyDetector.detectAnomaly(any())).willReturn(false);
+
+        // when
+        heartRateService.processHeartRates(memberId, newRequest);
+
+        // then
+        then(heartRateAnomalyDetector).should().detectAnomaly(any());
+        then(heartRateResultRepository).should().save(any(HeartRateResult.class));
+        then(heartRateEventRepository).should().saveAll(any());
+    }
+
+    @Test
+    @DisplayName("신규 이상 배치는 Emergency를 저장하지만 중복 배치에서는 Emergency를 저장하지 않는다")
+    void 중복_이상_배치에서_Emergency를_저장하지_않는다() {
+        // given
+        Long memberId = 1L;
+        LocalDateTime batchStart = LocalDateTime.of(2026, 1, 1, 12, 0, 0);
+        List<HeartRateMeasurement> measurements = java.util.stream.IntStream.range(0, 15)
+                .mapToObj(i -> new HeartRateMeasurement(70 + i, batchStart.plusSeconds(i)))
+                .toList();
+        HeartRateSendRequest duplicateRequest = new HeartRateSendRequest(measurements, "서울시");
+        Member member = Member.createMember(MemberType.SENIOR, "시니어", "01012345678");
+        HeartRateResult existingResult = HeartRateResult.of(memberId, HeartRateStatus.ANOMALY, 84, batchStart.plusSeconds(14));
+
+        given(memberRepository.findById(memberId)).willReturn(Optional.of(member));
+        given(heartRateEventRepository.existsByMemberIdAndMeasuredAt(memberId, batchStart)).willReturn(true);
+        given(heartRateResultRepository.findByMemberId(memberId)).willReturn(Optional.of(existingResult));
+
+        // when
+        HeartRateStatusResponse response = heartRateService.processHeartRates(memberId, duplicateRequest);
+
+        // then
+        assertThat(response.heartRateStatus()).isEqualTo(HeartRateStatus.ANOMALY);
+        then(heartRateEmergencyRepository).should(never()).save(any());
     }
 
     private HeartRateSendRequest request() {

--- a/backend/widyu-domain/src/main/java/com/widyu/heart/HeartRateEmergency.java
+++ b/backend/widyu-domain/src/main/java/com/widyu/heart/HeartRateEmergency.java
@@ -11,6 +11,7 @@ import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
 import java.time.LocalDateTime;
 import lombok.AccessLevel;
 import lombok.Builder;
@@ -19,7 +20,13 @@ import lombok.NoArgsConstructor;
 
 @Entity
 @Getter
-@Table(name = "heart_rate_emergency")
+@Table(
+    name = "heart_rate_emergency",
+    uniqueConstraints = @UniqueConstraint(
+        name = "uk_heart_emergency_member_time",
+        columnNames = {"member_id", "measured_at"}
+    )
+)
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class HeartRateEmergency extends BaseTimeEntity {
 

--- a/backend/widyu-domain/src/main/java/com/widyu/heart/HeartRateEvent.java
+++ b/backend/widyu-domain/src/main/java/com/widyu/heart/HeartRateEvent.java
@@ -13,6 +13,7 @@ import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
 import java.time.LocalDateTime;
 import lombok.AccessLevel;
 import lombok.Builder;
@@ -21,7 +22,13 @@ import lombok.NoArgsConstructor;
 
 @Entity
 @Getter
-@Table(name = "heart_rate_event")
+@Table(
+    name = "heart_rate_event",
+    uniqueConstraints = @UniqueConstraint(
+        name = "uk_heart_event_member_time",
+        columnNames = {"member_id", "measured_at"}
+    )
+)
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class HeartRateEvent extends BaseTimeEntity {
 


### PR DESCRIPTION
## 개요
심박수 배치 수집 API가 동일 측정 배치를 재전송받아도 `HeartRateEvent`와 `HeartRateEmergency`를 중복 저장하지 않도록 멱등성을 보강합니다.

## 관련 문서
- LLD: -
- ADR: -

## 관련 이슈
Closes #416

## 변경 사항
- 변경 모듈: widyu-api / widyu-domain
- `HeartRateEvent`에 `UNIQUE(member_id, measured_at)` 제약을 추가합니다.
- `HeartRateEmergency`에 `UNIQUE(member_id, measured_at)` 제약을 추가합니다.
- `HeartRateEventRepository`에 `existsByMemberIdAndMeasuredAt()` 조회 메서드를 추가합니다.
- `HeartRateService.processHeartRates()`에서 배치 최소 `measuredAt` 기준으로 중복 배치를 감지하고 기존 상태를 반환합니다.
- TEST-012 기준으로 동일 배치 재처리 시 Event·Emergency 중복 저장을 막는 단위 테스트를 추가합니다.

## 테스트
- `./gradlew compileJava`: 통과
- `./gradlew :backend:widyu-api:test`: 통과
- `./gradlew :backend:widyu-domain:test`: 통과

## 체크리스트
- [x] 엔티티 변경 시 `./gradlew compileJava` 실행
- [x] MySQL ENUM 변경 시 ALTER TABLE 명시: 해당 없음
- [x] `@Async` 메서드에 `@Transactional` 확인: 해당 없음
- [x] LLD 인수조건 전체 충족: LLD 없음, ARCH-016/TEST-012 기준으로 확인했습니다.

## Open Questions (LLD 미결정 사항)
없습니다.

## 비고
MySQL ENUM 변경과 별도 ALTER TABLE 명령은 없습니다.
클라이언트가 안정적인 배치 식별자(UUID)를 제공할 수 있는지는 후속 확인이 필요합니다.
