### PR TITLE
위험 심박 감지 조회 API를 최근 15분 내 여부만 반환하도록 단순화합니다

### DIFF
--- a/backend/CLAUDE.md
+++ b/backend/CLAUDE.md
@@ -46,7 +46,7 @@
 - **AI 응답 중 `alert`·`level`만 사용**. `reason`(서맥·빈맥 등 사유)·`layer`(L0 고정임계값/L1 개인기준선)·`baseline_source`는 폐기 — 개인화는 `context=REST`에서만 동작
 - REST(`HeartRateController`) + WebSocket(`HeartRateWebSocketController`) 이중 지원
   - 시니어 → `/app/heart-rate/send` / 보호자 구독 `/topic/heart-rate/{memberId}` / ACK `/user/queue/heart-rate/result`
-- **위급 사이클**: 위험 감지 후 5분 유지, 그 안에 재감지되면 마지막 감지 기준 연장. "마지막 감지 + 5분" == "최근 5분 내 감지 존재"이므로 상태를 저장하지 않고 조회 윈도우로만 판정 (`/emergency/recent`)
+- **위급 사이클**: 위험 감지 후 5분 유지, 그 안에 재감지되면 마지막 감지 기준 연장. "마지막 감지 + 5분" == "최근 5분 내 감지 존재"이므로 상태를 저장하지 않고 조회 윈도우로만 판정. **그래프 조회 범위 산정에만 사용**하며, `/emergency/recent`는 사이클과 무관하게 최근 15분 내 기록 유무만 반환
 - **조회 범위 규칙**: 그래프는 응급 화면이므로 events·max·min·firstEmergency가 **진행 중인 사이클 시작 5분 전 ~ 현재**. 사이클 없으면 빈 배열. `emergencyHistory`의 count·events는 전체 기간이지만 `totalDuration`은 현재 사이클 지속 시간(첫 감지~마지막 감지, 분). 갱신(`/graph/refresh`)은 `since` 지정 시 그 이후 신규 이벤트만, 미지정 시 최근 5개
 - 조회 지연은 정상 — 배치 저장 시점에만 갱신됨(워치 배치 주기 + AI 15회 순차 호출)
 - AI: Docker `ryuchanghoon/widyu-ai-ver7:latest` port 5000, multi-arch. → LLD-0010·0019·0020, ADR-0008·0013·0014

--- a/backend/widyu-api/src/main/java/com/widyu/heart/application/HeartRateService.java
+++ b/backend/widyu-api/src/main/java/com/widyu/heart/application/HeartRateService.java
@@ -42,10 +42,13 @@ public class HeartRateService {
 
     /**
      * 위급상황 사이클 유지 시간. 위험이 감지되면 그 시점부터 이 시간만큼 위험 상태를 유지하고,
-     * 그 안에 다시 감지되면 마지막 감지 시각 기준으로 연장된다.
+     * 그 안에 다시 감지되면 마지막 감지 시각 기준으로 연장된다. 그래프 조회 범위를 정하는 데 쓴다.
      * "마지막 감지 + 5분"과 "최근 5분 내 감지 존재"는 동치이므로 사이클 상태를 따로 저장하지 않는다.
      */
     private static final Duration EMERGENCY_CYCLE_WINDOW = Duration.ofMinutes(5);
+
+    /** 위급상황 감지 여부 조회 범위. 사이클과 무관하게 이 구간에 기록이 있으면 감지된 것으로 본다. */
+    private static final Duration RECENT_EMERGENCY_WINDOW = Duration.ofMinutes(15);
 
     private final HeartRateAnomalyDetector heartRateAnomalyDetector;
     private final HeartRatePersistenceService heartRatePersistenceService;
@@ -102,12 +105,9 @@ public class HeartRateService {
 
     @Transactional(readOnly = true)
     public RecentEmergencyResponse getRecentEmergency(Long memberId) {
-        LocalDateTime since = LocalDateTime.now().minus(EMERGENCY_CYCLE_WINDOW);
-        return heartRateEmergencyRepository
-                .findFirstByMemberIdAndMeasuredAtAfterOrderByMeasuredAtDesc(memberId, since)
-                .map(emergency -> RecentEmergencyResponse.from(
-                        emergency, emergency.getMeasuredAt().plus(EMERGENCY_CYCLE_WINDOW)))
-                .orElseGet(RecentEmergencyResponse::notDetected);
+        LocalDateTime since = LocalDateTime.now().minus(RECENT_EMERGENCY_WINDOW);
+        boolean detected = heartRateEmergencyRepository.existsByMemberIdAndMeasuredAtAfter(memberId, since);
+        return RecentEmergencyResponse.of(detected);
     }
 
     @Transactional(readOnly = true)

--- a/backend/widyu-api/src/main/java/com/widyu/heart/controller/docs/HeartRateDocs.java
+++ b/backend/widyu-api/src/main/java/com/widyu/heart/controller/docs/HeartRateDocs.java
@@ -114,20 +114,10 @@ public interface HeartRateDocs {
     );
 
     @Operation(
-            summary = "위험 심박수 감지 여부 (5분 연장 사이클)",
+            summary = "최근 15분 내 위험 심박수 감지 여부",
             description = """
-                    현재 위험 상태인지 조회합니다.
+                    최근 15분 이내에 위급상황(EMERGENCY)으로 기록된 심박수가 있는지 여부만 반환합니다.
                     보호자에게 FCM 긴급 알림이 발송되는 것과 동일한 기준(`alert=true` + `EMERGENCY`)입니다.
-
-                    **판정 방식**: 위험이 감지되면 그 시점부터 5분간 위험 상태를 유지하고,
-                    그 안에 다시 감지되면 **마지막 감지 시각 기준으로 5분 연장**됩니다.
-                    5분 동안 추가 감지가 없으면 사이클이 종료됩니다.
-
-                    예) 0분 0초 감지 → 5분 0초까지 위험. 3분 0초에 재감지 → 8분 0초까지 위험.
-
-                    `cycleExpiresAt`은 현재 사이클이 종료되는 시각입니다.
-                    이 시각까지는 재조회 없이 위험 상태로 표시해도 되며, 그 전에 재감지되면 값이 뒤로 밀립니다.
-                    감지되지 않은 경우 `detected=false`, `emergency=null`, `cycleExpiresAt=null`입니다.
 
                     **접근 권한**:
                     - memberId 미입력 시: 본인 조회
@@ -147,13 +137,7 @@ public interface HeartRateDocs {
                                               "code": "HEART_2006",
                                               "message": "최근 심박수 위험 감지 여부 조회 완료",
                                               "data": {
-                                                "detected": true,
-                                                "emergency": {
-                                                  "heartRate": 178,
-                                                  "measuredAt": "2026-02-01T15:48:00",
-                                                  "location": "서울시 강남구"
-                                                },
-                                                "cycleExpiresAt": "2026-02-01T15:53:00"
+                                                "detected": true
                                               }
                                             }
                                             """
@@ -165,9 +149,7 @@ public interface HeartRateDocs {
                                               "code": "HEART_2006",
                                               "message": "최근 심박수 위험 감지 여부 조회 완료",
                                               "data": {
-                                                "detected": false,
-                                                "emergency": null,
-                                                "cycleExpiresAt": null
+                                                "detected": false
                                               }
                                             }
                                             """

--- a/backend/widyu-api/src/main/java/com/widyu/heart/dto/response/RecentEmergencyResponse.java
+++ b/backend/widyu-api/src/main/java/com/widyu/heart/dto/response/RecentEmergencyResponse.java
@@ -1,18 +1,9 @@
 package com.widyu.heart.dto.response;
 
-import com.widyu.heart.HeartRateEmergency;
-import java.time.LocalDateTime;
-
 public record RecentEmergencyResponse(
-        boolean detected,
-        EmergencyEventResponse emergency, // detected=false 이면 null
-        LocalDateTime cycleExpiresAt // 위험 상태가 유지되는 시각. 그 전에 다시 감지되면 연장된다
+        boolean detected
 ) {
-    public static RecentEmergencyResponse from(HeartRateEmergency emergency, LocalDateTime cycleExpiresAt) {
-        return new RecentEmergencyResponse(true, EmergencyEventResponse.from(emergency), cycleExpiresAt);
-    }
-
-    public static RecentEmergencyResponse notDetected() {
-        return new RecentEmergencyResponse(false, null, null);
+    public static RecentEmergencyResponse of(boolean detected) {
+        return new RecentEmergencyResponse(detected);
     }
 }

--- a/backend/widyu-api/src/main/java/com/widyu/heart/repository/HeartRateEmergencyRepository.java
+++ b/backend/widyu-api/src/main/java/com/widyu/heart/repository/HeartRateEmergencyRepository.java
@@ -14,7 +14,7 @@ public interface HeartRateEmergencyRepository extends JpaRepository<HeartRateEme
 
     Optional<HeartRateEmergency> findFirstByMemberIdAndMeasuredAtAfterOrderByMeasuredAtAsc(Long memberId, LocalDateTime since);
 
-    Optional<HeartRateEmergency> findFirstByMemberIdAndMeasuredAtAfterOrderByMeasuredAtDesc(Long memberId, LocalDateTime since);
+    boolean existsByMemberIdAndMeasuredAtAfter(Long memberId, LocalDateTime since);
 
     long countByMemberId(Long memberId);
     long countByMeasuredAtAfter(LocalDateTime measuredAt);

--- a/backend/widyu-api/src/test/java/com/widyu/heart/application/HeartRateServiceTest.java
+++ b/backend/widyu-api/src/test/java/com/widyu/heart/application/HeartRateServiceTest.java
@@ -399,75 +399,42 @@ class HeartRateServiceTest {
     }
 
     @Test
-    @DisplayName("위험 사이클 안에 위급 기록이 있으면 감지됨과 해당 기록을 반환한다")
-    void 위험사이클_안에_위급기록이_있으면_감지됨을_반환한다() {
+    @DisplayName("최근 15분 내 위급 기록이 있으면 감지됨을 반환한다")
+    void 최근_15분내_위급기록이_있으면_감지됨을_반환한다() {
         // given
         Long memberId = 1L;
-        LocalDateTime measuredAt = LocalDateTime.now().minusMinutes(3);
-        Member member = Member.createMember(MemberType.SENIOR, "시니어", "01012345678");
-        HeartRateEmergency emergency = HeartRateEmergency.of(member, 178, measuredAt, "서울시 강남구");
-
-        given(heartRateEmergencyRepository
-                .findFirstByMemberIdAndMeasuredAtAfterOrderByMeasuredAtDesc(eq(memberId), any()))
-                .willReturn(Optional.of(emergency));
+        given(heartRateEmergencyRepository.existsByMemberIdAndMeasuredAtAfter(eq(memberId), any()))
+                .willReturn(true);
 
         // when
         RecentEmergencyResponse response = heartRateService.getRecentEmergency(memberId);
 
         // then
         assertThat(response.detected()).isTrue();
-        assertThat(response.emergency().heartRate()).isEqualTo(178);
-        assertThat(response.emergency().measuredAt()).isEqualTo(measuredAt);
-        assertThat(response.emergency().location()).isEqualTo("서울시 강남구");
     }
 
     @Test
-    @DisplayName("위험 사이클 만료 시각은 마지막 감지 시각의 5분 뒤로 연장된다")
-    void 위험사이클_만료시각은_마지막_감지시각의_5분뒤다() {
+    @DisplayName("최근 15분 내 위급 기록이 없으면 감지되지 않음을 반환한다")
+    void 최근_15분내_위급기록이_없으면_감지되지_않음을_반환한다() {
         // given
         Long memberId = 1L;
-        LocalDateTime lastDetectedAt = LocalDateTime.now().minusMinutes(2);
-        Member member = Member.createMember(MemberType.SENIOR, "시니어", "01012345678");
-        HeartRateEmergency emergency = HeartRateEmergency.of(member, 180, lastDetectedAt, "서울시 강남구");
-
-        given(heartRateEmergencyRepository
-                .findFirstByMemberIdAndMeasuredAtAfterOrderByMeasuredAtDesc(eq(memberId), any()))
-                .willReturn(Optional.of(emergency));
-
-        // when
-        RecentEmergencyResponse response = heartRateService.getRecentEmergency(memberId);
-
-        // then
-        assertThat(response.cycleExpiresAt()).isEqualTo(lastDetectedAt.plusMinutes(5));
-        assertThat(response.cycleExpiresAt()).isAfter(LocalDateTime.now());
-    }
-
-    @Test
-    @DisplayName("위험 사이클이 종료되었으면 감지되지 않음을 반환한다")
-    void 위험사이클이_종료되었으면_감지되지_않음을_반환한다() {
-        // given
-        Long memberId = 1L;
-        given(heartRateEmergencyRepository
-                .findFirstByMemberIdAndMeasuredAtAfterOrderByMeasuredAtDesc(eq(memberId), any()))
-                .willReturn(Optional.empty());
+        given(heartRateEmergencyRepository.existsByMemberIdAndMeasuredAtAfter(eq(memberId), any()))
+                .willReturn(false);
 
         // when
         RecentEmergencyResponse response = heartRateService.getRecentEmergency(memberId);
 
         // then
         assertThat(response.detected()).isFalse();
-        assertThat(response.emergency()).isNull();
-        assertThat(response.cycleExpiresAt()).isNull();
     }
 
     @Test
-    @DisplayName("위험 사이클 조회는 5분 전을 기준 시각으로 사용한다")
-    void 위험사이클_조회는_5분전을_기준시각으로_사용한다() {
+    @DisplayName("위급 감지 조회는 15분 전을 기준 시각으로 사용한다")
+    void 위급감지_조회는_15분전을_기준시각으로_사용한다() {
         // given
         Long memberId = 1L;
-        given(heartRateEmergencyRepository
-                .findFirstByMemberIdAndMeasuredAtAfterOrderByMeasuredAtDesc(eq(memberId), any()))
-                .willReturn(Optional.empty());
+        given(heartRateEmergencyRepository.existsByMemberIdAndMeasuredAtAfter(eq(memberId), any()))
+                .willReturn(false);
 
         // when
         heartRateService.getRecentEmergency(memberId);
@@ -475,9 +442,9 @@ class HeartRateServiceTest {
         // then
         ArgumentCaptor<LocalDateTime> sinceCaptor = ArgumentCaptor.forClass(LocalDateTime.class);
         then(heartRateEmergencyRepository).should()
-                .findFirstByMemberIdAndMeasuredAtAfterOrderByMeasuredAtDesc(eq(memberId), sinceCaptor.capture());
+                .existsByMemberIdAndMeasuredAtAfter(eq(memberId), sinceCaptor.capture());
         assertThat(sinceCaptor.getValue()).isBetween(
-                LocalDateTime.now().minusMinutes(6), LocalDateTime.now().minusMinutes(4));
+                LocalDateTime.now().minusMinutes(16), LocalDateTime.now().minusMinutes(14));
     }
 
     // TEST-012: 심박 수집 배치 멱등성 검증


### PR DESCRIPTION
## 개요

위험 심박 감지 조회 API(`GET /api/v1/heart-rate/emergency/recent`)의 응답을 `detected` 하나로 줄이고, 판정 범위를 원래 요구사항인 최근 15분 고정 윈도우로 되돌립니다.

보호자 화면에서 필요한 것은 "지금 위험 표시를 띄울지" 여부 하나인데, 응답이 사이클 만료 시각과 위급 기록 상세까지 담고 있어 클라이언트가 다뤄야 할 정보가 많았습니다.

## 관련 문서

- LLD: docs/lld/LLD-0019-heart-rate-personalized-ai-integration.md

신규 LLD는 작성하지 않았습니다. `docs/lld/README.md`의 "단순 조회 endpoint", "DTO 필드 추가처럼 영향 범위가 명확한 작은 변경" 기준에 해당합니다.

## 관련 이슈

Closes #480

## 변경 사항

- 변경 모듈: widyu-api

**응답 단순화**

```diff
- { "detected": true, "emergency": { "heartRate": 178, "measuredAt": "...", "location": "..." }, "cycleExpiresAt": "..." }
+ { "detected": true }
```

- `RecentEmergencyResponse`를 `detected` 한 필드로 줄이고 `emergency`·`cycleExpiresAt`을 제거합니다.
- 최신 위급 기록을 꺼내오던 `findFirstByMemberIdAndMeasuredAtAfterOrderByMeasuredAtDesc`를 `existsByMemberIdAndMeasuredAtAfter`로 교체합니다. 존재 여부만 필요하므로 엔티티를 로드하지 않습니다.

**판정 범위 분리**

`/emergency/recent`는 최근 15분 고정 윈도우로 판정합니다. 5분 연장 사이클은 그래프 조회 범위를 정하기 위해 도입한 개념이므로 그쪽에만 남깁니다.

| 상수 | 값 | 쓰는 곳 |
| --- | --- | --- |
| `RECENT_EMERGENCY_WINDOW` | 15분 고정 | `/emergency/recent` |
| `EMERGENCY_CYCLE_WINDOW` | 5분 연장 사이클 | `/graph`, `/graph/refresh` |

그래프의 사이클 기준 동작(사이클 시작 5분 전 ~ 현재, 사이클 없으면 빈 배열)은 변경되지 않았습니다.

**문서**

- Swagger 설명과 응답 예시를 갱신했습니다.
- `backend/CLAUDE.md`의 심박 조회 규칙에 두 판정이 분리되어 있음을 명시했습니다.

## 테스트

- `./gradlew :backend:widyu-api:test --tests "com.widyu.heart.*"`: 통과 (38건, 0 실패)
- `bash scripts/harness/run-module-tests.sh`: 통과
- `HeartRateServiceTest`의 위험 감지 테스트를 15분 기준으로 교체했습니다.
  - `최근 15분 내 위급 기록이 있으면 감지됨을 반환한다`
  - `최근 15분 내 위급 기록이 없으면 감지되지 않음을 반환한다`
  - `위급 감지 조회는 15분 전을 기준 시각으로 사용한다`
- 그래프의 사이클 기준 테스트 5건은 그대로 통과합니다(사이클 시작 산정·간격 5분 초과 제외·빈 그래프 등).

## 체크리스트

- [x] 엔티티 변경 없음 — `compileJava` 불필요
- [x] MySQL ENUM 변경 없음
- [x] `@Async` 메서드 추가 없음
- [x] LLD 인수조건 전체 충족

## 리뷰 포인트

**위험 감지(15분)와 그래프 범위(5분 사이클)를 다른 기준으로 두는 것이 맞는지** 봐주세요.

위험 표시는 "최근에 한 번이라도 있었나"라 여유 있는 창이 맞고, 그래프는 "지금 진행 중인 상황"을 그리는 화면이라 사이클 구간이 맞다고 판단했습니다. 다만 두 기준이 다르면 `detected=true`인데 그래프가 비어 있는 구간(마지막 감지 후 5~15분)이 생깁니다. 화면 흐름상 문제가 된다면 그래프도 15분으로 통일할 수 있습니다.

## Open Questions

- `context=REST`(L1 경로)에서 위급 상황이 감지되지 않는 원인은 #477에서 확인 중입니다.
- 앱이 실제로 `context`를 전송하는지는 `rawContext` 로그로 관측합니다. dev 로그상 현재는 `[null]`로 미전송이 확인되었습니다.

## 비고

**클라이언트 영향**: 응답 필드가 줄어듭니다. `emergency`·`cycleExpiresAt`을 참조하던 코드가 있다면 수정이 필요합니다. 이 API는 #476에서 추가된 뒤 아직 화면에 연동되지 않은 것으로 파악하고 있습니다.

**폴링 방식**: `cycleExpiresAt`이 없어졌으므로 만료 시각 기반 타이머 대신 원하는 주기로 폴링해 `detected`만 확인하면 됩니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **변경 사항**
  * 최근 위급 심박수 조회가 최근 15분 내 감지 여부만 반환하도록 간소화되었습니다.
  * 응답에서 위급 이벤트 상세 정보와 사이클 만료 시간이 제거되고, 감지 여부만 제공됩니다.
  * 위급 사이클 판정은 기존과 동일하게 최근 5분 기준으로 유지됩니다.
  * 관련 API 문서와 동작 검증이 업데이트되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->