### PR TITLE
fix(health): 의약품 동기화 배치의 페이지 실패를 재시도합니다

### DIFF
--- a/backend/widyu-api/src/main/java/com/widyu/goal/medicineschedule/scheduler/MedicineSyncScheduler.java
+++ b/backend/widyu-api/src/main/java/com/widyu/goal/medicineschedule/scheduler/MedicineSyncScheduler.java
@@ -11,8 +11,8 @@ import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 
 /**
- * 공공 의약품 API 데이터를 자체 DB에 주기적으로 동기화
- * - 매일 새벽 3시 실행 (트래픽 없는 시간대)
+ * 공공 의약품 API의 신규 데이터를 자체 DB에 주기적으로 보충
+ * - 매월 1일 새벽 3시 실행 (트래픽 없는 시간대)
  * - 100건 단위 청크 처리로 DB 부하 분산
  * - 신규 약품만 INSERT (기존 데이터 스킵)
  */
@@ -23,6 +23,8 @@ public class MedicineSyncScheduler {
 
     private static final int CHUNK_SIZE = 100;
     private static final long API_CALL_DELAY_MS = 300; // 공공 API 부하 방지
+    private static final int MAX_PAGE_ATTEMPTS = 3;
+    private static final long INITIAL_RETRY_DELAY_MS = 1_000;
 
     private final MedicineApiClient medicineApiClient;
     private final ExternalMedicineService externalMedicineService;
@@ -31,37 +33,33 @@ public class MedicineSyncScheduler {
     @Scheduled(cron = "0 0 3 1 * *")
     public void syncMedicineData() {
         log.info("의약품 DB 동기화 시작");
+        int totalSynced = syncMedicinePages();
+        log.info("의약품 DB 동기화 완료 - 총 {}건 처리", totalSynced);
+    }
+
+    int syncMedicinePages() {
         int page = 1;
         int totalSynced = 0;
 
         while (true) {
             try {
-                MedicineApiResponse response = medicineApiClient.fetchAllMedicines(
-                        medicineProperties.api().serviceKey(),
-                        CHUNK_SIZE,
-                        page,
-                        "json"
-                );
-
-                if (response == null || response.body() == null) {
-                    log.warn("의약품 API 응답 없음 - page: {}", page);
+                PageSyncResult pageSyncResult = syncPageWithRetry(page);
+                if (pageSyncResult == null) {
+                    log.error("의약품 동기화 중단 - 재시도 소진 page: {}", page);
                     break;
                 }
 
-                List<MedicineApiResponse.MedicineItem> items = response.body().items() != null
-                        ? response.body().items()
-                        : (response.body().item() != null ? response.body().item() : List.of());
-
-                if (items.isEmpty()) {
+                if (pageSyncResult.fetchedCount() == 0) {
                     log.info("의약품 동기화 완료 - 마지막 페이지: {}", page);
                     break;
                 }
 
-                externalMedicineService.upsertMedicines(items);
-                totalSynced += items.size();
+                totalSynced += pageSyncResult.insertedCount();
                 log.debug("의약품 동기화 진행 중 - page: {}, 누적: {}건", page, totalSynced);
 
-                if (items.size() < CHUNK_SIZE) break; // 마지막 페이지
+                if (pageSyncResult.fetchedCount() < CHUNK_SIZE) {
+                    break;
+                }
 
                 page++;
                 Thread.sleep(API_CALL_DELAY_MS);
@@ -70,12 +68,54 @@ public class MedicineSyncScheduler {
                 Thread.currentThread().interrupt();
                 log.warn("의약품 동기화 인터럽트 - page: {}", page);
                 break;
-            } catch (Exception e) {
-                log.error("의약품 동기화 실패 - page: {}, error: {}", page, e.getMessage(), e);
-                break;
             }
         }
 
-        log.info("의약품 DB 동기화 완료 - 총 {}건 처리", totalSynced);
+        return totalSynced;
+    }
+
+    private PageSyncResult syncPageWithRetry(int page) throws InterruptedException {
+        long retryDelayMs = INITIAL_RETRY_DELAY_MS;
+        for (int attempt = 1; attempt <= MAX_PAGE_ATTEMPTS; attempt++) {
+            try {
+                MedicineApiResponse response = medicineApiClient.fetchAllMedicines(
+                        medicineProperties.api().serviceKey(),
+                        CHUNK_SIZE,
+                        page,
+                        "json"
+                );
+                List<MedicineApiResponse.MedicineItem> items = extractItems(response);
+                if (items.isEmpty()) {
+                    return new PageSyncResult(0, 0);
+                }
+                List<?> saved = externalMedicineService.upsertMedicines(items);
+                return new PageSyncResult(items.size(), saved.size());
+            } catch (Exception e) {
+                log.warn("의약품 동기화 페이지 실패 - page: {}, attempt: {}/{}, error: {}",
+                        page, attempt, MAX_PAGE_ATTEMPTS, e.getMessage());
+                if (attempt == MAX_PAGE_ATTEMPTS) {
+                    break;
+                }
+                Thread.sleep(retryDelayMs);
+                retryDelayMs *= 2;
+            }
+        }
+        return null;
+    }
+
+    private List<MedicineApiResponse.MedicineItem> extractItems(MedicineApiResponse response) {
+        if (response == null || response.body() == null) {
+            throw new IllegalStateException("의약품 API 응답이 비어있습니다.");
+        }
+        if (response.body().items() != null) {
+            return response.body().items();
+        }
+        if (response.body().item() != null) {
+            return response.body().item();
+        }
+        return List.of();
+    }
+
+    private record PageSyncResult(int fetchedCount, int insertedCount) {
     }
 }

--- a/backend/widyu-api/src/test/java/com/widyu/goal/medicineschedule/scheduler/MedicineSyncSchedulerTest.java
+++ b/backend/widyu-api/src/test/java/com/widyu/goal/medicineschedule/scheduler/MedicineSyncSchedulerTest.java
@@ -1,0 +1,105 @@
+package com.widyu.goal.medicineschedule.scheduler;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import com.widyu.global.properties.MedicineProperties;
+import com.widyu.goal.medicineschedule.application.ExternalMedicineService;
+import com.widyu.goal.medicineschedule.client.MedicineApiClient;
+import com.widyu.goal.medicineschedule.dto.external.MedicineApiResponse;
+import com.widyu.medicine.Medicine;
+import java.util.List;
+import java.util.stream.IntStream;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("MedicineSyncScheduler 단위 테스트")
+class MedicineSyncSchedulerTest {
+
+    @Mock private MedicineApiClient medicineApiClient;
+    @Mock private ExternalMedicineService externalMedicineService;
+    @Mock private MedicineProperties medicineProperties;
+
+    @Captor private ArgumentCaptor<List<MedicineApiResponse.MedicineItem>> itemsCaptor;
+
+    @InjectMocks private MedicineSyncScheduler medicineSyncScheduler;
+
+    @Test
+    @DisplayName("페이지 조회가 일시 실패한 후 재시도하면 다음 페이지까지 동기화한다")
+    void 페이지_조회가_일시_실패한_후_재시도하면_다음_페이지까지_동기화한다() {
+        // given
+        given(medicineProperties.api()).willReturn(new MedicineProperties.Api("url", "service-key"));
+        given(medicineApiClient.fetchAllMedicines(anyString(), anyInt(), anyInt(), anyString()))
+                .willThrow(new IllegalStateException("temporary failure"))
+                .willReturn(responseWithItems(100))
+                .willReturn(emptyResponse());
+        given(externalMedicineService.upsertMedicines(org.mockito.ArgumentMatchers.anyList()))
+                .willReturn(savedMedicines(30));
+
+        // when
+        int totalSynced = medicineSyncScheduler.syncMedicinePages();
+
+        // then
+        verify(medicineApiClient, times(2)).fetchAllMedicines("service-key", 100, 1, "json");
+        verify(medicineApiClient).fetchAllMedicines("service-key", 100, 2, "json");
+        verify(externalMedicineService).upsertMedicines(itemsCaptor.capture());
+        assertThat(itemsCaptor.getValue()).hasSize(100);
+        assertThat(totalSynced).isEqualTo(30);
+    }
+
+    @Test
+    @DisplayName("페이지 재시도가 소진되면 이후 동기화를 중단한다")
+    void 페이지_재시도가_소진되면_이후_동기화를_중단한다() {
+        // given
+        given(medicineProperties.api()).willReturn(new MedicineProperties.Api("url", "service-key"));
+        given(medicineApiClient.fetchAllMedicines(anyString(), anyInt(), anyInt(), anyString()))
+                .willThrow(new IllegalStateException("persistent failure"));
+
+        // when
+        int totalSynced = medicineSyncScheduler.syncMedicinePages();
+
+        // then
+        verify(medicineApiClient, times(3)).fetchAllMedicines("service-key", 100, 1, "json");
+        verify(externalMedicineService, never()).upsertMedicines(org.mockito.ArgumentMatchers.anyList());
+        assertThat(totalSynced).isZero();
+    }
+
+    private MedicineApiResponse emptyResponse() {
+        return new MedicineApiResponse(
+                null,
+                new MedicineApiResponse.Body(1, 0, 100, List.of(), null)
+        );
+    }
+
+    private MedicineApiResponse responseWithItems(int count) {
+        List<MedicineApiResponse.MedicineItem> items = IntStream.range(0, count)
+                .mapToObj(index -> new MedicineApiResponse.MedicineItem(
+                        "제조사",
+                        "약품" + index,
+                        "seq-" + index,
+                        null,
+                        null,
+                        null
+                ))
+                .toList();
+        return new MedicineApiResponse(null, new MedicineApiResponse.Body(1, count, 100, items, null));
+    }
+
+    private List<Medicine> savedMedicines(int count) {
+        return IntStream.range(0, count)
+                .mapToObj(index -> org.mockito.Mockito.mock(Medicine.class))
+                .toList();
+    }
+}

--- a/docs/adr/ADR-0006-medicine-search-fallback-fulltext.md
+++ b/docs/adr/ADR-0006-medicine-search-fallback-fulltext.md
@@ -23,7 +23,7 @@
 - 자체 DB 결과가 없을 때만 공공 API `getDrbEasyDrugList`를 호출한다.
 - 외부 API 응답은 `itemSeq` 기준으로 신규 데이터만 저장한다.
 - 공공 API 응답 내부 중복과 동시 저장 경쟁은 `seenSeqs`, 기존 `itemSeq` 조회, `DataIntegrityViolationException` 후 DB 재조회로 흡수한다.
-- 배치 동기화는 100건 단위 청크로 호출하고 호출 사이에 300ms 대기한다.
+- 배치는 매월 1일 03:00에 100건 단위 청크로 신규 데이터를 보충하고 호출 사이에 300ms 대기한다. 페이지 실패는 최대 3회 재시도한다.
 
 성능 기준은 `apiDocs/blog/medicine-api-troubleshooting.md`의 SQL 벤치마크를 따른다.
 수만 건 규모 데이터에서 평균 검색 시간이 `593ms → 111ms`로 줄어든 것을 기준 수치로 기록한다.
@@ -59,6 +59,7 @@
 
 ### 부정 / 트레이드오프
 - 자체 DB 데이터가 최신 공공 API와 일시적으로 다를 수 있다.
+- 배치는 신규 `itemSeq`만 저장하므로 기존 의약품의 수정·삭제는 반영하지 않는 backfill이다.
 - 단일 글자 검색은 FULLTEXT 대신 prefix LIKE를 사용하므로 검색 품질과 성능 특성이 다르다.
 - 동시 신규 검색 시 INSERT 경쟁이 발생할 수 있으며, 현재는 DB 예외 후 재조회로 흡수한다.
 

--- a/docs/lld/LLD-0005-medicine-search-fallback.md
+++ b/docs/lld/LLD-0005-medicine-search-fallback.md
@@ -25,7 +25,7 @@
 - 2글자 이상 FULLTEXT 검색, 1글자 prefix LIKE 검색
 - 외부 공공 API fallback
 - `itemSeq` 기준 중복 제거와 신규 약품 저장
-- 공공 API 데이터 배치 동기화
+- 공공 API 신규 데이터 backfill 배치
 
 ### Out of scope
 - 약품 삭제·수정 동기화 정책
@@ -151,19 +151,23 @@ GET {medicine.api.url}/getDrbEasyDrugList
 
 현재 구현은 INSERT 경쟁을 락으로 막지 않고, DB 제약과 재조회로 흡수한다.
 
-### 5-3. 배치 동기화 (`MedicineSyncScheduler`)
+### 5-3. 월간 신규 데이터 backfill (`MedicineSyncScheduler`)
 
 ```
 @Scheduled(cron = "0 0 3 1 * *")  ← 매월 1일 03:00
   page = 1
   while true:
-    1. fetchAllMedicines(serviceKey, 100, page, "json")
-    2. 응답 없음 또는 items empty → 종료
-    3. externalMedicineService.upsertMedicines(items)
-    4. items.size < 100 → 마지막 페이지로 보고 종료
-    5. page++
-    6. Thread.sleep(300ms)
+    1. fetchAllMedicines(serviceKey, 100, page, "json")와 upsert를 한 페이지 작업으로 처리
+    2. 페이지 실패 시 1초, 2초 간격으로 최대 3회 재시도
+    3. 재시도 소진 → 오류 로그 후 배치 종료
+    4. items empty → 종료
+    5. 실제 신규 INSERT 건수를 totalSynced에 누적
+    6. items.size < 100 → 마지막 페이지로 보고 종료
+    7. page++
+    8. Thread.sleep(300ms)
 ```
+
+기존 `itemSeq`는 갱신·삭제하지 않고 건너뛴다. 따라서 이 배치는 전체 데이터 동기화가 아니라 신규 약품을 보충하는 backfill이다. 사용자가 검색한 신규 약품은 DB miss 시 외부 API fallback으로 즉시 저장된다.
 
 ## 6. 예외 / 에러 처리
 
@@ -173,8 +177,7 @@ GET {medicine.api.url}/getDrbEasyDrugList
 | 외부 API 응답 null/body null | 빈 `medicines` 목록 반환 |
 | 외부 API 호출/파싱 실패 | log.error 후 빈 목록 반환 |
 | `DataIntegrityViolationException` | log.warn 후 FULLTEXT DB 재조회 |
-| 배치 중 API 응답 없음 | log.warn 후 배치 종료 |
-| 배치 중 예외 | log.error 후 배치 종료 |
+| 배치 페이지 API 응답 없음·저장 실패 | 최대 3회 지수 백오프 재시도 후 log.error와 함께 배치 종료 |
 
 ## 7. 인수조건 (Acceptance Criteria)
 
@@ -186,6 +189,7 @@ GET {medicine.api.url}/getDrbEasyDrugList
 - [x] 외부 API 응답 내부 중복 `itemSeq`는 한 번만 저장한다
 - [x] 중복 INSERT 예외 발생 시 DB를 재조회해 정상 응답을 반환한다
 - [x] 배치 동기화는 100건 단위 청크와 300ms 호출 간격을 사용한다
+- [x] 배치 페이지 실패는 최대 3회 재시도하고, 성공 페이지의 신규 INSERT만 누적한다
 - [x] Swagger에 약품 검색 응답이 반영된다
 
 ## 8. 영향 범위 / 마이그레이션


### PR DESCRIPTION
## 개요
의약품 DB 동기화 배치(`MedicineSyncScheduler`)는 페이지 조회·저장 중 예외가 발생하면 재시도 없이 배치 전체를 즉시 중단합니다. 공공 API의 일시적 오류에도 그 달의 신규 약품 보충이 통째로 건너뛰어지는 문제를 LLD-0005 기준으로 페이지 단위 지수 백오프 재시도로 해결합니다.

## 관련 문서
- LLD: docs/lld/LLD-0005-medicine-search-fallback.md
- ADR: docs/adr/ADR-0006-medicine-search-fallback-fulltext.md

## 관련 이슈
Closes #464

## 변경 사항
- 변경 모듈: widyu-api
- 페이지 단위 실패를 지수 백오프(1초 → 2초)로 최대 3회 재시도하고, 재시도 소진 시에만 오류 로그와 함께 배치를 중단합니다.
- 동기화 누적 집계를 조회 건수가 아닌 실제 신규 INSERT 건수(`upsertMedicines` 저장 결과) 기준으로 바꿉니다.
- 페이지 조회·항목 추출·저장을 `syncPageWithRetry`·`extractItems`로 분리해 단일 책임 구조로 정리합니다.
- 배치가 전체 동기화가 아니라 신규 보충 backfill이라는 성격을 ADR-0006·LLD-0005에 명시합니다.
- 재시도 성공·소진 중단·신규 건수 집계에 대한 단위 테스트를 추가합니다.

## 테스트
- `./gradlew :backend:widyu-api:test`: 통과

## 체크리스트
- [x] 엔티티 변경 시 `./gradlew compileJava` 실행 (해당 없음 — 엔티티 변경 없음)
- [x] MySQL ENUM 변경 시 ALTER TABLE 명시 (해당 없음)
- [x] `@Async` 메서드에 `@Transactional` 확인 (해당 없음 — `@Scheduled`만 사용)
- [x] LLD 인수조건 전체 충족

## 리뷰 포인트
재시도 소진 시 다음 페이지로 넘어가지 않고 배치 전체를 중단하는 선택(페이지 순서 보장 우선)이 backfill 성격에 맞는지 확인 부탁드립니다.

## Open Questions (LLD 미결정 사항)
없습니다.

## 비고
- 스키마 변경이 없어 배포 시 별도 작업이 필요하지 않습니다.
- 재시도 소진으로 중단된 달은 다음 달 배치 또는 검색 miss 시 외부 API fallback 저장으로 보충됩니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
