### PR TITLE
fix(album): 비동기 영상 메타데이터 저장 오류를 수정합니다

### DIFF
--- a/backend/widyu-api/src/test/java/com/widyu/album/AlbumVideoProcessingPersistenceTest.java
+++ b/backend/widyu-api/src/test/java/com/widyu/album/AlbumVideoProcessingPersistenceTest.java
@@ -1,0 +1,66 @@
+package com.widyu.album;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import com.widyu.global.config.JpaAuditingConfig;
+import com.widyu.global.entity.Status;
+import com.widyu.member.Member;
+import com.widyu.member.MemberType;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.ActiveProfiles;
+
+@DataJpaTest
+@ActiveProfiles("test")
+@Import(JpaAuditingConfig.class)
+@DisplayName("Album 영상 처리 완료 영속화 테스트")
+class AlbumVideoProcessingPersistenceTest {
+
+    @Autowired private TestEntityManager entityManager;
+    @MockBean private JPAQueryFactory jpaQueryFactory;
+
+    @Test
+    @DisplayName("null 메타데이터 placeholder로 저장된 영상 앨범도 처리 완료할 수 있다")
+    void null_메타데이터_placeholder로_저장된_영상_앨범도_처리_완료할_수_있다() {
+        // given
+        Member member = Member.createMember(MemberType.SENIOR, "시니어", "01011112222");
+        entityManager.persist(member);
+        Album album = Album.createAlbumForProcessing(
+                member, "영상 앨범", List.of(""), nullPlaceholder(), nullPlaceholder());
+        entityManager.persistAndFlush(album);
+        Long albumId = album.getId();
+        entityManager.clear();
+
+        Album processingAlbum = entityManager.find(Album.class, albumId);
+
+        // when
+        processingAlbum.completeVideoProcessing(
+                Map.of(0, "https://cdn/video.mp4"),
+                Map.of(0, "https://cdn/thumb.jpg"),
+                Map.of(0, 10));
+        entityManager.flush();
+        entityManager.clear();
+
+        // then
+        Album completedAlbum = entityManager.find(Album.class, albumId);
+        assertThat(completedAlbum.getStatus()).isEqualTo(Status.ACTIVE);
+        assertThat(completedAlbum.getMediaUrls()).containsExactly("https://cdn/video.mp4");
+        assertThat(completedAlbum.getThumbnailUrls()).containsExactly("https://cdn/thumb.jpg");
+        assertThat(completedAlbum.getDurations()).containsExactly(10);
+    }
+
+    private <T> List<T> nullPlaceholder() {
+        List<T> values = new ArrayList<>();
+        values.add(null);
+        return values;
+    }
+}

--- a/backend/widyu-domain/src/main/java/com/widyu/album/Album.java
+++ b/backend/widyu-domain/src/main/java/com/widyu/album/Album.java
@@ -128,16 +128,19 @@ public class Album extends BaseTimeEntity {
     public void completeVideoProcessing(Map<Integer, String> videoUrlsByIndex,
                                         Map<Integer, String> thumbnailUrlsByIndex,
                                         Map<Integer, Integer> durationsByIndex) {
-        for (Map.Entry<Integer, String> entry : videoUrlsByIndex.entrySet()) {
-            this.mediaUrls.set(entry.getKey(), entry.getValue());
-        }
-        for (Map.Entry<Integer, String> entry : thumbnailUrlsByIndex.entrySet()) {
-            this.thumbnailUrls.set(entry.getKey(), entry.getValue());
-        }
-        for (Map.Entry<Integer, Integer> entry : durationsByIndex.entrySet()) {
-            this.durations.set(entry.getKey(), entry.getValue());
-        }
+        replaceValuesByIndex(this.mediaUrls, videoUrlsByIndex);
+        replaceValuesByIndex(this.thumbnailUrls, thumbnailUrlsByIndex);
+        replaceValuesByIndex(this.durations, durationsByIndex);
         this.status = Status.ACTIVE;
+    }
+
+    private <T> void replaceValuesByIndex(List<T> values, Map<Integer, T> valuesByIndex) {
+        for (Map.Entry<Integer, T> entry : valuesByIndex.entrySet()) {
+            while (values.size() <= entry.getKey()) {
+                values.add(null);
+            }
+            values.set(entry.getKey(), entry.getValue());
+        }
     }
 
     public int getPhotoCount() {

--- a/docs/lld/LLD-0006-album-video-upload-pipeline.md
+++ b/docs/lld/LLD-0006-album-video-upload-pipeline.md
@@ -76,7 +76,7 @@ album
 ```
 
 `Album.completeVideoProcessing(videoUrlsByIndex, thumbnailUrlsByIndex, durationsByIndex)`:
-- index별 placeholder를 실제 URL/길이로 교체
+- index별 placeholder를 실제 URL/길이로 교체한다. `@ElementCollection`은 null placeholder를 저장하지 않으므로, 재조회된 컬렉션이 비어 있으면 대상 index까지 확장한 뒤 교체한다.
 - `status = ACTIVE`로 전환
 
 ### Async 작업 DTO


### PR DESCRIPTION
## 개요
LLD-0006의 비동기 영상 처리 완료 단계에서 null placeholder가 저장되지 않아 메타데이터 컬렉션을 갱신하지 못하는 문제를 수정합니다.

## 관련 문서
- LLD: docs/lld/LLD-0006-album-video-upload-pipeline.md
- ADR: docs/adr/ADR-0004-media-upload-strategy.md

## 관련 이슈
Closes #454

## 변경 사항
- 변경 모듈: widyu-api / widyu-domain
- 비어 있는 메타데이터 컬렉션을 대상 index까지 확장한 뒤 영상 URL, 썸네일 URL, 재생 시간을 반영합니다.
- 처리 완료 후 앨범 상태를 ACTIVE로 전환하는 기존 흐름을 유지합니다.

## 테스트
- `./gradlew :backend:widyu-api:test`: 통과했습니다.
- `./gradlew :backend:widyu-domain:test`: 통과했습니다.

## 체크리스트
- [x] 엔티티 변경에 따라 `./gradlew compileJava`을 실행했습니다.
- [x] MySQL ENUM 변경이 없습니다.
- [x] `@Async` 메서드의 `@Transactional`을 유지했습니다.
- [x] LLD 인수조건을 충족했습니다.

## Open Questions (LLD 미결정 사항)
없습니다.

## 비고
DB 스키마와 API 계약 변경이 없습니다.