### PR TITLE
[설정] Claude Code 권한 설정을 보완하고 Project 스코프를 팀 공유로 전환합니다

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,4 +1,24 @@
 {
+  "$schema": "https://json.schemastore.org/claude-code-settings.json",
+  "permissions": {
+    "deny": [
+      "Read(./.env)",
+      "Read(./.env.*)",
+      "Read(./**/application-prod.yml)",
+      "Read(./**/application-secret.yml)",
+      "Read(./src/main/resources/firebase/**)",
+      "Read(./**/*.pem)",
+      "Read(./**/*.p8)",
+      "Bash(cat ./.env:*)",
+      "Bash(cat .env:*)"
+    ],
+    "ask": [
+      "Bash(git push:*)",
+      "Bash(git commit:*)",
+      "Bash(gh pr create:*)",
+      "Bash(gh pr merge:*)"
+    ]
+  },
   "hooks": {
     "PostToolUse": [
       {

--- a/.gitignore
+++ b/.gitignore
@@ -47,10 +47,12 @@ out/
 src/main/resources/firebase/
 *.json
 !admin/*.json
-!scripts/harness/settings-template.json
 
 # claude
-.claude/
+# settings.json 은 Project 스코프(팀 공유 권한·훅)라 추적한다.
+# settings.local.json·audit/·state/·worktrees/ 등 나머지는 개인·런타임 산출물이므로 제외.
+.claude/*
+!.claude/settings.json
 apiDocs/
 docs/architecture/
 

--- a/scripts/harness/install-hooks.sh
+++ b/scripts/harness/install-hooks.sh
@@ -1,50 +1,34 @@
 #!/usr/bin/env bash
-# install-hooks.sh — .claude/settings.json 에 harness 훅을 설치한다.
+# install-hooks.sh — Codex 용 .agents/skills 를 Claude Code 가 찾도록 심링크를 건다.
 #
-# 사용: bash scripts/harness/install-hooks.sh [--force]
-#   --force : 기존 settings.json 을 덮어쓴다 (기본은 이미 있으면 건너뜀)
+# 사용: bash scripts/harness/install-hooks.sh
 #
-# 이 PR 에서 추가된 훅 구성:
+# 훅 설정(.claude/settings.json)은 이제 git 으로 추적되므로 복사 단계가 없다.
+# clone·pull 하면 아래 훅이 그대로 적용된다:
 #   PostToolUse(Edit|Write) → on-file-edit.sh + audit-log.sh
 #   PostToolUse(Bash)       → audit-log.sh
 #   Stop                    → on-stop.sh + audit-log.sh
-#
-# .claude/ 는 .gitignore 대상이므로 settings.json 을 직접 추적할 수 없다.
-# 이 스크립트를 실행해 templates/settings-template.json 을 .claude/settings.json 으로 설치한다.
 
 set -euo pipefail
 
 ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
-TEMPLATE="$ROOT/scripts/harness/settings-template.json"
-TARGET="$ROOT/.claude/settings.json"
-FORCE="${1:-}"
-
-if [[ ! -f "$TEMPLATE" ]]; then
-  echo "❌ 템플릿 없음: $TEMPLATE" >&2
-  exit 1
-fi
+SETTINGS="$ROOT/.claude/settings.json"
 
 mkdir -p "$ROOT/.claude"
 
 # .agents/skills 는 Codex 용 경로라 Claude Code 가 자동 탐색하지 않는다.
 # SKILL.md 에 name/description 프론트매터가 이미 있으므로 심링크만 걸면
 # 그대로 슬래시 커맨드로 잡힌다. (CLAUDE.md 문장에만 의존하면 로딩이 확률적이다)
-# settings.json 존재 여부와 무관하게 걸어야 한다 — 아래 조기 종료보다 앞에 둔다.
-if [[ ! -e "$ROOT/.claude/skills" ]]; then
+if [[ -e "$ROOT/.claude/skills" ]]; then
+  echo "ℹ️  스킬 링크 이미 존재: .claude/skills"
+else
   ln -s ../.agents/skills "$ROOT/.claude/skills"
   echo "✅ 스킬 연결: .claude/skills → .agents/skills"
 fi
 
-if [[ -f "$TARGET" && "$FORCE" != "--force" ]]; then
-  echo "ℹ️  $TARGET 이미 존재합니다. 덮어쓰려면 --force 옵션을 사용하세요."
-  echo "   현재 설정 유지."
-  exit 0
+if [[ -f "$SETTINGS" ]]; then
+  echo "✅ 훅 설정 확인: $SETTINGS (git 추적 파일)"
+else
+  echo "❌ $SETTINGS 이 없습니다. develop 최신화 후 다시 실행하세요." >&2
+  exit 1
 fi
-
-cp "$TEMPLATE" "$TARGET"
-echo "✅ 훅 설치 완료: $TARGET"
-echo ""
-echo "   활성화된 훅:"
-echo "   • PostToolUse(Edit|Write) → on-file-edit.sh (규칙 검사) + audit-log.sh"
-echo "   • PostToolUse(Bash)       → audit-log.sh (명령 기록)"
-echo "   • Stop                    → on-stop.sh (Codex 검수) + audit-log.sh"

--- a/scripts/harness/install-hooks.sh
+++ b/scripts/harness/install-hooks.sh
@@ -19,16 +19,50 @@ mkdir -p "$ROOT/.claude"
 # .agents/skills 는 Codex 용 경로라 Claude Code 가 자동 탐색하지 않는다.
 # SKILL.md 에 name/description 프론트매터가 이미 있으므로 심링크만 걸면
 # 그대로 슬래시 커맨드로 잡힌다. (CLAUDE.md 문장에만 의존하면 로딩이 확률적이다)
-if [[ -e "$ROOT/.claude/skills" ]]; then
-  echo "ℹ️  스킬 링크 이미 존재: .claude/skills"
+# -e 로 판정하면 안 된다. 일반 파일·디렉터리에도 참이라 링크가 없는데 "존재"로 보고하고,
+# 반대로 깨진 심링크에는 거짓이라 ln 이 "File exists" 로 죽는다 (set -e 로 스크립트 중단).
+SKILL_LINK="$ROOT/.claude/skills"
+SKILL_TARGET="../.agents/skills"
+
+if [[ -L "$SKILL_LINK" ]]; then
+  CURRENT_TARGET="$(readlink "$SKILL_LINK")"
+  if [[ "$CURRENT_TARGET" == "$SKILL_TARGET" ]]; then
+    echo "✅ 스킬 링크 확인: .claude/skills → $SKILL_TARGET"
+  else
+    echo "❌ .claude/skills 가 다른 대상을 가리킵니다: $CURRENT_TARGET" >&2
+    echo "   기대값: $SKILL_TARGET — 확인 후 직접 지우고 다시 실행하세요." >&2
+    exit 1
+  fi
+elif [[ -e "$SKILL_LINK" ]]; then
+  echo "❌ .claude/skills 가 심링크가 아닌 일반 파일·디렉터리입니다." >&2
+  echo "   내용을 확인한 뒤 옮기거나 지우고 다시 실행하세요." >&2
+  exit 1
 else
-  ln -s ../.agents/skills "$ROOT/.claude/skills"
-  echo "✅ 스킬 연결: .claude/skills → .agents/skills"
+  ln -s "$SKILL_TARGET" "$SKILL_LINK"
+  echo "✅ 스킬 연결: .claude/skills → $SKILL_TARGET"
 fi
 
-if [[ -f "$SETTINGS" ]]; then
+# 존재만 보면 추적되지 않은 옛 로컬 파일을 팀 정책 파일로 잘못 보고한다.
+# 그 상태로 pull 하면 "untracked working tree file would be overwritten" 로 막힌다.
+if git -C "$ROOT" ls-files --error-unmatch -- .claude/settings.json >/dev/null 2>&1; then
   echo "✅ 훅 설정 확인: $SETTINGS (git 추적 파일)"
-else
-  echo "❌ $SETTINGS 이 없습니다. develop 최신화 후 다시 실행하세요." >&2
-  exit 1
+  exit 0
 fi
+
+{
+  echo "❌ .claude/settings.json 이 git 추적 상태가 아닙니다."
+  echo ""
+  if [[ -f "$SETTINGS" ]]; then
+    echo "   예전 install-hooks.sh 가 복사해 둔 로컬 파일로 보입니다. 아래 순서로 전환하세요."
+    echo "     1) 개인 허용 규칙이 있으면 .claude/settings.local.json 으로 옮깁니다"
+    echo "     2) cp .claude/settings.json /tmp/settings.json.bak   # 백업"
+    echo "     3) rm .claude/settings.json"
+    echo "     4) git pull origin develop"
+  else
+    echo "   develop 을 최신화하면 팀 공유 설정이 내려옵니다."
+    echo "     git pull origin develop"
+  fi
+  echo ""
+  echo "   전환 후 이 스크립트를 다시 실행하세요."
+} >&2
+exit 1


### PR DESCRIPTION
## 개요

Claude Code 권한 설정의 두 가지 구멍을 메웁니다.

첫째, 루트 `.env`에 실제 시크릿 51개(`MYSQL_PASSWORD`, `JWT_*_SECRET` 3종, `COOLSMS_API_SECRET`, `OAUTH_NAVER_CLIENT_SECRET` 등)가 있는데 세 스코프 어디에도 deny 규칙이 없었습니다. 반대로 로컬 allow에는 `Bash(cat:*)`·`Bash(grep:*)`가 있어 `cat .env`가 프롬프트 없이 통과하고 출력이 트랜스크립트에 남았습니다. 감사 로그 redaction(#473)으로 출력단은 막았지만 입력단이 열려 있던 상태입니다.

둘째, `.gitignore`가 `.claude/`를 통째로 무시해 Project 스코프 설정을 추적할 수 없었고, 이를 우회하려고 `settings-template.json`을 복사하는 구조를 쓰고 있었습니다. 이 구조는 팀원이 스크립트를 실행해야만 훅이 걸리고, 이미 파일이 있으면 조기 종료라 템플릿 변경이 전파되지 않으며, 같은 내용이 두 파일에 존재해 조용히 어긋납니다.

## 관련 문서
- LLD: - (설정 변경 작업이라 LLD가 없습니다)
- ADR: -
- 참고: `apiDocs/engineering/learning/2-settings.json-세팅하기.pdf` (스코프·우선순위·allow/deny/ask 게이트)

## 관련 이슈
Closes #484

## 변경 사항
- 변경 모듈: 저장소 설정 (`widyu-api`·`widyu-domain` 변경 없습니다)
- `.gitignore`: `.claude/` → `.claude/*` + `!.claude/settings.json`으로 바꿔 Project 설정만 추적합니다. `settings-template.json` 예외 라인을 제거했습니다
- `.claude/settings.json`: git 추적 대상으로 전환하고 `$schema`·`permissions.deny`(9개)·`permissions.ask`(4개)를 추가했습니다. 기존 훅 3종은 그대로입니다
- deny: `.env`, `.env.*`, `application-prod.yml`, `application-secret.yml`, `firebase/**`, `*.pem`, `*.p8`, Bash `cat .env` 경로
- ask: `git push`, `git commit`, `gh pr create`, `gh pr merge`
- `scripts/harness/settings-template.json`: 삭제했습니다 (추적 파일과 내용 중복)
- `scripts/harness/install-hooks.sh`: 복사 로직과 `--force` 옵션을 걷어내고, `.agents/skills` 심링크 생성과 설정 존재 확인만 남겼습니다

## 테스트
- `./gradlew :backend:widyu-api:test`: 실행하지 않았습니다 (Java 코드 변경이 없습니다)
- `./gradlew :backend:widyu-domain:test`: 실행하지 않았습니다 (동일)

권한 규칙은 실제 시크릿을 노출하지 않도록 더미 파일 `.env.verify`로 검증했습니다.

- `Read(.env.verify)` → `File is in a directory that is denied by your permission settings.`
- `cat .env.verify` → `Permission to use Bash with command cat .env.verify has been denied.`
- `git ls-files .claude/` → `settings.json`만 잡히고 `settings.local.json`·`audit/`·`state/`는 잡히지 않습니다
- `bash scripts/harness/install-hooks.sh` → exit 0, 심링크 확인 후 정상 종료합니다
- 두 settings 파일 모두 JSON 파싱 유효합니다

검증에 쓴 더미 파일은 삭제했습니다.

## 체크리스트
- [x] 엔티티 변경 시 `./gradlew compileJava` 실행 — 해당 없습니다
- [x] MySQL ENUM 변경 시 ALTER TABLE 명시 — 해당 없습니다
- [x] `@Async` 메서드에 `@Transactional` 확인 — 해당 없습니다
- [x] LLD 인수조건 전체 충족 — LLD가 없어 이슈 #484의 완료 조건 5개로 대체했으며 전부 충족했습니다

## 리뷰 포인트

**`.claude/settings.json`을 git으로 추적하고 `settings-template.json`을 없애는 방향이 맞는지** 봐주세요. 팀원 머신에 이미 로컬 `.claude/settings.json`이 있으면 pull 시 충돌하므로, 머지 후 "로컬 파일을 한 번 지우고 pull" 공지가 필요합니다. 이 전환 비용이 크다고 보시면 템플릿 삭제만 되돌리고 deny·ask 추가만 남길 수 있습니다.

## Open Questions (LLD 미결정 사항)
- **`Read` deny는 Bash 하위 프로세스에 적용되지 않습니다** (CodeRabbit 지적, `.claude/settings.json:14`). `head .env`·`grep X .env`·`python3 -c "open('.env')"` 는 여전히 통과합니다. 즉 이번 deny는 **실수 방지용 가드**이지 보안 경계가 아닙니다. 근본 해법인 `sandbox.filesystem.denyRead` 도입은 gradle·docker·Codex 검수 전 경로의 회귀 확인이 필요해 이 PR 범위를 넘습니다 → **#488** 로 분리했습니다.
- `Bash(rm:*)` 유지 여부 — 제거하면 임시 파일 정리마다 프롬프트가 발생해 이번에는 **유지**했습니다. 감사 로그에서 dangerous 16건이 잡힌 명령군이라 ask 전환도 선택지입니다.
- `settings.local.json`의 `Bash(git commit:*)` allow가 이번에 추가한 Project ask와 충돌합니다. **Local이 Project보다 우선순위가 높아 allow가 이깁니다.** 커밋을 실제로 확인받으려면 로컬 allow에서 해당 항목을 빼야 하며, 이 PR에서는 건드리지 않았습니다.

## 비고
- 배포 영향은 없습니다. 애플리케이션 코드·인프라 변경이 없습니다.
- `.claude/settings.local.json`(추적하지 않음)에서 `Bash(bash:*)`를 `Bash(bash scripts/:*)`로 축소하고 죽은 규칙 3개(`Bash(for script in ...)`, `Bash(do echo ...)`, `Bash(done)`)를 삭제했습니다. 개인 파일이라 이 PR에는 포함되지 않으며, 팀원 각자 동일한 정리가 필요합니다.
- 후속 작업 후보: `.claude/skills` 심링크까지 추적하면 `install-hooks.sh` 자체가 필요 없어집니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **변경 사항**
  * Claude 설정 파일을 저장소에서 추적하도록 변경했습니다.
  * 설정 파일에 민감한 파일 및 리소스 접근 제한을 추가했습니다.
  * 커밋, 푸시, PR 생성·병합 전 확인 절차를 적용했습니다.
  * 설치 스크립트가 기존 설정을 덮어쓰지 않고, 설정 파일과 스킬 링크 상태를 확인하도록 개선했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
