### PR TITLE
docs(album): 영상 벤치마크 문서 경로를 정정합니다

### DIFF
--- a/docs/lld/LLD-0006-album-video-upload-pipeline.md
+++ b/docs/lld/LLD-0006-album-video-upload-pipeline.md
@@ -218,4 +218,4 @@ HTTP 202 이후 async 실패는 클라이언트 요청에 직접 예외로 반�
 - `AlbumVideoProcessingService.java`: `@Async @Transactional` 영상 처리
 - `FFmpegVideoCompressionService.java`: 압축, 길이 추출, 썸네일 생성
 - `Album.java` (widyu-domain): PROCESSING/ACTIVE 상태 전환
-- `apiDocs/video-benchmark-results.md`: 영상 처리 벤치마크
+- `apiDocs/api/album/video-benchmark-results.md`: 영상 처리 벤치마크


### PR DESCRIPTION
## 개요
앨범 영상 업로드 비동기 처리 파이프라인 LLD가 실제 존재하는 영상 처리 벤치마크 문서를 참조하도록 경로를 정정합니다.

## 관련 문서
- LLD: `docs/lld/LLD-0006-album-video-upload-pipeline.md`
- ADR: `docs/adr/ADR-0004-media-upload-strategy.md`

## 관련 이슈
Closes #439

## 변경 사항
- 변경 모듈: docs
- LLD-0006의 영상 처리 벤치마크 참조를 `apiDocs/api/album/video-benchmark-results.md`로 수정합니다.

## 테스트
- 실행하지 않았습니다. 문서 경로만 수정했습니다.

## 체크리스트
- [x] 엔티티 변경 시 `./gradlew compileJava` 실행
- [x] MySQL ENUM 변경 시 ALTER TABLE 명시 여부 확인
- [x] `@Async` 메서드에 `@Transactional` 확인
- [x] LLD 인수조건 전체 충족

## Open Questions (LLD 미결정 사항)
없습니다.

## 비고
배포 영향은 없습니다.