### PR TITLE
fix(pay): 부분 취소 재요청 멱등성을 보장합니다

### DIFF
--- a/backend/widyu-api/src/main/java/com/widyu/pay/application/PaymentService.java
+++ b/backend/widyu-api/src/main/java/com/widyu/pay/application/PaymentService.java
@@ -131,17 +131,24 @@ public class PaymentService {
 
     @Transactional
     public PaymentConfirmResponse cancelPayment(String paymentKey, CancelRequest cancelRequest) {
-        Payment payment = paymentRepository.findByPaymentKey(paymentKey)
+        Payment payment = paymentRepository.findByPaymentKeyForUpdate(paymentKey)
                 .orElseThrow(() -> new BusinessException(ErrorCode.PAYMENT_NOT_FOUND));
         Member currentMember = memberUtil.getCurrentMember();
 
         validatePaymentOwnership(payment, currentMember.getId());
+
+        PaymentCancel existingCancellation = findCancellationByIdempotencyKey(payment, cancelRequest);
+        if (existingCancellation != null) {
+            validateExistingCancellationRequest(existingCancellation, cancelRequest);
+            return PaymentConfirmResponse.from(payment);
+        }
 
         if (payment.isCanceled()) {
             return PaymentConfirmResponse.from(payment);
         }
 
         CancelRequest effectiveRequest = sanitizeCancelRequest(payment, cancelRequest);
+        validatePartialCancellationIdempotencyKey(payment, effectiveRequest);
         int refundPointAmount = calculateRefundPointAmount(payment, effectiveRequest.cancelAmount());
         validateRefundPointBalance(currentMember, refundPointAmount);
         PaymentConfirmResponse response = paymentClient.cancelPayment(paymentKey, effectiveRequest);
@@ -154,12 +161,13 @@ public class PaymentService {
                 refundPointAmount,
                 effectiveRequest.cancelReason(),
                 currentMember.getId(),
+                effectiveRequest.idempotencyKey(),
                 canceledAt
         );
         payment.addCancellation(paymentCancel);
         payment.cancel(effectiveRequest.cancelAmount(), refundPointAmount, effectiveRequest.cancelReason(), canceledAt);
         // confirmPayment와 동일: 상위 트랜잭션 안이라 재시도가 동작하지 않으며, PG 취소 재호출을 피하기 위해
-        // 포인트 @Version 충돌 시 롤백 후 409로 응답한다. (취소는 isCanceled 가드로 멱등)
+        // 포인트 @Version 충돌 시 롤백 후 409로 응답한다. 부분 취소 재전송은 멱등 키로 선행 차단한다.
         seniorProfileService.deductPointsFromMember(
                 currentMember.getId(),
                 (long) refundPointAmount,
@@ -252,7 +260,44 @@ public class PaymentService {
             throw new BusinessException(ErrorCode.BAD_REQUEST, "남은 결제 금액보다 크게 취소할 수 없습니다.");
         }
 
-        return new CancelRequest(reason, cancelAmount);
+        String idempotencyKey = cancelRequest == null ? null : cancelRequest.idempotencyKey();
+        return new CancelRequest(reason, cancelAmount, idempotencyKey);
+    }
+
+    private PaymentCancel findCancellationByIdempotencyKey(Payment payment, CancelRequest cancelRequest) {
+        if (cancelRequest == null || cancelRequest.idempotencyKey() == null || cancelRequest.idempotencyKey().isBlank()) {
+            return null;
+        }
+
+        return payment.getCancellations().stream()
+                .filter(cancellation -> cancelRequest.idempotencyKey().equals(cancellation.getIdempotencyKey()))
+                .findFirst()
+                .orElse(null);
+    }
+
+    private void validateExistingCancellationRequest(PaymentCancel paymentCancel, CancelRequest cancelRequest) {
+        String cancelReason = cancelRequest.cancelReason();
+        if (cancelReason == null || cancelReason.isBlank()) {
+            cancelReason = "사용자 요청";
+        }
+
+        Integer cancelAmount = cancelRequest.cancelAmount();
+        if (cancelAmount == null) {
+            cancelAmount = paymentCancel.getCancelAmount();
+        }
+
+        if (!paymentCancel.matchesRequest(cancelReason, cancelAmount)) {
+            throw new BusinessException(ErrorCode.BAD_REQUEST, "같은 멱등 키에는 동일한 취소 요청만 사용할 수 있습니다.");
+        }
+    }
+
+    private void validatePartialCancellationIdempotencyKey(Payment payment, CancelRequest cancelRequest) {
+        if (cancelRequest.cancelAmount() >= payment.getRemainingAmount()) {
+            return;
+        }
+        if (cancelRequest.idempotencyKey() == null || cancelRequest.idempotencyKey().isBlank()) {
+            throw new BusinessException(ErrorCode.BAD_REQUEST, "부분 취소에는 멱등 키가 필요합니다.");
+        }
     }
 
     private int calculateRefundPointAmount(Payment payment, int cancelAmount) {

--- a/backend/widyu-api/src/main/java/com/widyu/pay/controller/docs/PaymentDocs.java
+++ b/backend/widyu-api/src/main/java/com/widyu/pay/controller/docs/PaymentDocs.java
@@ -174,7 +174,7 @@ public interface PaymentDocs {
 
     @Operation(
             summary = "결제 취소",
-            description = "주어진 paymentKey를 기준으로 결제를 취소합니다."
+            description = "주어진 paymentKey를 기준으로 결제를 취소합니다. 부분 취소에는 재전송 방지를 위한 idempotencyKey가 필요합니다."
     )
     @ApiResponse(
             responseCode = "200",
@@ -239,8 +239,9 @@ public interface PaymentDocs {
                                     name = "취소 요청 예시",
                                     value = """
                                             {
-                                              "cancelReason": "사용자 요청",
-                                              "cancelAmount": 10000
+                                              "cancelReason": "부분 취소 요청",
+                                              "cancelAmount": 3000,
+                                              "idempotencyKey": "cancel-20260725-0001"
                                             }
                                             """
                             )

--- a/backend/widyu-api/src/main/java/com/widyu/pay/dto/request/CancelRequest.java
+++ b/backend/widyu-api/src/main/java/com/widyu/pay/dto/request/CancelRequest.java
@@ -1,5 +1,6 @@
 package com.widyu.pay.dto.request;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import jakarta.validation.constraints.Positive;
 import jakarta.validation.constraints.Size;
 
@@ -8,6 +9,13 @@ public record CancelRequest(
         String cancelReason,
 
         @Positive(message = "취소 금액은 0보다 커야 합니다.")
-        Integer cancelAmount
+        Integer cancelAmount,
+
+        @Size(max = 100, message = "멱등 키는 최대 100자입니다.")
+        @JsonProperty(access = JsonProperty.Access.WRITE_ONLY)
+        String idempotencyKey
 ) {
+    public CancelRequest(String cancelReason, Integer cancelAmount) {
+        this(cancelReason, cancelAmount, null);
+    }
 }

--- a/backend/widyu-api/src/main/java/com/widyu/pay/repository/PaymentRepository.java
+++ b/backend/widyu-api/src/main/java/com/widyu/pay/repository/PaymentRepository.java
@@ -5,6 +5,8 @@ import com.widyu.pay.PaymentStatus;
 import java.time.ZonedDateTime;
 import java.util.List;
 import java.util.Optional;
+import jakarta.persistence.LockModeType;
+import org.springframework.data.jpa.repository.Lock;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -14,6 +16,10 @@ import org.springframework.data.repository.query.Param;
 public interface PaymentRepository extends JpaRepository<Payment, Long> {
 
     Optional<Payment> findByPaymentKey(String paymentKey);
+
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("SELECT p FROM Payment p WHERE p.paymentKey = :paymentKey")
+    Optional<Payment> findByPaymentKeyForUpdate(@Param("paymentKey") String paymentKey);
 
     List<Payment> findByMemberId(Long memberId);
 

--- a/backend/widyu-api/src/test/java/com/widyu/pay/application/PaymentServiceTest.java
+++ b/backend/widyu-api/src/test/java/com/widyu/pay/application/PaymentServiceTest.java
@@ -16,6 +16,7 @@ import com.widyu.member.MemberType;
 import com.widyu.member.SeniorProfile;
 import com.widyu.member.application.SeniorProfileService;
 import com.widyu.pay.Payment;
+import com.widyu.pay.PaymentCancel;
 import com.widyu.pay.PaymentOrder;
 import com.widyu.pay.PaymentOrderStatus;
 import com.widyu.pay.PaymentStatus;
@@ -91,6 +92,16 @@ class PaymentServiceTest {
     }
 
     @Test
+    @DisplayName("결제 취소 조회는 병렬 취소 요청을 직렬화하기 위해 비관적 쓰기 락을 사용한다")
+    void 결제_취소_조회는_비관적_쓰기_락을_사용한다() throws NoSuchMethodException {
+        Lock lock = PaymentRepository.class
+                .getMethod("findByPaymentKeyForUpdate", String.class)
+                .getAnnotation(Lock.class);
+
+        assertThat(lock.value()).isEqualTo(LockModeType.PESSIMISTIC_WRITE);
+    }
+
+    @Test
     @DisplayName("이미 저장된 주문 결제면 기존 결제를 반환하고 PG 승인 호출을 생략한다")
     void 중복_결제_승인_요청은_기존_결제를_반환한다() {
         Member member = createMember(1L, "보호자");
@@ -137,7 +148,7 @@ class PaymentServiceTest {
         PaymentConfirmResponse canceledResponse = createResponse("pay_123", "order_123", 10000, PaymentStatus.CANCELED);
 
         given(memberUtil.getCurrentMember()).willReturn(member);
-        given(paymentRepository.findByPaymentKey("pay_123")).willReturn(Optional.of(payment));
+        given(paymentRepository.findByPaymentKeyForUpdate("pay_123")).willReturn(Optional.of(payment));
         given(paymentClient.cancelPayment("pay_123", new CancelRequest("사용자 요청", 10000))).willReturn(canceledResponse);
 
         PaymentConfirmResponse result = paymentService.cancelPayment("pay_123", null);
@@ -163,7 +174,7 @@ class PaymentServiceTest {
         Payment payment = createPayment(otherMember, paymentOrder, "pay_123", "order_123", 10000, PaymentStatus.DONE);
 
         given(memberUtil.getCurrentMember()).willReturn(currentMember);
-        given(paymentRepository.findByPaymentKey("pay_123")).willReturn(Optional.of(payment));
+        given(paymentRepository.findByPaymentKeyForUpdate("pay_123")).willReturn(Optional.of(payment));
 
         assertThatThrownBy(() -> paymentService.cancelPayment("pay_123", new CancelRequest("사용자 요청", null)))
                 .isInstanceOf(BusinessException.class)
@@ -181,7 +192,7 @@ class PaymentServiceTest {
         payment.cancel(10000, 10000, "기존 취소", ZonedDateTime.now());
 
         given(memberUtil.getCurrentMember()).willReturn(member);
-        given(paymentRepository.findByPaymentKey("pay_123")).willReturn(Optional.of(payment));
+        given(paymentRepository.findByPaymentKeyForUpdate("pay_123")).willReturn(Optional.of(payment));
 
         PaymentConfirmResponse result = paymentService.cancelPayment("pay_123", new CancelRequest("다시 취소", null));
 
@@ -200,10 +211,10 @@ class PaymentServiceTest {
         PaymentConfirmResponse partialCanceledResponse = createResponse("pay_123", "order_123", 10000, PaymentStatus.PARTIAL_CANCELED);
 
         given(memberUtil.getCurrentMember()).willReturn(member);
-        given(paymentRepository.findByPaymentKey("pay_123")).willReturn(Optional.of(payment));
-        given(paymentClient.cancelPayment("pay_123", new CancelRequest("부분 취소", 3000))).willReturn(partialCanceledResponse);
+        given(paymentRepository.findByPaymentKeyForUpdate("pay_123")).willReturn(Optional.of(payment));
+        given(paymentClient.cancelPayment("pay_123", new CancelRequest("부분 취소", 3000, "cancel-request-1"))).willReturn(partialCanceledResponse);
 
-        PaymentConfirmResponse result = paymentService.cancelPayment("pay_123", new CancelRequest("부분 취소", 3000));
+        PaymentConfirmResponse result = paymentService.cancelPayment("pay_123", new CancelRequest("부분 취소", 3000, "cancel-request-1"));
 
         assertThat(result.getStatus()).isEqualTo(PaymentStatus.PARTIAL_CANCELED);
         assertThat(payment.getCanceledAmount()).isEqualTo(3000);
@@ -212,6 +223,85 @@ class PaymentServiceTest {
         assertThat(result.getCancellations()).hasSize(1);
         assertThat(paymentOrder.getStatus()).isEqualTo(PaymentOrderStatus.PAID);
         verify(seniorProfileService).deductPointsFromMember(member.getId(), 3000L, "부분 취소");
+    }
+
+    @Test
+    @DisplayName("같은 멱등 키로 부분 취소를 재요청하면 PG를 재호출하지 않고 기존 결과를 반환한다")
+    void 동일_멱등_키_부분_취소_재요청은_기존_결과를_반환한다() {
+        Member member = createMember(1L, "시니어");
+        PaymentOrder paymentOrder = createOrder(member, "order_123", 10000, PaymentOrderStatus.PAID);
+        Payment payment = createPayment(member, paymentOrder, "pay_123", "order_123", 10000, PaymentStatus.DONE);
+        PaymentCancel paymentCancel = PaymentCancel.create(
+                payment,
+                3000,
+                3000,
+                "부분 취소",
+                member.getId(),
+                "cancel-request-1",
+                ZonedDateTime.now()
+        );
+        payment.addCancellation(paymentCancel);
+        payment.cancel(3000, 3000, "부분 취소", ZonedDateTime.now());
+
+        given(memberUtil.getCurrentMember()).willReturn(member);
+        given(paymentRepository.findByPaymentKeyForUpdate("pay_123")).willReturn(Optional.of(payment));
+
+        PaymentConfirmResponse result = paymentService.cancelPayment(
+                "pay_123",
+                new CancelRequest("부분 취소", 3000, "cancel-request-1")
+        );
+
+        assertThat(result.getStatus()).isEqualTo(PaymentStatus.PARTIAL_CANCELED);
+        assertThat(result.getCancellations()).hasSize(1);
+        verify(paymentClient, never()).cancelPayment(any(), any());
+        verify(seniorProfileService, never()).deductPointsFromMember(anyLong(), anyLong(), any());
+    }
+
+    @Test
+    @DisplayName("같은 멱등 키에 다른 부분 취소 요청을 보내면 예외가 발생한다")
+    void 동일_멱등_키_상이한_부분_취소_요청은_예외가_발생한다() {
+        Member member = createMember(1L, "시니어");
+        PaymentOrder paymentOrder = createOrder(member, "order_123", 10000, PaymentOrderStatus.PAID);
+        Payment payment = createPayment(member, paymentOrder, "pay_123", "order_123", 10000, PaymentStatus.DONE);
+        PaymentCancel paymentCancel = PaymentCancel.create(
+                payment,
+                3000,
+                3000,
+                "부분 취소",
+                member.getId(),
+                "cancel-request-1",
+                ZonedDateTime.now()
+        );
+        payment.addCancellation(paymentCancel);
+        payment.cancel(3000, 3000, "부분 취소", ZonedDateTime.now());
+
+        given(memberUtil.getCurrentMember()).willReturn(member);
+        given(paymentRepository.findByPaymentKeyForUpdate("pay_123")).willReturn(Optional.of(payment));
+
+        assertThatThrownBy(() -> paymentService.cancelPayment(
+                "pay_123",
+                new CancelRequest("다른 사유", 3000, "cancel-request-1")
+        )).isInstanceOf(BusinessException.class)
+                .hasFieldOrPropertyWithValue("errorCode", ErrorCode.BAD_REQUEST);
+
+        verify(paymentClient, never()).cancelPayment(any(), any());
+    }
+
+    @Test
+    @DisplayName("부분 취소에 멱등 키가 없으면 PG 호출 전에 예외가 발생한다")
+    void 부분_취소_멱등_키_누락_시_예외가_발생한다() {
+        Member member = createMember(1L, "시니어");
+        PaymentOrder paymentOrder = createOrder(member, "order_123", 10000, PaymentOrderStatus.PAID);
+        Payment payment = createPayment(member, paymentOrder, "pay_123", "order_123", 10000, PaymentStatus.DONE);
+
+        given(memberUtil.getCurrentMember()).willReturn(member);
+        given(paymentRepository.findByPaymentKeyForUpdate("pay_123")).willReturn(Optional.of(payment));
+
+        assertThatThrownBy(() -> paymentService.cancelPayment("pay_123", new CancelRequest("부분 취소", 3000)))
+                .isInstanceOf(BusinessException.class)
+                .hasFieldOrPropertyWithValue("errorCode", ErrorCode.BAD_REQUEST);
+
+        verify(paymentClient, never()).cancelPayment(any(), any());
     }
 
     @Test
@@ -225,7 +315,7 @@ class PaymentServiceTest {
         Payment payment = createPayment(member, paymentOrder, "pay_123", "order_123", 10000, PaymentStatus.DONE);
 
         given(memberUtil.getCurrentMember()).willReturn(member);
-        given(paymentRepository.findByPaymentKey("pay_123")).willReturn(Optional.of(payment));
+        given(paymentRepository.findByPaymentKeyForUpdate("pay_123")).willReturn(Optional.of(payment));
 
         assertThatThrownBy(() -> paymentService.cancelPayment("pay_123", null))
                 .isInstanceOf(BusinessException.class)
@@ -312,7 +402,7 @@ class PaymentServiceTest {
         PaymentConfirmResponse canceledResponse = createResponse("pay_123", "order_123", 10000, PaymentStatus.CANCELED);
 
         given(memberUtil.getCurrentMember()).willReturn(member);
-        given(paymentRepository.findByPaymentKey("pay_123")).willReturn(Optional.of(payment));
+        given(paymentRepository.findByPaymentKeyForUpdate("pay_123")).willReturn(Optional.of(payment));
         given(paymentClient.cancelPayment("pay_123", new CancelRequest("사용자 요청", 10000))).willReturn(canceledResponse);
         org.mockito.BDDMockito.willThrow(new BusinessException(ErrorCode.POINT_CONCURRENT_UPDATE))
                 .given(seniorProfileService)
@@ -334,7 +424,7 @@ class PaymentServiceTest {
         Payment payment = createPayment(member, paymentOrder, "pay_123", "order_123", 10000, PaymentStatus.DONE);
 
         given(memberUtil.getCurrentMember()).willReturn(member);
-        given(paymentRepository.findByPaymentKey("pay_123")).willReturn(Optional.of(payment));
+        given(paymentRepository.findByPaymentKeyForUpdate("pay_123")).willReturn(Optional.of(payment));
         given(paymentClient.cancelPayment("pay_123", new CancelRequest("사용자 요청", 10000)))
                 .willThrow(new IllegalStateException("PG timeout"));
 

--- a/backend/widyu-api/src/test/java/com/widyu/pay/integration/PaymentIntegrationTest.java
+++ b/backend/widyu-api/src/test/java/com/widyu/pay/integration/PaymentIntegrationTest.java
@@ -3,6 +3,8 @@ package com.widyu.pay.integration;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 
 import com.widyu.auth.application.SmsService;
 import com.widyu.auth.repository.RefreshTokenRepository;
@@ -139,7 +141,7 @@ class PaymentIntegrationTest {
         ));
         paymentService.confirmPayment(new PaymentApproveRequest(orderResponse.orderId(), "pay_654321"));
         given(memberUtil.getCurrentMember()).willReturn(reloadCurrentMember(currentMember.getId()));
-        given(paymentClient.cancelPayment("pay_654321", new CancelRequest("부분 취소", 3000)))
+        given(paymentClient.cancelPayment("pay_654321", new CancelRequest("부분 취소", 3000, "cancel-request-1")))
                 .willReturn(createGatewayResponse(
                         "pay_654321",
                         orderResponse.orderId(),
@@ -148,7 +150,7 @@ class PaymentIntegrationTest {
                 ));
         PaymentConfirmResponse cancelResponse = paymentService.cancelPayment(
                 "pay_654321",
-                new CancelRequest("부분 취소", 3000)
+                new CancelRequest("부분 취소", 3000, "cancel-request-1")
         );
 
         Payment payment = paymentRepository.findByPaymentKey("pay_654321").orElseThrow();
@@ -167,6 +169,49 @@ class PaymentIntegrationTest {
         assertThat(pointHistories.get(0).getType()).isEqualTo(PointHistoryType.USE);
         assertThat(pointHistories.get(0).getAmount()).isEqualTo(3000L);
         assertThat(pointHistories.get(0).getDescription()).isEqualTo("부분 취소");
+    }
+
+    @Test
+    @DisplayName("같은 멱등 키로 부분 취소를 재요청하면 취소와 포인트 환수가 한 번만 반영된다")
+    void 동일_멱등_키_부분_취소_재요청_통합() {
+        Member currentMember = createSeniorMember("김영희", "01099998887", "FAM003", "INV0033");
+        given(memberUtil.getCurrentMember()).willReturn(currentMember, currentMember);
+
+        PaymentOrderResponse orderResponse = paymentService.createOrder(new PaymentOrderCreateRequest("POINT_10000"));
+        given(paymentClient.confirmPayment(any())).willReturn(createGatewayResponse(
+                "pay_777777",
+                orderResponse.orderId(),
+                "포인트 충전 10,000원",
+                PaymentStatus.DONE
+        ));
+        paymentService.confirmPayment(new PaymentApproveRequest(orderResponse.orderId(), "pay_777777"));
+
+        CancelRequest cancelRequest = new CancelRequest("부분 취소", 3000, "cancel-request-duplicate");
+        given(memberUtil.getCurrentMember()).willReturn(
+                reloadCurrentMember(currentMember.getId()),
+                reloadCurrentMember(currentMember.getId())
+        );
+        given(paymentClient.cancelPayment("pay_777777", cancelRequest)).willReturn(createGatewayResponse(
+                "pay_777777",
+                orderResponse.orderId(),
+                "포인트 충전 10,000원",
+                PaymentStatus.PARTIAL_CANCELED
+        ));
+
+        paymentService.cancelPayment("pay_777777", cancelRequest);
+        PaymentConfirmResponse duplicatedResponse = paymentService.cancelPayment("pay_777777", cancelRequest);
+
+        Payment payment = paymentRepository.findByPaymentKey("pay_777777").orElseThrow();
+        SeniorProfile seniorProfile = seniorProfileRepository.findByMemberId(currentMember.getId()).orElseThrow();
+        List<com.widyu.member.PointHistory> pointHistories =
+                pointHistoryRepository.findAllBySeniorProfileIdOrderByCreatedAtDesc(seniorProfile.getId());
+
+        assertThat(duplicatedResponse.getStatus()).isEqualTo(PaymentStatus.PARTIAL_CANCELED);
+        assertThat(duplicatedResponse.getCancellations()).hasSize(1);
+        assertThat(payment.getCanceledAmount()).isEqualTo(3000);
+        assertThat(seniorProfile.getPoints()).isEqualTo(7100L);
+        assertThat(pointHistories).hasSize(2);
+        verify(paymentClient, times(1)).cancelPayment("pay_777777", cancelRequest);
     }
 
     private Member createSeniorMember(String name, String phoneNumber, String familyCode, String inviteCode) {

--- a/backend/widyu-domain/src/main/java/com/widyu/pay/PaymentCancel.java
+++ b/backend/widyu-domain/src/main/java/com/widyu/pay/PaymentCancel.java
@@ -10,6 +10,7 @@ import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
 import java.time.ZonedDateTime;
 import lombok.AccessLevel;
 import lombok.Builder;
@@ -19,7 +20,13 @@ import lombok.NoArgsConstructor;
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-@Table(name = "payment_cancel")
+@Table(
+        name = "payment_cancel",
+        uniqueConstraints = @UniqueConstraint(
+                name = "uk_payment_cancel_payment_idempotency_key",
+                columnNames = {"payment_id", "idempotency_key"}
+        )
+)
 public class PaymentCancel extends BaseTimeEntity {
 
     @Id
@@ -42,30 +49,39 @@ public class PaymentCancel extends BaseTimeEntity {
     @Column(name = "requested_by_member_id", nullable = false)
     private Long requestedByMemberId;
 
+    @Column(name = "idempotency_key", length = 100)
+    private String idempotencyKey;
+
     @Column(name = "canceled_at", nullable = false)
     private ZonedDateTime canceledAt;
 
     @Builder(access = AccessLevel.PRIVATE)
     private PaymentCancel(Payment payment, int cancelAmount, int cancelPointAmount, String cancelReason,
-                          Long requestedByMemberId, ZonedDateTime canceledAt) {
+                          Long requestedByMemberId, String idempotencyKey, ZonedDateTime canceledAt) {
         this.payment = payment;
         this.cancelAmount = cancelAmount;
         this.cancelPointAmount = cancelPointAmount;
         this.cancelReason = cancelReason;
         this.requestedByMemberId = requestedByMemberId;
+        this.idempotencyKey = idempotencyKey;
         this.canceledAt = canceledAt;
     }
 
     public static PaymentCancel create(Payment payment, int cancelAmount, int cancelPointAmount, String cancelReason,
-                                       Long requestedByMemberId, ZonedDateTime canceledAt) {
+                                       Long requestedByMemberId, String idempotencyKey, ZonedDateTime canceledAt) {
         return PaymentCancel.builder()
                 .payment(payment)
                 .cancelAmount(cancelAmount)
                 .cancelPointAmount(cancelPointAmount)
                 .cancelReason(cancelReason)
                 .requestedByMemberId(requestedByMemberId)
+                .idempotencyKey(idempotencyKey)
                 .canceledAt(canceledAt)
                 .build();
+    }
+
+    public boolean matchesRequest(String cancelReason, int cancelAmount) {
+        return this.cancelAmount == cancelAmount && this.cancelReason.equals(cancelReason);
     }
 
     void assignPayment(Payment payment) {

--- a/docs/adr/ADR-0012-payment-cancel-idempotency.md
+++ b/docs/adr/ADR-0012-payment-cancel-idempotency.md
@@ -1,0 +1,35 @@
+# ADR-0012: 부분 취소는 클라이언트 멱등 키와 결제 행 잠금으로 직렬화한다
+
+- 상태: Accepted
+- 날짜: 2026-07-25
+
+## 맥락
+
+부분 취소는 PG 환불, `PaymentCancel` 저장, `Payment` 누적 취소 금액 변경, 포인트 환수를 하나의 흐름에서 수행한다. 기존에는 같은 요청의 재전송이나 병렬 요청이 PG 환불과 포인트 환수를 중복 수행할 수 있었다.
+
+## 결정
+
+- 부분 취소 요청은 `idempotencyKey`를 제공한다.
+- `PaymentCancel`에 요청 키를 저장하고 `(payment_id, idempotency_key)` 고유 제약을 둔다.
+- 취소 시작 시 `Payment`를 비관적 쓰기 잠금으로 조회한다. 잠금을 획득한 뒤 같은 키의 취소 이력이 있으면 PG를 다시 호출하지 않고 현재 결제 결과를 반환한다.
+- 같은 키에 금액 또는 사유가 다르면 `BAD_REQUEST`로 거부한다.
+- `idempotencyKey`는 내부 중복 방지용으로만 사용하며 PG 요청 본문에는 전송하지 않는다.
+
+전액 취소는 기존처럼 취소 상태를 반환할 수 있으므로 키를 필수로 만들지 않는다. 단, 같은 결제 행 잠금으로 병렬 전액 취소도 직렬화한다.
+
+## 대안
+
+1. Toss 취소 거래 키만 저장한다: PG 응답 계약에 의존하고 요청 전 중복 호출을 막지 못한다.
+2. `Payment`의 낙관적 락만 사용한다: 커밋 시점 충돌 전에 외부 PG 호출이 중복될 수 있다.
+3. 분산 락을 사용한다: DB 트랜잭션과 별도 일관성 모델·운영 의존성이 필요하다.
+
+## 결과 및 후속 위험
+
+동일 부분 취소 재전송은 안전하게 처리되지만, 잠금을 보유한 채 PG를 호출하므로 PG 지연이 길면 동일 결제의 다른 취소 요청도 대기한다. 이는 중복 환불을 허용하는 것보다 우선한다. 운영 DB에는 아래 마이그레이션이 필요하다.
+
+```sql
+ALTER TABLE payment_cancel ADD COLUMN idempotency_key VARCHAR(100) NULL;
+ALTER TABLE payment_cancel
+    ADD CONSTRAINT uk_payment_cancel_payment_idempotency_key
+    UNIQUE (payment_id, idempotency_key);
+```

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -64,3 +64,4 @@ ADR 커버리지는 100%를 목표로 하지 않는다. 대신 다음 영역은 
 | [ADR-0009](ADR-0009-safe-zone-alert-deduplication.md) | 안전구역 이탈 알림 원자 중복 차단 | Accepted | 2026-07-21 |
 | [ADR-0010](ADR-0010-album-video-failure-compensation.md) | 앨범 영상 처리 실패 보상 삭제 정책 | Accepted | 2026-07-21 |
 | [ADR-0011](ADR-0011-album-notification-side-effect-isolation.md) | 앨범 알림 부수효과 격리 정책 | Accepted | 2026-07-21 |
+| [ADR-0012](ADR-0012-payment-cancel-idempotency.md) | 부분 취소 멱등성 및 직렬화 정책 | Accepted | 2026-07-25 |

--- a/docs/lld/LLD-0003-payment-points.md
+++ b/docs/lld/LLD-0003-payment-points.md
@@ -114,11 +114,13 @@ Request:
 ```json
 {
   "cancelReason": "구매 실수",
-  "cancelAmount": 10000
+  "cancelAmount": 10000,
+  "idempotencyKey": "cancel-20260725-0001"
 }
 ```
 - `cancelReason` 미전달 시 "사용자 요청"으로 처리
 - `cancelAmount` 미전달 시 전액 취소
+- 부분 취소는 `idempotencyKey` 필수. 같은 키 재전송은 기존 결과를 반환한다.
 
 ```http
 GET /api/v1/payment/me
@@ -325,12 +327,13 @@ POST {spring.payment.base-url}/{paymentKey}/cancel  → cancelPayment()
 - [x] 부분 취소 시 취소 금액 비례 포인트가 환수된다
 - [x] 전액 취소 시 PaymentOrder.status가 CANCELED로 변경된다
 - [x] 취소에 필요한 포인트가 부족하면 BAD_REQUEST가 반환된다
+- [x] 동일 멱등 키의 부분 취소 재전송은 PG 호출과 포인트 환수를 반복하지 않는다
 - [x] Swagger에 주문·승인·취소·내역 응답이 반영된다
 - [x] `./gradlew :backend:widyu-api:test`가 통과한다
 
 ## 8. 영향 범위 / 마이그레이션
 
-- 기존 구현 완료 상태, 스키마 변경 없음
+- 부분 취소 멱등성을 위해 `payment_cancel.idempotency_key`와 `(payment_id, idempotency_key)` 고유 제약을 추가한다.
 - `PointChargePackage` enum 변경 시 기존 `payment_order.package_id` 데이터 영향 없음 (문자열로 저장)
 - 새 패키지 추가: enum 값 추가만으로 반영 (DB 마이그레이션 불필요)
 
@@ -350,9 +353,18 @@ POST {spring.payment.base-url}/{paymentKey}/cancel  → cancelPayment()
   ALTER TABLE senior_profile ADD COLUMN version BIGINT NOT NULL DEFAULT 0;
   ```
 
+### 부분 취소 멱등 키 도입 (2026-07-25)
+
+```sql
+ALTER TABLE payment_cancel ADD COLUMN idempotency_key VARCHAR(100) NULL;
+ALTER TABLE payment_cancel
+    ADD CONSTRAINT uk_payment_cancel_payment_idempotency_key
+    UNIQUE (payment_id, idempotency_key);
+```
+
 ## 9. 미결정 사항 (Open Questions)
 
-없음. (백필 문서, 구현 완료 상태)
+Toss의 취소 거래 키를 대사·보정 식별자로 별도 보관할지 검토한다.
 
 ## 10. 참고
 

--- a/docs/lld/LLD-0017-payment-partial-cancel-idempotency.md
+++ b/docs/lld/LLD-0017-payment-partial-cancel-idempotency.md
@@ -1,0 +1,50 @@
+# LLD-0017: 부분 취소 멱등성 보장
+
+| 항목 | 값 |
+| --- | --- |
+| 상태 | Approved |
+| 관련 ARCH | ARCH-030 |
+| 관련 ADR | ADR-0012 |
+| 작성일 | 2026-07-25 |
+
+## 1. 목적
+
+같은 부분 취소 요청의 재전송 또는 병렬 실행이 PG 환불, 취소 이력, 포인트 환수를 중복 처리하지 않도록 한다.
+
+## 2. API 및 데이터 모델
+
+`POST /api/v1/payment/{paymentKey}/cancel`의 부분 취소 본문에 `idempotencyKey`를 추가한다.
+
+```json
+{
+  "cancelReason": "구매 실수",
+  "cancelAmount": 3000,
+  "idempotencyKey": "cancel-20260725-0001"
+}
+```
+
+- 부분 취소(`cancelAmount < 남은 금액`)는 `idempotencyKey`가 필수다.
+- 키는 최대 100자이며 서버 DB에만 저장한다. Toss PG 요청에는 전달하지 않는다.
+- `payment_cancel.idempotency_key`를 추가하고 `(payment_id, idempotency_key)`에 고유 제약을 둔다. NULL은 전액 취소의 하위 호환성을 위해 허용한다.
+
+## 3. 처리 흐름
+
+1. `PaymentRepository.findByPaymentKeyForUpdate()`로 결제 행을 `PESSIMISTIC_WRITE` 잠금으로 조회한다.
+2. 요청 키가 있고 같은 `PaymentCancel`이 있으면 금액·사유 일치 여부를 검증한다.
+   - 일치: PG 호출·포인트 환수 없이 현재 `PaymentConfirmResponse`를 반환한다.
+   - 불일치: `BAD_REQUEST`를 반환한다.
+3. 새 부분 취소인데 키가 없으면 PG 호출 전에 `BAD_REQUEST`를 반환한다.
+4. 기존 취소 흐름대로 잔액·포인트를 검증하고 PG를 호출한다.
+5. 성공하면 취소 이력과 키를 함께 저장하고 결제·포인트 상태를 갱신한다.
+
+## 4. 인수조건
+
+- [x] 부분 취소에 멱등 키가 없으면 PG 호출 전에 거부한다.
+- [x] 동일 키·동일 요청 재전송은 PG 호출과 포인트 환수를 한 번만 수행한다.
+- [x] 동일 키·상이한 요청은 거부한다.
+- [x] 취소 결제 조회는 비관적 쓰기 잠금을 사용한다.
+- [x] `./gradlew :backend:widyu-api:test --tests 'com.widyu.pay.application.PaymentServiceTest' --tests 'com.widyu.pay.integration.PaymentIntegrationTest'`가 통과한다.
+
+## 5. 미결정 사항
+
+Toss의 취소 거래 키를 별도 대사 식별자로 보관할지 여부는 PG 대사·보정 작업 설계에서 결정한다.

--- a/docs/lld/README.md
+++ b/docs/lld/README.md
@@ -65,3 +65,4 @@ LLD가 필요 없는 PR은 PR 본문에 `LLD: N/A - <사유>`를 남긴다.
 | LLD-0014 | FCM 토큰 소유자 변경 처리 | Approved | #428 |
 | LLD-0015 | 결제 PG 호출과 내부 반영 경계 검증 | Approved | #430 |
 | LLD-0016 | 결제 승인 멱등성 보강 | Approved | #433 |
+| LLD-0017 | 부분 취소 멱등성 보장 | Approved | - |


### PR DESCRIPTION
## 개요
부분 취소 요청의 재전송 또는 병렬 실행에서 PG 환불, 취소 이력, 포인트 환수가 중복 처리되지 않도록 멱등성과 동시성 제어를 적용합니다.

## 관련 문서
- LLD: `docs/lld/LLD-0017-payment-partial-cancel-idempotency.md`
- ADR: `docs/adr/ADR-0012-payment-cancel-idempotency.md`

## 관련 이슈
Closes #437

## 변경 사항
- 변경 모듈: widyu-api / widyu-domain
- 부분 취소 요청에 멱등 키를 추가하고 `PaymentCancel`에 저장합니다.
- 동일한 멱등 키의 재요청은 요청 내용 일치 여부를 검증한 뒤 PG 호출과 포인트 환수 없이 기존 결과를 반환합니다.
- 부분 취소에 멱등 키가 없거나 같은 키로 다른 요청이 들어오면 거부합니다.
- 결제 취소 조회에 비관적 쓰기 잠금을 적용합니다.
- 부분 취소 멱등성 및 결제 취소 잠금 관련 테스트를 보강합니다.

## 테스트
- `./gradlew :backend:widyu-api:test --tests 'com.widyu.pay.application.PaymentServiceTest' --tests 'com.widyu.pay.integration.PaymentIntegrationTest'`: 통과
- `./gradlew :backend:widyu-domain:test`: 통과
- `./gradlew compileJava`: 통과

## 체크리스트
- [x] 엔티티 변경 시 `./gradlew compileJava` 실행
- [ ] MySQL ENUM 변경 시 ALTER TABLE 명시
- [x] `@Async` 메서드에 `@Transactional` 확인
- [x] LLD 인수조건 전체 충족

## Open Questions (LLD 미결정 사항)
Toss의 취소 거래 키를 별도 대사 식별자로 보관할지 여부는 PG 대사·보정 작업 설계에서 결정합니다.

## 비고
부분 취소 요청에는 `idempotencyKey`가 필요합니다.