### PR TITLE
개발 서버의 Hibernate SQL 로그를 비활성화합니다

### DIFF
--- a/backend/widyu-api/src/main/resources/application-dev.yml
+++ b/backend/widyu-api/src/main/resources/application-dev.yml
@@ -4,16 +4,14 @@ spring:
       on-profile: "dev"
 
   jpa:
+    show-sql: false
     hibernate:
       ddl-auto: update
-    properties:
-      hibernate:
-        show_sql: true
-        format_sql: true
     open-in-view: false
 
 logging:
   level:
     org.springframework.web: info
-    org.hibernate.SQL: debug
-    org.hibernate.type: trace
+    org.hibernate.SQL: "off"
+    org.hibernate.type: "off"
+    org.hibernate.orm.jdbc.bind: "off"


### PR DESCRIPTION
## 개요
WebSocket과 스케줄러의 내부 조회로 개발 서버 로그가 과도하게 출력되지 않도록 dev 프로필의 Hibernate SQL 출력을 비활성화합니다.

## 관련 문서
- LLD: -
- ADR: -

## 관련 이슈
Closes #471

## 변경 사항
- 변경 모듈: `widyu-api`
- `spring.jpa.show-sql`을 `false`로 명시합니다.
- Hibernate SQL, 타입 및 JDBC 바인딩 로거를 `off`로 명시합니다.
- 일반 Spring Web INFO 로그는 유지합니다.

## 의도적으로 안 한 것
- local/test 프로필의 Hibernate 진단 로그는 변경하지 않습니다.
- API, WebSocket, 스케줄러의 쿼리 실행 동작은 변경하지 않습니다.

## 테스트
- dev YAML 설정값 검증: 통과했습니다.
- `./gradlew :backend:widyu-api:processResources`: 통과했습니다.

## 체크리스트
- [x] 엔티티 및 MySQL ENUM 변경이 없습니다.
- [x] LLD가 필요 없는 단순 프로필 설정 변경입니다.

## 리뷰 포인트
dev 프로필에서만 Hibernate SQL과 바인딩 로그를 명시적으로 끄는 범위가 적절한지 확인 부탁드립니다.

## Open Questions (LLD 미결정 사항)
없습니다.

## 비고
- 적용하려면 개발 서버를 재배포하거나 재시작해야 합니다.
