### PR TITLE
refactor(pay): PG 클라이언트 인프라 패키지 이동

### DIFF
--- a/backend/widyu-api/src/main/java/com/widyu/global/config/FeignConfig.java
+++ b/backend/widyu-api/src/main/java/com/widyu/global/config/FeignConfig.java
@@ -5,7 +5,7 @@ import org.springframework.context.annotation.Configuration;
 
 @Configuration
 @EnableFeignClients(basePackages = {
-        "com.widyu.pay.config",
+        "com.widyu.pay",
         "com.widyu.goal.medicineschedule.client",
         "com.widyu.goal.addressbookmark.client"
 })

--- a/backend/widyu-api/src/main/java/com/widyu/pay/application/PaymentService.java
+++ b/backend/widyu-api/src/main/java/com/widyu/pay/application/PaymentService.java
@@ -11,7 +11,7 @@ import com.widyu.pay.PaymentCancel;
 import com.widyu.pay.PaymentOrder;
 import com.widyu.pay.PaymentStatus;
 import com.widyu.pay.PointChargePackage;
-import com.widyu.pay.config.PaymentClient;
+import com.widyu.pay.infrastructure.PaymentClient;
 import com.widyu.pay.dto.mapper.PaymentMapper;
 import com.widyu.pay.dto.request.CancelRequest;
 import com.widyu.pay.dto.request.PaymentApproveRequest;

--- a/backend/widyu-api/src/main/java/com/widyu/pay/infrastructure/PaymentClient.java
+++ b/backend/widyu-api/src/main/java/com/widyu/pay/infrastructure/PaymentClient.java
@@ -1,5 +1,6 @@
-package com.widyu.pay.config;
+package com.widyu.pay.infrastructure;
 
+import com.widyu.pay.config.PaymentFeignConfig;
 import com.widyu.pay.dto.request.CancelRequest;
 import com.widyu.pay.dto.request.PaymentGatewayConfirmRequest;
 import com.widyu.pay.dto.response.PaymentConfirmResponse;

--- a/backend/widyu-api/src/test/java/com/widyu/pay/application/PaymentServiceTest.java
+++ b/backend/widyu-api/src/test/java/com/widyu/pay/application/PaymentServiceTest.java
@@ -20,7 +20,7 @@ import com.widyu.pay.PaymentOrder;
 import com.widyu.pay.PaymentOrderStatus;
 import com.widyu.pay.PaymentStatus;
 import com.widyu.pay.PointChargePackage;
-import com.widyu.pay.config.PaymentClient;
+import com.widyu.pay.infrastructure.PaymentClient;
 import com.widyu.pay.dto.request.CancelRequest;
 import com.widyu.pay.dto.request.PaymentApproveRequest;
 import com.widyu.pay.dto.request.PaymentOrderCreateRequest;

--- a/backend/widyu-api/src/test/java/com/widyu/pay/integration/PaymentIntegrationTest.java
+++ b/backend/widyu-api/src/test/java/com/widyu/pay/integration/PaymentIntegrationTest.java
@@ -22,7 +22,7 @@ import com.widyu.pay.Payment;
 import com.widyu.pay.PaymentOrder;
 import com.widyu.pay.PaymentStatus;
 import com.widyu.pay.application.PaymentService;
-import com.widyu.pay.config.PaymentClient;
+import com.widyu.pay.infrastructure.PaymentClient;
 import com.widyu.pay.dto.request.CancelRequest;
 import com.widyu.pay.dto.request.PaymentApproveRequest;
 import com.widyu.pay.dto.request.PaymentOrderCreateRequest;


### PR DESCRIPTION
## 개요
외부 PG 호출 인터페이스인 PaymentClient를 설정 패키지에서 인프라 패키지로 이동해 Feign 설정과 외부 연동 책임을 분리합니다.

## 관련 문서
- LLD: LLD-0003
- ADR: 없음

## 관련 이슈
Closes #435

## 변경 사항
- 변경 모듈: widyu-api
- PaymentClient를 `pay.infrastructure` 패키지로 이동합니다.
- 결제 서비스와 테스트의 import를 새 패키지로 갱신합니다.
- Feign 설정과 PG 호출 계약은 유지합니다.

## 테스트
- `./gradlew :backend:widyu-api:test --tests "com.widyu.pay.application.PaymentServiceTest"`: 통과

## 체크리스트
- [x] 엔티티 변경 없음
- [x] MySQL ENUM 변경 없음
- [x] `@Async` 메서드 변경 없음

## Open Questions (LLD 미결정 사항)
없습니다.

## 비고
DB 스키마와 API 계약 변경은 없습니다.