### PR TITLE
feat(home): 보호자 홈 카드에 외출 상태를 제공합니다

### DIFF
--- a/backend/widyu-api/src/main/java/com/widyu/home/application/GuardianHomeService.java
+++ b/backend/widyu-api/src/main/java/com/widyu/home/application/GuardianHomeService.java
@@ -13,6 +13,7 @@ import com.widyu.healthschedule.HealthSchedule;
 import com.widyu.heart.repository.HeartRateResultRepository;
 import com.widyu.home.dto.response.GuardianHomeCardsResponse;
 import com.widyu.home.dto.response.GuardianSeniorListResponse;
+import com.widyu.location.realtime.application.RealtimeLocationService;
 import com.widyu.medicine.MedicationProof;
 import com.widyu.medicine.MedicineSchedule;
 import com.widyu.member.FamilyMembership;
@@ -50,6 +51,7 @@ public class GuardianHomeService {
     private final HealthScheduleRepository healthScheduleRepository;
     private final WalkRepository walkRepository;
     private final HomeAlbumRecommendationService albumRecommendationService;
+    private final RealtimeLocationService realtimeLocationService;
 
     public GuardianHomeCardsResponse getHomeCards(Long memberId) {
         Member guardian = memberUtil.getCurrentMember();
@@ -60,7 +62,8 @@ public class GuardianHomeService {
         Member senior = resolveSenior(memberId, guardian);
         LocalDate today = LocalDate.now();
 
-        return new GuardianHomeCardsResponse(
+        return GuardianHomeCardsResponse.of(
+                realtimeLocationService.getOutingStatus(senior.getId()),
                 getHeartRateInfo(senior),
                 getMedicineInfo(senior, today),
                 getScoredAlbums(senior, today),

--- a/backend/widyu-api/src/main/java/com/widyu/home/dto/response/GuardianHomeCardsResponse.java
+++ b/backend/widyu-api/src/main/java/com/widyu/home/dto/response/GuardianHomeCardsResponse.java
@@ -15,6 +15,9 @@ import java.util.List;
 
 public record GuardianHomeCardsResponse(
 
+        @Schema(description = "외출 여부 (true=외출 중, false=집, null=최근 위치 없음)", example = "true")
+        Boolean isOuting,
+
         @Schema(description = "심박수 · 착용 상태")
         HeartRateInfo heartRate,
 
@@ -33,6 +36,17 @@ public record GuardianHomeCardsResponse(
 
     private static final DateTimeFormatter TIME_FORMATTER = DateTimeFormatter.ofPattern("HH:mm");
     private static final long WEARING_THRESHOLD_SECONDS = 30;
+
+    public static GuardianHomeCardsResponse of(
+            Boolean isOuting,
+            HeartRateInfo heartRate,
+            MedicineInfo medicine,
+            List<AlbumInfo> albums,
+            HealthScheduleInfo healthSchedule,
+            WalkInfo walk
+    ) {
+        return new GuardianHomeCardsResponse(isOuting, heartRate, medicine, albums, healthSchedule, walk);
+    }
 
     public record HeartRateInfo(
             @Schema(description = "워치 착용 여부 (최근 30초 이내 심박 데이터 수신 시 true)", example = "true")
@@ -65,6 +79,7 @@ public record GuardianHomeCardsResponse(
         }
     }
 
+    @Schema(name = "GuardianHomeMedicineInfo")
     public record MedicineInfo(
             @Schema(description = "오늘 총 복용 예정 횟수 (동그라미 개수)", example = "6")
             Integer totalCount,
@@ -103,6 +118,7 @@ public record GuardianHomeCardsResponse(
         }
     }
 
+    @Schema(name = "GuardianHomeHealthScheduleInfo")
     public record HealthScheduleInfo(
             @Schema(description = "건강 일정 ID", example = "3")
             Long scheduleId,

--- a/backend/widyu-api/src/main/java/com/widyu/location/realtime/application/RealtimeLocationService.java
+++ b/backend/widyu-api/src/main/java/com/widyu/location/realtime/application/RealtimeLocationService.java
@@ -18,6 +18,7 @@ import com.widyu.member.Member;
 import com.widyu.member.SeniorProfile;
 import com.widyu.member.repository.FamilyMembershipRepository;
 import com.widyu.member.repository.SeniorProfileRepository;
+import com.widyu.parentlocation.LocationType;
 import com.widyu.parentlocation.ParentLocation;
 import java.time.LocalDateTime;
 import org.springframework.scheduling.annotation.Scheduled;
@@ -167,6 +168,14 @@ public class RealtimeLocationService {
                 .toList();
     }
 
+    public Boolean getOutingStatus(Long memberId) {
+        StayInfo stayInfo = getStayInfo(memberId);
+        if (stayInfo == null) {
+            return null;
+        }
+        return !LocationType.HOME.name().equals(stayInfo.locationType());
+    }
+
     /**
      * 특정 시니어의 마지막 위치 조회 (REST API용)
      * @param memberId 시니어의 Member ID
@@ -185,21 +194,14 @@ public class RealtimeLocationService {
         Member seniorMember = seniorProfile.getMember();
 
         // 체류 시간 및 위치 타입 정보 조회 (memberId 기준)
-        String stayKey = LOCATION_STAY_KEY_PREFIX + memberId;
         LocalDateTime stayStartTime = LocalDateTime.now();
         String locationType = null;
         StayInfo stayInfo = null;
 
-        try {
-            Object stayObj = redisTemplate.opsForValue().get(stayKey);
-            if (stayObj instanceof StayInfo info) {
-                stayInfo = info;
-                stayStartTime = stayInfo.startTime();
-                locationType = stayInfo.locationType();
-            }
-        } catch (Exception e) {
-            log.warn("StayInfo 역직렬화 실패 (stale data) - stayKey: {}, 삭제 후 재생성", stayKey, e);
-            redisTemplate.delete(stayKey);
+        stayInfo = getStayInfo(memberId);
+        if (stayInfo != null) {
+            stayStartTime = stayInfo.startTime();
+            locationType = stayInfo.locationType();
         }
 
         // SeniorLocation(5분 TTL) 우선 조회, 만료 시 StayInfo(24시간 TTL)로 fallback
@@ -230,6 +232,20 @@ public class RealtimeLocationService {
                 locationType,
                 locationName
         );
+    }
+
+    private StayInfo getStayInfo(Long memberId) {
+        String stayKey = LOCATION_STAY_KEY_PREFIX + memberId;
+        try {
+            Object stayObj = redisTemplate.opsForValue().get(stayKey);
+            if (stayObj instanceof StayInfo stayInfo) {
+                return stayInfo;
+            }
+        } catch (Exception e) {
+            log.warn("StayInfo 역직렬화 실패 (stale data) - stayKey: {}, 삭제 후 재생성", stayKey, e);
+            redisTemplate.delete(stayKey);
+        }
+        return null;
     }
 
     /**

--- a/backend/widyu-api/src/test/java/com/widyu/home/GuardianHomeCardsSwaggerSchemaTest.java
+++ b/backend/widyu-api/src/test/java/com/widyu/home/GuardianHomeCardsSwaggerSchemaTest.java
@@ -1,0 +1,27 @@
+package com.widyu.home;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.widyu.home.dto.response.GuardianHomeCardsResponse;
+import io.swagger.v3.core.converter.AnnotatedType;
+import io.swagger.v3.core.converter.ModelConverters;
+import io.swagger.v3.core.converter.ResolvedSchema;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+@DisplayName("보호자 홈 카드 Swagger 스키마 테스트")
+class GuardianHomeCardsSwaggerSchemaTest {
+
+    @Test
+    @DisplayName("보호자 홈의 약 복용과 건강 일정 스키마가 시니어 홈 스키마와 구분된다")
+    void 보호자_홈의_약복용과_건강일정_스키마가_시니어_홈_스키마와_구분된다() {
+        // when
+        ResolvedSchema resolvedSchema = ModelConverters.getInstance().resolveAsResolvedSchema(
+                new AnnotatedType(GuardianHomeCardsResponse.class).resolveAsRef(false)
+        );
+
+        // then
+        assertThat(resolvedSchema.referencedSchemas)
+                .containsKeys("GuardianHomeMedicineInfo", "GuardianHomeHealthScheduleInfo");
+    }
+}

--- a/backend/widyu-api/src/test/java/com/widyu/home/GuardianHomeServiceTest.java
+++ b/backend/widyu-api/src/test/java/com/widyu/home/GuardianHomeServiceTest.java
@@ -18,6 +18,7 @@ import com.widyu.heart.repository.HeartRateResultRepository;
 import com.widyu.home.application.GuardianHomeService;
 import com.widyu.home.application.HomeAlbumRecommendationService;
 import com.widyu.home.dto.response.GuardianHomeCardsResponse;
+import com.widyu.location.realtime.application.RealtimeLocationService;
 import com.widyu.medicine.MedicineSchedule;
 import com.widyu.member.Family;
 import com.widyu.member.FamilyMembership;
@@ -53,6 +54,7 @@ class GuardianHomeServiceTest {
     @Mock private HealthScheduleRepository healthScheduleRepository;
     @Mock private WalkRepository walkRepository;
     @Mock private HomeAlbumRecommendationService albumRecommendationService;
+    @Mock private RealtimeLocationService realtimeLocationService;
 
     @Test
     @DisplayName("시니어가 보호자 홈을 호출하면 403 예외가 발생한다")
@@ -105,12 +107,14 @@ class GuardianHomeServiceTest {
         given(healthScheduleRepository.findByMemberIdAndDate(any(), any(), any())).willReturn(List.of());
         given(walkRepository.findByMemberAndWalkDate(any(), any())).willReturn(Optional.empty());
         given(albumRecommendationService.recommendAlbums(any(), any())).willReturn(List.of());
+        given(realtimeLocationService.getOutingStatus(any())).willReturn(true);
 
         // when
         GuardianHomeCardsResponse response = guardianHomeService.getHomeCards(null);
 
         // then
         assertThat(response.medicine()).isNull();
+        assertThat(response.isOuting()).isTrue();
     }
 
     @Test

--- a/backend/widyu-api/src/test/java/com/widyu/location/realtime/application/RealtimeLocationServiceTest.java
+++ b/backend/widyu-api/src/test/java/com/widyu/location/realtime/application/RealtimeLocationServiceTest.java
@@ -150,6 +150,21 @@ class RealtimeLocationServiceTest {
     }
 
     @Test
+    @DisplayName("집 밖의 체류 위치이면 외출 중으로 반환한다")
+    void 집_밖의_체류위치이면_외출중으로_반환한다() {
+        // given
+        given(redisTemplate.opsForValue()).willReturn(valueOperations);
+        given(valueOperations.get("location:stay:1"))
+                .willReturn(StayInfo.of(37.5, 127.0, null, null));
+
+        // when
+        Boolean isOuting = realtimeLocationService.getOutingStatus(1L);
+
+        // then
+        assertThat(isOuting).isTrue();
+    }
+
+    @Test
     @DisplayName("연결되지 않은 보호자가 이동 경로 조회 시 FORBIDDEN 예외를 던진다")
     void 연결되지_않은_보호자_이동_경로_조회_시_예외가_발생한다() {
         // given


### PR DESCRIPTION
## 개요

보호자 홈 카드 API가 화면에 필요한 외출 여부와 실제 응답 스키마를 제공하도록 수정합니다.

## 관련 문서

- LLD: -
- ADR: -

## 관련 이슈

Closes #452

## 변경 사항

- 변경 모듈: widyu-api
- 최근 위치 체류 정보를 기준으로 보호자 홈 응답에 `isOuting`을 반환합니다.
- 보호자 홈의 약 복용·건강 일정 Swagger 중첩 스키마 이름을 분리합니다.
- 외출 상태와 Swagger 스키마를 단위 테스트로 검증합니다.

## 테스트

- `bash scripts/harness/run-module-tests.sh`: 통과
- `./gradlew :backend:widyu-api:test --tests 'com.widyu.home.GuardianHomeServiceTest' --tests 'com.widyu.location.realtime.application.RealtimeLocationServiceTest' --tests 'com.widyu.home.GuardianHomeCardsSwaggerSchemaTest'`: 통과

## 체크리스트

- [x] 엔티티 변경 없음
- [x] MySQL ENUM 변경 없음
- [x] `@Async` 변경 없음
- [x] 이슈 완료 조건을 충족했습니다.

## Open Questions

없습니다.

## 비고

최근 위치 정보가 없으면 `isOuting`은 `null`을 반환합니다.
