### PR TITLE
하네스 게이트 결함을 수정합니다 (결제 도메인 검수 누락·중복 검수·루프 리셋·피드백 미전달)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -57,7 +57,11 @@ WIDYU는 시니어(부모)와 보호자(자녀·가족)가 사진·영상을 공
 
 ## AI 하네스 워크플로우
 
-Java 파일 수정 시 `on-file-edit.sh` 훅이 `scripts/harness/validate-java-rules.sh`로 아래 **코드 작성 원칙**을 자동 검사합니다. 작업 순서:
+Java 파일 수정 시 `on-file-edit.sh` 훅이 `scripts/harness/validate-java-rules.sh`로 아래 **코드 작성 원칙**을 자동 검사합니다. 라인 단위 규칙은 HEAD 대비 **추가된 라인만** 봅니다(기존 코드의 위반은 무관한 수정을 막지 않습니다. 파일 전체 검사는 `HARNESS_FULL_FILE=1`).
+
+응답 종료 시에는 `on-stop.sh`가 정적 규칙 → `compileJava` → Codex 시맨틱 검수를 순서대로 실행합니다. 같은 diff는 두 번 검수하지 않고, `auth`·`pay`·`global/security` 변경은 크기와 무관하게 항상 Codex 검수를 거칩니다.
+
+작업 순서:
 
 1. 관련 도메인 문서 확인 (backend/CLAUDE.md → 해당 도메인 섹션)
 2. 변경 계획 + 완료 조건 작성 (어떤 파일·왜, 그리고 "무엇이 되면 done"인지 검증 가능한 성공 기준으로)

--- a/scripts/harness/aggregate-audit.py
+++ b/scripts/harness/aggregate-audit.py
@@ -6,7 +6,7 @@
       --out path  : 출력 파일 경로 (기본 stdout)
 
 지표 (harness-step8-measurement-plan.md §2.5):
-  1. Codex REQUEST_CHANGES율 (+ APPROVE 도달률, 평균 라운드)
+  1. Codex 수정요구(BLOCKER)율 (+ APPROVE 도달률, 평균 라운드)
   2. 정적 규칙 위반율 (java_rule_check 이벤트 기반)
   3. 워크플로 이탈 수 (workflow_risk / operational_code_on_protected_branch 태그)
   4. 파이프라인 단계별 도달률 (pipeline_step 이벤트 — 미수집 시 N/A)
@@ -23,6 +23,10 @@ import sys
 from collections import Counter, defaultdict
 from datetime import datetime, timezone
 from pathlib import Path
+
+# 수정 요구 판정의 verdict 문자열. on-stop.sh 는 BLOCKER 를 기록하고,
+# 3-arm 실험기 로그에는 REQUEST_CHANGES 가 남아 있어 양쪽을 모두 센다.
+_RC_VERDICTS = ("BLOCKER", "REQUEST_CHANGES")
 
 # ---------------------------------------------------------------------------
 # 인수
@@ -93,9 +97,9 @@ total = len(events)
 codex_events = [e for e in events if e.get("event") == "codex_review"]
 n_codex = len(codex_events)
 n_approve = sum(1 for e in codex_events if e.get("verdict") == "APPROVE")
-n_rc = sum(1 for e in codex_events if e.get("verdict") == "REQUEST_CHANGES")
+n_rc = sum(1 for e in codex_events if e.get("verdict") in _RC_VERDICTS)
 n_failed = sum(1 for e in codex_events if e.get("verdict") == "FAILED")
-rounds = [e.get("round", 0) for e in codex_events if e.get("verdict") == "REQUEST_CHANGES"]
+rounds = [e.get("round", 0) for e in codex_events if e.get("verdict") in _RC_VERDICTS]
 avg_round = (sum(rounds) / len(rounds)) if rounds else 0
 # APPROVE 도달률: 세션 중 최종 APPROVE 로 끝난 세션 수 (session_id 기준 마지막 verdict)
 last_verdict: dict[str, str] = {}
@@ -178,7 +182,7 @@ if n_codex == 0:
 else:
     lines.append(f"| 항목 | 값 |")
     lines.append(f"|---|---|")
-    lines.append(f"| REQUEST_CHANGES율 | {pct(rc_rate)} ({n_rc}/{n_codex}) |")
+    lines.append(f"| BLOCKER율 | {pct(rc_rate)} ({n_rc}/{n_codex}) |")
     lines.append(f"| 최종 APPROVE 도달률 | {pct(approve_reach_rate)} |")
     lines.append(f"| RC 평균 라운드 | {avg_round:.1f} |")
     lines.append(f"| FAILED (Codex 실행 실패) | {n_failed}건 |")

--- a/scripts/harness/audit-log.py
+++ b/scripts/harness/audit-log.py
@@ -88,10 +88,20 @@ _BEARER_RE = re.compile(r"(?i)Bearer\s+([A-Za-z0-9\-_.~+/=]{4,})")
 _URL_USERINFO_RE = re.compile(r"(?i)://([^:@/\s]+):([^@\s]{3,})@")
 
 # Step 3: key=value / key: value / key="value" 형태 키워드 매칭
+#
+# 키워드 앞뒤의 이름 조각을 함께 삼켜야 한다. 그러지 않으면 AWS_ACCESS_KEY_ID 처럼
+# suffix 가 붙은 표준 변수명에서 구분자 그룹이 빈 문자열로 매칭되고 값 그룹이 "_ID" 를
+# 먹어, 정작 뒤따르는 실제 키가 그대로 남는다. 구분자도 반드시 존재해야 한다.
+# 키워드는 _ / - 로 구분되는 식별자 토큰 경계에서만 인정한다. 임의 substring 을
+# 허용하면 "tokenizer" 같은 평범한 단어가 걸려 뒤 인자까지 통째로 마스킹된다.
+# 구분자는 반드시 있어야 하되 키·값의 따옴표를 함께 삼켜야 한다.
+# ("KEY": "secret" / KEY="secret" 형태에서 값이 그대로 남으면 안 된다)
 _REDACT_RE = re.compile(
-    r"(?i)(token|secret|password|passwd|authorization|bearer|jwt"
-    r"|credential|api[_\-]?key|db_password|jwt_secret)"
-    r"([=:\s\"']*)"
+    r"(?i)\b((?:[a-z0-9]+[_\-])*"
+    r"(?:token|secret|password|passwd|authorization|bearer|jwt|credential"
+    r"|api[_\-]?key|access[_\-]?key|private[_\-]?key)"
+    r"(?:[_\-][a-z0-9]+)*)"
+    r"([\"']?[ \t]*[=:][ \t]*[\"']?|[ \t]+[\"']?)"
     r"([^\s\"'&]{3,})"
 )
 
@@ -121,9 +131,13 @@ _DANGEROUS = [
     re.compile(r"git\s+restore\b"),
     re.compile(r"git\s+clean\s+\S*f"),
 ]
-# rm -rf 는 위험 경로에 한해 dangerous
+# rm -rf 는 위험 경로에 한해 dangerous.
+# 경로 매칭은 rm 자신의 인자 안으로 제한한다. `.*?` 로 줄 전체를 훑으면
+# `rm -rf tmpdir && git clone .../scripts` 처럼 뒤쪽에 우연히 걸리는 단어까지
+# 위험으로 찍혀 오탐률이 100% 가 된다. 셸 구분자에서 끊는다.
+# 공백은 [ \t] 로 제한한다. \s 는 개행까지 삼켜 다음 줄의 경로를 rm 인자로 오인한다.
 _RM_DANGEROUS_PATH = re.compile(
-    r"rm\s+-[rf]{1,2}\s+.*?(src|\.git|backend|admin|scripts)\b"
+    r"rm[ \t]+-[rf]{1,2}[ \t]+(?:[^\s;&|]+[ \t]+)*[^\s;&|]*(src|\.git|backend|admin|scripts)\b"
 )
 _GIT_WRITE = re.compile(r"\bgit\s+(commit|push|merge)\b")
 _TEST = re.compile(r"gradlew.*test|run-module-tests")

--- a/scripts/harness/audit-log.sh
+++ b/scripts/harness/audit-log.sh
@@ -10,8 +10,10 @@ STATE_DIR="$ROOT/.claude/state"
 
 mkdir -p "$AUDIT_DIR" "$STATE_DIR"
 
-# TTL 청소 — 2시간 경과 상태 파일 삭제 (모든 훅 공통 시작부에서 실행)
-find "$STATE_DIR" -type f -mmin +120 -delete 2>/dev/null || true
+# TTL 청소 — 24시간 경과 상태 파일 삭제 (모든 훅 공통 시작부에서 실행)
+# 2시간이던 시절에는 긴 세션 도중 codex-round 상태가 지워져 무한 루프 방지 카운터와
+# 검수 지문이 함께 리셋됐다. 세션 길이보다 넉넉해야 한다.
+find "$STATE_DIR" -type f -mmin +1440 -delete 2>/dev/null || true
 
 # stdin 을 Python 에 직접 전달 (heredoc escaping 없이)
 python3 "$ROOT/scripts/harness/audit-log.py" "$AUDIT_DIR" "$ROOT" || true

--- a/scripts/harness/codex-review.sh
+++ b/scripts/harness/codex-review.sh
@@ -21,8 +21,23 @@ set -uo pipefail
 ROOT_DIR="$(cd "$(dirname "$0")/../.." && pwd)"
 cd "$ROOT_DIR" || exit 3
 
-CHANGED=$(git status --porcelain --untracked-files=all 2>/dev/null \
-  | sed -E 's/^...//; s/^.* -> //' \
+# on-stop.sh 의 _changed_java 와 동일한 NUL 기반 감지. 줄 파싱을 남겨두면
+# 공백이 든 경로에서 변경을 못 보고 NO_JAVA_CHANGES 로 그냥 승인해 버린다.
+CHANGED=$(git status --porcelain -z --untracked-files=all 2>/dev/null \
+  | python3 -c "
+import sys
+data = sys.stdin.buffer.read().split(b'\0')
+i = 0
+while i < len(data):
+    entry = data[i]
+    i += 1
+    if len(entry) < 4:
+        continue
+    status, path = entry[:2], entry[3:]
+    if b'R' in status or b'C' in status:
+        i += 1
+    sys.stdout.buffer.write(path + b'\n')
+" 2>/dev/null \
   | grep -E '\.java$' \
   | grep -E '^backend/(widyu-api|widyu-domain)/src/main/java/' \
   | grep -vE '/generated/' || true)
@@ -79,8 +94,17 @@ SUGGESTIONS:
 EOF
 
 REPORT_FILE="$(mktemp -t codex-review.XXXXXX)"
-CODEX_BIN="$(command -v codex)"
+CODEX_BIN="$(command -v codex || true)"
 TIMEOUT_BIN="$(command -v timeout || command -v gtimeout || true)"
+
+# codex 미설치 시 빈 문자열로 실행돼 "command not found" 로 흘러가면
+# 원인이 네트워크·인증 실패와 구분되지 않는다. 명시적으로 알린다.
+if [[ -z "$CODEX_BIN" ]]; then
+  echo "CODEX_FAILED"
+  echo "codex 실행 파일을 찾을 수 없습니다 (PATH 확인 필요)."
+  rm -f "$REPORT_FILE"
+  exit 3
+fi
 
 run_codex() {
   if [[ -n "$TIMEOUT_BIN" ]]; then

--- a/scripts/harness/install-hooks.sh
+++ b/scripts/harness/install-hooks.sh
@@ -26,6 +26,15 @@ fi
 
 mkdir -p "$ROOT/.claude"
 
+# .agents/skills 는 Codex 용 경로라 Claude Code 가 자동 탐색하지 않는다.
+# SKILL.md 에 name/description 프론트매터가 이미 있으므로 심링크만 걸면
+# 그대로 슬래시 커맨드로 잡힌다. (CLAUDE.md 문장에만 의존하면 로딩이 확률적이다)
+# settings.json 존재 여부와 무관하게 걸어야 한다 — 아래 조기 종료보다 앞에 둔다.
+if [[ ! -e "$ROOT/.claude/skills" ]]; then
+  ln -s ../.agents/skills "$ROOT/.claude/skills"
+  echo "✅ 스킬 연결: .claude/skills → .agents/skills"
+fi
+
 if [[ -f "$TARGET" && "$FORCE" != "--force" ]]; then
   echo "ℹ️  $TARGET 이미 존재합니다. 덮어쓰려면 --force 옵션을 사용하세요."
   echo "   현재 설정 유지."

--- a/scripts/harness/on-file-edit.sh
+++ b/scripts/harness/on-file-edit.sh
@@ -5,8 +5,23 @@ ROOT_DIR="$(cd "$(dirname "$0")/../.." && pwd)"
 AUDIT_DIR="$ROOT_DIR/.claude/audit"
 
 input=$(cat)
-file_path=$(echo "$input" | python3 -c "import json,sys; d=json.load(sys.stdin); print(d.get('tool_input',{}).get('file_path',''))" 2>/dev/null || true)
-session_id=$(echo "$input" | python3 -c "import json,sys; d=json.load(sys.stdin); print(d.get('session_id',''))" 2>/dev/null || true)
+# 값 2개를 python3 2회 기동으로 뽑던 것을 1회로 합친다.
+# 이 훅은 Edit/Write 마다 실행되고 그중 81%는 java 가 아니라 즉시 종료하므로,
+# 파싱 비용이 그대로 낭비된다.
+# 구분자는 NUL 이어야 한다. 개행으로 나누면 경로에 개행이 든 경우 잘려 나가
+# 규칙 검사가 조용히 건너뛰어진다.
+{
+  IFS= read -r -d '' file_path
+  IFS= read -r -d '' session_id
+} < <(
+  printf '%s' "$input" | python3 -c "
+import json, sys
+d = json.load(sys.stdin)
+out = sys.stdout.buffer
+out.write(d.get('tool_input', {}).get('file_path', '').encode() + b'\0')
+out.write(d.get('session_id', '').encode() + b'\0')
+" 2>/dev/null
+)
 
 # Java 파일이 아니거나 테스트/generated 경로면 스킵
 if [[ "$file_path" != *.java ]]; then exit 0; fi
@@ -14,7 +29,7 @@ if [[ "$file_path" == */test/* ]] || [[ "$file_path" == */generated/* ]]; then e
 if [[ "$file_path" != */main/java/* ]]; then exit 0; fi
 
 # 규칙 검사 실행 (exec 대신 호출 — 종료 코드 캡처 후 audit 기록)
-bash "$(dirname "$0")/validate-java-rules.sh" "$file_path"
+RULE_OUT=$(bash "$(dirname "$0")/validate-java-rules.sh" "$file_path" 2>&1)
 VIOLATIONS_RC=$?
 
 # java_rule_check 이벤트 audit 기록 (violations: 0=통과, 1=위반 존재)
@@ -38,4 +53,11 @@ with open(out, 'a') as f:
     f.write(json.dumps(record, ensure_ascii=False) + '\n')
 " "$AUDIT_DIR" "$session_id" "$file_path" "$VIOLATIONS_RC" 2>/dev/null || true
 
-exit $VIOLATIONS_RC
+# PostToolUse 에서 모델에 피드백이 전달되는 종료 코드는 2 뿐이고, 전달 통로는 stderr 다.
+# 이전에는 stdout + exit 1 이라 101회 발동 중 위반 2건이 모델에 한 번도 닿지 않았다.
+if [[ $VIOLATIONS_RC -ne 0 ]]; then
+  printf '%s\n' "$RULE_OUT" >&2
+  exit 2
+fi
+
+exit 0

--- a/scripts/harness/on-stop.sh
+++ b/scripts/harness/on-stop.sh
@@ -2,20 +2,28 @@
 # Stop hook: Claude 응답 종료 시 Java 변경을 감지하면 3-Tier 검수 → 피드백 루프.
 #
 # 흐름:
-#   Tier 0) uncommitted main-source Java 변경 없음 → 정지 허용 (exit 0)
-#   Tier 1) 정적 규칙 검사 (validate-java-rules.sh, 무료·<1초)
-#            위반 발견 → exit 2 + 위반 리포트 전달 (Codex 호출 없음)
-#   Tier 2) Codex 필요성 게이트
-#            diff<30 LOC & ≤2파일 & 신규 파일 0 & 비민감 경로 → Codex 생략, exit 0
-#   Tier 3) Codex 시맨틱 리뷰
-#            APPROVE  → 정지 허용 (exit 0). SUGGESTIONS는 .claude/suggestions/ 에 저장
-#            BLOCKER  → BLOCKERS만 Claude에 전달 (exit 2). SUGGESTIONS는 저장만
-#            실행 실패 → 경고 후 정지 허용 (fail-open)
+#   Tier 0)   uncommitted main-source Java 변경 없음 → 정지 허용 (exit 0)
+#   Tier 1)   정적 규칙 검사 (validate-java-rules.sh, 무료·<1초)
+#              위반 발견 → exit 2 + 위반 리포트 전달 (Codex 호출 없음)
+#   Tier 1.5) 컴파일 검사 (gradlew compileJava, warm ~7초)
+#              실패 → exit 2 + 컴파일 오류 전달 (Codex 호출 없음)
+#   Tier 2)   Codex 필요성 게이트
+#              diff<30 LOC & ≤2파일 & 신규 파일 0 & 비민감 경로 → Codex 생략, exit 0
+#              직전 검수 이후 diff 무변경 → Codex 생략, exit 0
+#   Tier 3)   Codex 시맨틱 리뷰
+#              APPROVE  → 정지 허용 (exit 0). SUGGESTIONS는 .claude/suggestions/ 에 저장
+#              BLOCKER  → BLOCKERS만 Claude에 전달 (exit 2). SUGGESTIONS는 저장만
+#              실행 실패 → 경고 후 정지 허용 (fail-open)
 #
-# 무한 루프 방지:
-#   static_round  — Tier 1 위반 카운터 (최대 MAX_ROUNDS)
-#   round         — Tier 3 BLOCKER 카운터 (최대 MAX_ROUNDS)
-#   두 카운터 모두 .claude/state/codex-round-<sid>.json 에 세션별 저장
+# 무한 루프 방지 (.claude/state/codex-round-<sid>.json 에 세션별 저장):
+#   static_round        — Tier 1 위반 카운터 (최대 MAX_ROUNDS)
+#   compile_round       — Tier 1.5 실패 카운터 (최대 MAX_ROUNDS)
+#   round               — Tier 3 BLOCKER 카운터 (최대 MAX_ROUNDS)
+#   reviewed_hash       — 검수를 마쳤거나 포기한 diff 지문. 같은 지문은 재검수하지 않는다
+#   static_gave_up_hash — Tier 1 을 포기한 diff 지문. 같은 지문은 다시 막지 않는다
+#
+# 카운터 소진 시 상태 파일을 지우면 다음 정지에서 0부터 다시 세어 루프가 무한해진다.
+# 반드시 지문을 남겨 같은 상태의 재진입을 차단할 것.
 set -uo pipefail
 
 ROOT_DIR="$(cd "$(dirname "$0")/../.." && pwd)"
@@ -126,16 +134,63 @@ json.dump(state, open(path, 'w'))
 
 # ─── Tier 0: Java 변경 감지 ───────────────────────────────────────────────────
 
-CHANGED_JAVA=$(git -C "$ROOT_DIR" status --porcelain --untracked-files=all 2>/dev/null \
-  | sed -E 's/^...//; s/^.* -> //' \
-  | grep -E '\.java$' \
-  | grep -E '^backend/(widyu-api|widyu-domain)/src/main/java/' \
-  | grep -vE '/generated/|\.harness-metrics/' || true)
+# -z 로 NUL 구분 출력을 받는다. 기본 porcelain 은 공백·개행이 든 경로를 따옴표로
+# 감싸고 이스케이프해서, 줄 단위 파싱이 그런 경로를 조용히 빠뜨린다.
+_changed_java() {
+  git -C "$ROOT_DIR" status --porcelain -z --untracked-files=all 2>/dev/null \
+    | python3 -c "
+import sys
+data = sys.stdin.buffer.read().split(b'\0')
+i = 0
+while i < len(data):
+    entry = data[i]
+    i += 1
+    if len(entry) < 4:
+        continue
+    # porcelain 은 항상 XY + 공백 + 경로다. 첫 공백으로 자르면 ' M path' 처럼
+    # X 가 공백인 항목에서 경로가 'M path' 가 된다.
+    status, path = entry[:2], entry[3:]
+    # rename/copy 는 다음 NUL 필드가 원본 경로다. 대상 경로만 쓰고 원본은 건너뛴다.
+    # R/C 는 X(staged)뿐 아니라 Y 자리에도 올 수 있으므로 두 바이트를 모두 본다.
+    if b'R' in status or b'C' in status:
+        i += 1
+    sys.stdout.buffer.write(path + b'\n')
+" 2>/dev/null \
+    | grep -E '\.java$' \
+    | grep -E '^backend/(widyu-api|widyu-domain)/src/main/java/' \
+    | grep -vE '/generated/|\.harness-metrics/' || true
+}
+
+CHANGED_JAVA=$(_changed_java)
 
 if [[ -z "$CHANGED_JAVA" ]]; then
   rm -f "$STATE_FILE"
   exit 0
 fi
+
+# ─── 현재 Java 변경 상태의 지문 ───────────────────────────────────────────────
+#
+# 같은 diff 를 두 번 검수하지 않기 위한 키. 검수를 마쳤거나(APPROVE) 라운드 소진으로
+# 포기한 상태를 이 해시로 기록해 두면, 코드가 실제로 바뀌기 전까지 재검수하지 않는다.
+# untracked 신규 파일은 diff 에 안 잡히므로 내용을 직접 이어 붙인다.
+
+# HEAD 를 반드시 섞는다. 같은 untracked 파일을 들고 브랜치를 옮기면 diff 내용이
+# 같아 해시가 일치하고, 직전 브랜치의 reviewed_hash 로 새 브랜치 검수를 건너뛴다.
+_diff_hash() {
+  {
+    git -C "$ROOT_DIR" rev-parse HEAD 2>/dev/null || echo "no-head"
+    git -C "$ROOT_DIR" diff HEAD -- '*src/main/java*.java'
+    # untracked 신규 파일은 diff 에 안 잡히므로 내용을 직접 이어 붙인다.
+    _changed_java | while IFS= read -r f; do
+      if ! git -C "$ROOT_DIR" ls-files --error-unmatch "$f" >/dev/null 2>&1; then
+        echo "--- $f"
+        cat "$ROOT_DIR/$f" 2>/dev/null
+      fi
+    done
+  } 2>/dev/null | shasum -a 256 | cut -d' ' -f1
+}
+
+DIFF_HASH=$(_diff_hash)
 
 # ─── Tier 1: 정적 규칙 검사 ───────────────────────────────────────────────────
 
@@ -147,37 +202,94 @@ while IFS= read -r f; do
   if [[ $RC -ne 0 ]]; then RULE_REPORT+="$OUT"$'\n'; fi
 done <<< "$CHANGED_JAVA"
 
+STATIC_WAIVED=0
 if [[ -n "$RULE_REPORT" ]]; then
+  # 이 diff 상태에 대해 이미 포기한 적이 있으면 다시 막지 않는다.
+  # (예전에는 포기 시 상태 파일을 지워 카운터가 0으로 돌아갔고, 같은 위반으로 무한 반복됐다)
+  # 단 여기서 종료하면 컴파일·의미 검수까지 함께 사라지므로, 차단만 풀고 아래로 흘려보낸다.
+  if [[ "$(_read_state_field "static_gave_up_hash" "")" == "$DIFF_HASH" ]]; then
+    _audit_event "static_check" "result=violation_waived"
+    echo "⚠️  미해결 규칙 위반이 있습니다(자동 수정 중단됨). 컴파일·의미 검수는 계속합니다." >&2
+    STATIC_WAIVED=1
+  fi
+fi
+
+if [[ -n "$RULE_REPORT" && $STATIC_WAIVED -eq 0 ]]; then
   STATIC_ROUND=$(_read_state_field "static_round")
   STATIC_ROUND=$((STATIC_ROUND + 1))
   _write_state_field "static_round" "$STATIC_ROUND"
   _audit_event "static_check" "result=violation" "round=$STATIC_ROUND"
 
   if [[ $STATIC_ROUND -gt $MAX_ROUNDS ]]; then
-    rm -f "$STATE_FILE"
+    _write_state_field "static_gave_up_hash" "$DIFF_HASH"
+    _write_state_field "static_round" 0
     {
       echo "⚠️  코드 규칙 위반이 ${MAX_ROUNDS}회 반복 미해결. 자동 수정 루프를 중단합니다."
       echo "    아래 항목을 수동으로 확인하세요."
       echo "----- 정적 규칙 위반 -----"
       printf '%s\n' "$RULE_REPORT"
     } >&2
-    exit 0
+    # 여기서 끝내면 이번 정지에서 컴파일·의미 검수가 통째로 사라진다.
+    # 다음 정지가 온다는 보장도 없으므로 차단만 풀고 같은 실행에서 계속 진행한다.
+    STATIC_WAIVED=1
+  else
+    {
+      echo "🔁 코드 규칙 위반 감지 (라운드 ${STATIC_ROUND}/${MAX_ROUNDS}) — 아래 항목을 수정하세요."
+      echo "수정 후 정지 시 다시 자동 검사됩니다."
+      echo "----- 정적 규칙 위반 -----"
+      printf '%s\n' "$RULE_REPORT"
+    } >&2
+    exit 2
   fi
-
-  {
-    echo "🔁 코드 규칙 위반 감지 (라운드 ${STATIC_ROUND}/${MAX_ROUNDS}) — 아래 항목을 수정하세요."
-    echo "수정 후 정지 시 다시 자동 검사됩니다."
-    echo "----- 정적 규칙 위반 -----"
-    printf '%s\n' "$RULE_REPORT"
-  } >&2
-  exit 2
 fi
 
-_audit_event "static_check" "result=pass"
+# 위반을 waive 하고 내려온 경우까지 pass 로 적으면 감사 로그가 자기모순이 된다.
+if [[ -z "$RULE_REPORT" ]]; then
+  _audit_event "static_check" "result=pass"
+fi
 # 통과 시 정적 카운터 리셋 — 같은 세션의 다음 수정 건이 이전 카운트를 이어받지 않게
 if [[ -f "$STATE_FILE" ]]; then
   _write_state_field "static_round" 0
 fi
+
+# ─── Tier 1.5: 컴파일 검사 ────────────────────────────────────────────────────
+#
+# 결정적이고 warm 기준 ~7초. 컴파일도 안 되는 상태로 Codex(최대 480초)를 부르는 건
+# 순수 낭비이므로 여기서 먼저 거른다.
+
+if ! COMPILE_OUT=$("$ROOT_DIR/gradlew" -p "$ROOT_DIR" compileJava --console=plain -q 2>&1); then
+  # 포기한 diff 는 다시 막지 않는다. 카운터만 0으로 되돌리면 다음 정지에서
+  # 같은 실패로 라운드 1부터 또 차단해 루프가 끝나지 않는다.
+  if [[ "$(_read_state_field "compile_gave_up_hash" "")" == "$DIFF_HASH" ]]; then
+    _audit_event "compile_check" "result=fail_waived"
+    echo "⚠️  컴파일 실패가 미해결 상태입니다(자동 수정 중단됨)." >&2
+    exit 0
+  fi
+
+  COMPILE_ROUND=$(_read_state_field "compile_round")
+  COMPILE_ROUND=$((COMPILE_ROUND + 1))
+  _write_state_field "compile_round" "$COMPILE_ROUND"
+  _audit_event "compile_check" "result=fail" "round=$COMPILE_ROUND"
+
+  if [[ $COMPILE_ROUND -gt $MAX_ROUNDS ]]; then
+    _write_state_field "compile_gave_up_hash" "$DIFF_HASH"
+    _write_state_field "compile_round" 0
+    {
+      echo "⚠️  컴파일 실패가 ${MAX_ROUNDS}회 반복 미해결. 자동 수정 루프를 중단합니다."
+      printf '%s\n' "$COMPILE_OUT" | tail -30
+    } >&2
+    exit 0
+  fi
+
+  {
+    echo "🔁 컴파일 실패 (라운드 ${COMPILE_ROUND}/${MAX_ROUNDS}) — 아래 오류를 수정하세요."
+    printf '%s\n' "$COMPILE_OUT" | tail -30
+  } >&2
+  exit 2
+fi
+
+_audit_event "compile_check" "result=pass"
+_write_state_field "compile_round" 0
 
 # ─── Tier 2: Codex 필요성 게이트 ─────────────────────────────────────────────
 
@@ -188,15 +300,30 @@ DIFF_LOC=$(git -C "$ROOT_DIR" diff HEAD --numstat -- '*src/main/java*.java' 2>/d
   | awk '{a+=$1+$2} END{print a+0}')
 FILE_COUNT=$(echo "$CHANGED_JAVA" | grep -c . || true)
 # 신규 파일: untracked(??)와 staged 추가(A) 모두 포착
-NEW_FILES=$(git -C "$ROOT_DIR" status --porcelain --untracked-files=all 2>/dev/null \
-  | grep -cE '^([?][?]|A.|.A) .*src/main/java/.*\.java$' || true)
+# CHANGED_JAVA 와 같은 NUL 기반 목록에서 센다. 여기만 줄 파싱을 남겨두면
+# 공백이 든 경로의 신규 파일이 0개로 잡혀 소규모 변경 게이트로 검수가 새어나간다.
+NEW_FILES=$(echo "$CHANGED_JAVA" | while IFS= read -r f; do
+  [ -n "$f" ] || continue
+  git -C "$ROOT_DIR" ls-files --error-unmatch "$f" >/dev/null 2>&1 || echo "$f"
+done | grep -c . || true)
+# 민감 경로는 실제 패키지명 기준이어야 한다. com.widyu.pay 를 'payment' 로 적으면
+# 결제 도메인 전체가 게이트를 그냥 통과한다.
 SENSITIVE=$(echo "$CHANGED_JAVA" \
-  | grep -cE '/(auth|security|payment|global/security)/' || true)
+  | grep -cE '/com/widyu/(auth|pay)/|/global/security/' || true)
 
 if [[ $DIFF_LOC -lt 30 && $FILE_COUNT -le 2 && $NEW_FILES -eq 0 && $SENSITIVE -eq 0 ]]; then
   echo "✅ 소규모 변경 (${DIFF_LOC} LOC, ${FILE_COUNT}개 파일) — 정적 검사 통과, Codex 생략." >&2
   _audit_event "review_skipped" "reason=small_diff" "diff_loc=$DIFF_LOC" "file_count=$FILE_COUNT"
-  rm -f "$STATE_FILE"
+  _write_state_field "reviewed_hash" "$DIFF_HASH"
+  exit 0
+fi
+
+# 직전 검수 이후 Java 코드가 한 글자도 바뀌지 않았으면 재검수하지 않는다.
+# 워킹트리 diff 는 커밋 전까지 계속 누적되므로, 이 확인이 없으면 같은 diff 를
+# 세션이 끝날 때까지 반복 검수한다 (실측: Codex 호출의 33%가 중복이었다).
+if [[ "$(_read_state_field "reviewed_hash" "")" == "$DIFF_HASH" ]]; then
+  echo "✅ 직전 검수 이후 Java 변경 없음 — Codex 생략." >&2
+  _audit_event "review_skipped" "reason=unchanged_diff" "diff_loc=$DIFF_LOC" "file_count=$FILE_COUNT"
   exit 0
 fi
 
@@ -209,6 +336,32 @@ GATE_MISS=""
 _audit_event "gate_miss" "reason=${GATE_MISS}" "diff_loc=$DIFF_LOC" "file_count=$FILE_COUNT" "new_files=$NEW_FILES" "sensitive=$SENSITIVE"
 
 # ─── Tier 3: Codex 시맨틱 리뷰 ───────────────────────────────────────────────
+
+# 직전 BLOCKER 이후 코드가 그대로면 결과도 같다. 저장해 둔 리포트를 다시 내보내고
+# Codex 는 부르지 않는다. 라운드는 그대로 세어 MAX_ROUNDS 로 종결되게 둔다.
+# (실측: 한 세션에서 688 LOC 짜리 동일 diff 를 연속 3회 재검수한 사례가 있다)
+PREV_BLOCKED_FILE=$(_read_state_field "blocked_file" "")
+if [[ "$(_read_state_field "blocked_hash" "")" == "$DIFF_HASH" && -f "$PREV_BLOCKED_FILE" ]]; then
+  ROUND=$(_read_state_field "round")
+  ROUND=$((ROUND + 1))
+  _write_state_field "round" "$ROUND"
+  _audit_event "review_skipped" "reason=unchanged_after_blocker" "round=$ROUND"
+
+  if [[ $ROUND -gt $MAX_ROUNDS ]]; then
+    _write_state_field "round" 0
+    _write_state_field "reviewed_hash" "$DIFF_HASH"
+    echo "⚠️  코드 변경 없이 ${MAX_ROUNDS}회 반복됐습니다. 자동 검수 루프를 중단합니다." >&2
+    exit 0
+  fi
+
+  {
+    echo "🔁 직전 검수 이후 Java 코드가 바뀌지 않았습니다 (라운드 ${ROUND}/${MAX_ROUNDS})."
+    echo "아래 BLOCKER를 실제로 반영하거나, 반영이 불필요하다면 사용자에게 근거를 설명하세요."
+    echo "----- Codex Review (BLOCKERS) -----"
+    cat "$PREV_BLOCKED_FILE"
+  } >&2
+  exit 2
+fi
 
 echo "🔍 Codex 자동 검수 실행 중... (${DIFF_LOC} LOC, ${FILE_COUNT}개 파일)" >&2
 
@@ -244,6 +397,9 @@ _save_blockers() {
     echo ""
     printf '%s\n' "$body"
   } > "$blocker_file"
+  # 코드가 안 바뀐 채 재정지하면 Codex 를 다시 부르지 않고 이 파일을 재사용한다.
+  _write_state_field "blocked_file" "$blocker_file"
+  _write_state_field "blocked_hash" "$DIFF_HASH"
 }
 
 # codex exec는 프롬프트를 출력에 에코하며, 프롬프트에도 VERDICT:/SUGGESTIONS: 줄이
@@ -258,7 +414,9 @@ SUGGESTION_BODY=$(printf '%s\n' "$FINAL_SECTION" | awk 'found{print} /^SUGGESTIO
 # APPROVE → 라운드 초기화, 정지 허용
 if [[ $RC -eq 0 ]]; then
   _save_suggestions "$SUGGESTION_BODY"
-  rm -f "$STATE_FILE"
+  # 상태 파일을 지우면 같은 diff 를 다음 정지에서 또 검수한다. 지문만 남기고 보존.
+  _write_state_field "round" 0
+  _write_state_field "reviewed_hash" "$DIFF_HASH"
   echo "✅ Codex 검수 통과 (APPROVE)." >&2
   _audit_codex "APPROVE" 0
   exit 0
@@ -280,7 +438,10 @@ _save_suggestions "$SUGGESTION_BODY"
 _save_blockers "$BLOCKER_BODY" "$ROUND"
 
 if [[ $ROUND -gt $MAX_ROUNDS ]]; then
-  rm -f "$STATE_FILE"
+  # 포기도 지문으로 기록한다. 예전에는 상태를 지워 카운터가 0으로 돌아갔고,
+  # 같은 diff 로 라운드 1부터 다시 돌아 한 세션에서 Codex 를 12회까지 호출했다.
+  _write_state_field "round" 0
+  _write_state_field "reviewed_hash" "$DIFF_HASH"
   {
     echo "⚠️  Codex 검수를 ${MAX_ROUNDS}회 반복했으나 여전히 BLOCKER가 있습니다."
     echo "    자동 수정 루프를 중단합니다. 아래 리포트를 수동으로 확인하세요."

--- a/scripts/harness/validate-java-rules.sh
+++ b/scripts/harness/validate-java-rules.sh
@@ -1,6 +1,11 @@
 #!/bin/bash
 # WIDYU 코드 규칙 검사 (CLAUDE.md 기반)
 # 사용법: bash scripts/harness/validate-java-rules.sh <java-file-path>
+#
+# 라인 단위 규칙(1·2·6)은 HEAD 대비 추가된 라인만 검사한다. 파일 전체를 보면
+# 내가 쓰지 않은 기존 위반(현재 518개 중 40개)까지 걸려, 무관한 한 줄 수정에도
+# 정지가 차단된다. 파일 배치 규칙(3·4·5)은 성격상 파일 전체 기준을 유지한다.
+# HARNESS_FULL_FILE=1 이면 기존 방식대로 파일 전체를 검사한다.
 
 FILE="$1"
 if [[ ! -f "$FILE" ]]; then exit 0; fi
@@ -10,6 +15,70 @@ ERRORS=0
 
 echo "[HARNESS] 규칙 검사: ${FILE#*/WIDYU-server/}"
 
+# 추가된 라인 번호 집합. 파일로 넘긴다 — 인자로 넘기면 큰 파일에서 ARG_MAX 를 넘겨
+# awk 가 죽고, 그러면 위반이 하나도 안 잡힌 것처럼 조용히 통과해 버린다.
+ADDED_FILE=$(mktemp -t harness-added.XXXXXX)
+# 삭제 지점까지 포함한 "건드린 라인". 순수 삭제(@@ -19 +18,0 @@)는 추가 라인이 0이라
+# ADDED_FILE 에 아무것도 안 남는다. @Transactional 을 지워 규칙을 깨는 변경이 그렇다.
+TOUCHED_FILE=$(mktemp -t harness-touched.XXXXXX)
+trap 'rm -f "$ADDED_FILE" "$TOUCHED_FILE"' EXIT
+
+if [[ "${HARNESS_FULL_FILE:-0}" != "1" ]]; then
+    HUNKS=$(git diff HEAD -U0 -- "$FILE" 2>/dev/null | grep '^@@' || true)
+    printf '%s\n' "$HUNKS" \
+        | awk '/^@@/ {
+                 match($0, /\+[0-9]+(,[0-9]+)?/)
+                 spec = substr($0, RSTART + 1, RLENGTH - 1)
+                 split(spec, a, ",")
+                 count = (a[2] == "" ? 1 : a[2])
+                 for (i = 0; i < count; i++) print a[1] + i
+               }' > "$ADDED_FILE"
+    # 삭제 앵커는 @Transactional 을 지운 hunk 에만 붙인다. 모든 삭제에 앵커를 달면
+    # 기존 위반 바로 앞의 무관한 주석 한 줄만 지워도 규칙6이 되살아나, 레거시가
+    # 무관한 수정을 막지 않게 하려던 목적 자체가 무너진다.
+    {
+        cat "$ADDED_FILE"
+        git diff HEAD -U0 -- "$FILE" 2>/dev/null \
+            | awk '/^@@/ {
+                     match($0, /\+[0-9]+(,[0-9]+)?/)
+                     spec = substr($0, RSTART + 1, RLENGTH - 1)
+                     split(spec, a, ",")
+                     anchor = a[1]
+                     next
+                   }
+                   /^-[[:space:]]*@Transactional/ { print anchor; print anchor + 1 }'
+    } | sort -un > "$TOUCHED_FILE"
+    # 추적되지 않는 신규 파일은 diff 가 비어 있으므로 전체 라인을 대상으로 한다.
+    if [[ ! -s "$ADDED_FILE" && ! -s "$TOUCHED_FILE" ]] \
+        && ! git ls-files --error-unmatch "$FILE" >/dev/null 2>&1; then
+        awk '{print NR}' "$FILE" | tee "$ADDED_FILE" > "$TOUCHED_FILE"
+    fi
+fi
+
+# grep -n 출력(N:내용)을 추가된 라인만 남기고 거른다.
+filter_added() {
+    if [[ "${HARNESS_FULL_FILE:-0}" == "1" ]]; then cat; return; fi
+    if [[ ! -s "$ADDED_FILE" ]]; then return; fi
+    awk -v af="$ADDED_FILE" '
+        BEGIN { while ((getline l < af) > 0) keep[l] = 1 }
+        { split($0, p, ":"); if (p[1] in keep) print }
+    '
+}
+
+# "시작-끝: 내용" 형식을 구간 안에 추가된 라인이 하나라도 있으면 남긴다.
+# 애노테이션 블록처럼 위반 지점과 변경 지점이 다른 규칙에 쓴다.
+filter_added_range() {
+    if [[ "${HARNESS_FULL_FILE:-0}" == "1" ]]; then cat; return; fi
+    if [[ ! -s "$TOUCHED_FILE" ]]; then return; fi
+    awk -v af="$TOUCHED_FILE" '
+        BEGIN { while ((getline l < af) > 0) keep[l] = 1 }
+        {
+            split($0, p, ":"); split(p[1], r, "-")
+            for (i = r[1]; i <= r[2]; i++) if (i in keep) { print; break }
+        }
+    '
+}
+
 # ──────────────────────────────────────────────
 # 규칙 1: 삼항 연산자 금지
 # ──────────────────────────────────────────────
@@ -18,7 +87,8 @@ TERNARY=$(grep -n ' ? ' "$FILE" \
     | grep -v '^\s*\*' \
     | grep -v '? extends' \
     | grep -v '? super' \
-    | grep -v '".*?.*"')
+    | grep -v '".*?.*"' \
+    | filter_added)
 if [[ -n "$TERNARY" ]]; then
     echo "❌ [규칙1] 삼항 연산자 금지 → if/else 또는 early return으로 변경"
     echo "$TERNARY" | sed 's/^/   /'
@@ -30,7 +100,8 @@ fi
 # ──────────────────────────────────────────────
 if [[ "$BASENAME" == *Service* || "$BASENAME" == *Facade* ]]; then
     DTO_NEW=$(grep -nE 'new [A-Z][a-zA-Z]*(Response|Request|Dto|Res|Req)\(' "$FILE" \
-        | grep -v '^\s*//')
+        | grep -v '^\s*//' \
+        | filter_added)
     if [[ -n "$DTO_NEW" ]]; then
         echo "❌ [규칙2] DTO 직접 생성 금지 → DTO에 from()/of() 팩토리 메서드 추가"
         echo "$DTO_NEW" | sed 's/^/   /'
@@ -72,15 +143,24 @@ fi
 # ──────────────────────────────────────────────
 # 규칙 6: @Async 메서드에 @Transactional 확인
 # ──────────────────────────────────────────────
+# @Async 다음 줄만 보면 @Async→@EventListener→@Transactional 순서를 오탐한다.
+# 메서드 시그니처에 닿을 때까지 애노테이션 블록 전체에서 @Transactional 을 찾는다.
+# 위반은 메서드 선언 라인에 찍히지만 변경은 @Async 를 붙이거나 @Transactional 을
+# 지운 애노테이션 라인에서 일어난다. 블록 전체 구간을 기준으로 걸러야 놓치지 않는다.
 ASYNC_NO_TX=$(awk '
-    /^[[:space:]]*@Async/ { found_async=1; next }
-    found_async && /^[[:space:]]*@/ { if (!/Transactional/) { print NR": "$0" ← @Async인데 @Transactional 없음"; found_async=0 } next }
-    found_async && /^[[:space:]]*(public|protected|private)/ { print NR": "$0" ← @Async인데 @Transactional 없음"; found_async=0 }
-    { found_async=0 }
-' "$FILE")
+    /^[[:space:]]*@Async/ { in_block=1; has_tx=0; start=NR; next }
+    in_block && /^[[:space:]]*@Transactional/ { has_tx=1; next }
+    in_block && /^[[:space:]]*(@|\/\/|\*|$)/ { next }
+    in_block && /^[[:space:]]*(public|protected|private)/ {
+        if (!has_tx) print start"-"NR": "$0" ← @Async인데 @Transactional 없음"
+        in_block=0; next
+    }
+    { in_block=0 }
+' "$FILE" | filter_added_range)
 if [[ -n "$ASYNC_NO_TX" ]]; then
-    echo "⚠️  [규칙6] @Async 메서드에 @Transactional 누락 가능"
+    echo "❌ [규칙6] @Async 메서드에 @Transactional 누락"
     echo "$ASYNC_NO_TX" | sed 's/^/   /'
+    ((ERRORS++))
 fi
 
 # ──────────────────────────────────────────────


### PR DESCRIPTION
## 개요

감사 로그 1,806건과 3-arm 실험 지표 63 run을 집계한 결과, 하네스의 게이트가 설계 의도대로 동작하지 않고 있음을 확인해 수정했습니다. Java 코드 변경은 없고 하네스 훅·집계 스크립트만 다룹니다.

가장 큰 문제는 **결제 도메인이 검수 대상에서 통째로 빠져 있었다는 점**입니다. 민감 경로 정규식이 `payment`로 적혀 있으나 실제 패키지는 `com.widyu.pay`라, 38개 파일이 한 번도 민감 판정을 받은 적이 없었습니다. 지금까지 Codex가 잡은 BLOCKER 21건 중 다수가 결제 도메인의 금액 정합성·멱등성 결함이었는데, 그것들이 걸린 이유는 민감 경로여서가 아니라 diff가 컸기 때문이었습니다.

## 관련 문서

- LLD: -
- ADR: -

## 관련 이슈

Closes #473

## 변경 사항

- 변경 모듈: `scripts/harness` (Java 코드 변경 없음)

**Stop 훅 게이트 (`on-stop.sh`, `codex-review.sh`)**
- 민감 경로를 실제 패키지명 기준(`auth`·`pay`·`global/security`)으로 교정했습니다.
- Java 변경 상태의 sha256 지문을 도입해 같은 diff의 재검수를 막았습니다. Tier 3 진입 30회 중 10회(33%)가 중복이었습니다.
- 라운드 소진 시 상태 파일을 삭제하던 것을 지문 기록으로 바꿨습니다. 삭제는 카운터를 0으로 되돌려, `MAX_ROUNDS=3`인데도 한 세션에서 Codex를 12회 호출한 기록이 있었습니다.
- 컴파일 검사를 Tier 1.5로 추가했습니다(warm 7초). 컴파일 실패 상태에서 최대 480초짜리 Codex를 부르지 않습니다.
- 변경 파일 감지를 `porcelain -z` 기반 NUL 파싱으로 통일했습니다.
- 정적 규칙 라운드 소진 시 종료하던 것을 같은 실행에서 컴파일·의미 검수로 흘려보내도록 했습니다.

**정적 규칙 (`validate-java-rules.sh`, `on-file-edit.sh`)**
- 라인 단위 규칙을 HEAD 대비 추가된 라인 한정으로 바꿨습니다. 기존 위반 37건이 무관한 수정을 막고 있었습니다. 전체 검사는 `HARNESS_FULL_FILE=1`로 켭니다.
- PostToolUse 훅을 `exit 2` + stderr로 교정했습니다. 이전에는 stdout + `exit 1`이라 101회 발동 중 감지한 위반 2건이 모델에 한 번도 전달되지 않았습니다.
- 규칙6이 `@Async` 다음 줄만 보고 판정해 `@Async`→`@EventListener`→`@Transactional` 순서를 오탐했습니다(저장소 기존 경고 2건이 모두 오탐). 애노테이션 블록 전체를 보도록 고치고, `ERRORS`에 반영되지 않아 죽은 코드였던 것을 실제 차단 규칙으로 승격했습니다.
- 추가 라인 번호를 `awk` 인자로 넘기던 것을 임시 파일 전달로 바꿨습니다. `ARG_MAX` 초과 시 위반이 없는 것처럼 조용히 통과했습니다.

**감사 로그·집계 (`audit-log.py`, `audit-log.sh`, `aggregate-audit.py`, `install-hooks.sh`)**
- redaction에 `access_key` 계열을 추가해 AWS 액세스 키 평문 노출을 막았습니다. 키워드를 식별자 토큰 경계로 한정해 과잉 마스킹도 함께 정리했습니다.
- `aggregate-audit.py`가 `REQUEST_CHANGES`만 세는데 현행 훅은 `BLOCKER`를 기록해 지표가 0%로 나왔습니다. 실제 값은 70%입니다.
- `dangerous` 태그 정규식의 `.*?`가 줄 전체를 훑어 기록된 2건이 모두 오탐이었습니다.
- 상태 파일 TTL을 2시간에서 24시간으로 올렸습니다. 긴 세션 도중 루프 방지 카운터가 지워졌습니다.
- `.claude/skills → .agents/skills` 심링크를 설치하도록 했습니다.

## 테스트

Java 코드 변경이 없어 모듈 테스트는 해당 없습니다. 하네스 동작은 아래로 검증했습니다.

- 정적 규칙 532개 파일 회귀: crash 0, 변경분 모드 위반 0, 전체 모드 위반 37건(탐지력 손실 없음)
- redaction·dangerous 태그 17개 케이스: 실패 0 (따옴표·JSON 형식 포함, 과잉 마스킹 없음)
- 규칙 위반 5회 반복: 라운드 1→2→3→포기 후에도 컴파일·Codex 검수가 이어짐, 감사 로그 모순 없음
- 컴파일 실패 5회 반복: 라운드 소진 후 고착, Codex 호출 0회
- BLOCKER 반복 6회(코드 무변경): Codex 호출 6회 → 1회
- `aggregate-audit.py`: BLOCKER율 0.0% → 70.0% (21/30)

실사용 로그에도 효과가 남았습니다. 수정 전에는 결제 변경이 `review_skipped small_diff`로 무검수 통과했고, 수정 후에는 `gate_miss sensitive:2` → Codex 실행 → APPROVE → 다음 정지에서 `unchanged_diff` 생략으로 이어집니다.

## 체크리스트

- [x] 엔티티 변경 시 `./gradlew compileJava` 실행 — 엔티티 변경 없음
- [x] MySQL ENUM 변경 시 ALTER TABLE 명시 — 해당 없음
- [x] `@Async` 메서드에 `@Transactional` 확인 — 규칙6 자체를 수정, 저장소 내 실제 위반 0건 확인
- [x] LLD 인수조건 전체 충족 — 관련 LLD 없음

## 리뷰 포인트

**diff 지문 기반 상태 머신에 검수를 영구히 건너뛰는 경로가 없는지** 봐주시면 좋겠습니다. `reviewed_hash`·`blocked_hash`·`static_gave_up_hash`·`compile_gave_up_hash`·`round` 다섯 개가 얽혀 있어, 중복 검수를 막으려다 반대로 필요한 검수를 놓치는 조합이 생기지 않는지가 핵심입니다.

## Open Questions (LLD 미결정 사항)

없습니다.

## 비고

- 이 PR은 Codex 리뷰를 2회 받았습니다. 1차에서 BLOCKER 8건, 2차에서 10건을 지적받아 모두 반영했습니다. 2차 지적 중 상당수가 1차 수정 과정에서 새로 들어간 결함(따옴표 값 redaction 회귀, 삭제 앵커로 인한 레거시 위반 재발화)이었습니다.
- Codex가 지적한 항목 중 2건은 의도적으로 반영하지 않았습니다. NUL 파싱 후 경로를 개행으로 재출력하는 부분인데, 경로에 **개행**이 들어야 문제가 되고 공백은 이미 처리됩니다. 끝까지 NUL로 보존하려면 소비 체인 전체를 배열로 재구성해야 해서 발생 가능성 대비 변경 폭이 큽니다.
- 실험 지표 CSV(`apiDocs/harness/harness-engineering-metrics.csv`)의 컬럼 시프트 오염 9행과 그 원인인 실험 러너의 콤마 join도 함께 고쳤으나, `apiDocs/`가 `.gitignore` 대상이라 이 PR에는 포함되지 않습니다. 실험 자산 전체가 버전 관리를 받지 않는 점은 별도 논의가 필요합니다.
- 파일 9개로 PR 범위 가이드(3~8개)를 하나 초과하지만, 목적이 "하네스 게이트 결함 수정" 하나로 좁혀져 분리하지 않았습니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **개선 사항**
  - Java 변경 시 정적 규칙 검사와 컴파일 검증이 보다 정확하게 적용됩니다.
  - 공백이 포함된 파일명과 파일 추가·이동·복사 변경을 안정적으로 처리합니다.
  - 코드 검수 결과와 반복 실패 상태를 일관되게 기록하고 재활용합니다.
  - 민감정보 및 위험 명령어 탐지 정확도가 향상되었습니다.
  - 오래된 상태 파일의 정리 기준이 24시간으로 변경되었습니다.
  - 관련 스킬 경로가 없을 경우 자동으로 연결해 개발 환경 설정을 간소화합니다.

- **오류 수정**
  - 필수 검수 도구가 없을 때 명확한 실패 상태와 안내를 제공합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->