### PR TITLE
[문서] CLAUDE.md에 Compact instructions를 추가하고 훅 강제 범위를 실제와 일치시킵니다

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -57,7 +57,7 @@ WIDYU는 시니어(부모)와 보호자(자녀·가족)가 사진·영상을 공
 
 ## AI 하네스 워크플로우
 
-Java 파일 수정 시 `on-file-edit.sh` 훅이 `scripts/harness/validate-java-rules.sh`로 아래 **코드 작성 원칙**을 자동 검사합니다. 라인 단위 규칙은 HEAD 대비 **추가된 라인만** 봅니다(기존 코드의 위반은 무관한 수정을 막지 않습니다. 파일 전체 검사는 `HARNESS_FULL_FILE=1`).
+Java 파일 수정 시 `on-file-edit.sh` 훅이 `scripts/harness/validate-java-rules.sh`로 아래 **훅이 차단하는 규칙 6개**를 검사합니다. 라인 단위 규칙은 HEAD 대비 **추가된 라인만** 봅니다(기존 코드의 위반은 무관한 수정을 막지 않습니다. 파일 전체 검사는 `HARNESS_FULL_FILE=1`).
 
 응답 종료 시에는 `on-stop.sh`가 정적 규칙 → `compileJava` → Codex 시맨틱 검수를 순서대로 실행합니다. 같은 diff는 두 번 검수하지 않고, `auth`·`pay`·`global/security` 변경은 크기와 무관하게 항상 Codex 검수를 거칩니다.
 
@@ -69,11 +69,33 @@ Java 파일 수정 시 `on-file-edit.sh` 훅이 `scripts/harness/validate-java-r
 4. 테스트: `bash scripts/harness/run-module-tests.sh`
 5. 엔티티 변경 시 `./gradlew compileJava`
 
-## 코드 작성 원칙 (훅 강제)
+## 코드 작성 원칙
+
+훅이 차단하는 규칙 — `validate-java-rules.sh`의 규칙 1~6과 일대일 대응합니다.
 
 1. **삼항 연산자 금지** — 조건 분기는 `if/else` 또는 early return으로 작성한다
 2. **DTO 팩토리 메서드** — 서비스에서 `new DTO(...)` 직접 생성 금지. DTO의 `from()`/`of()` 정적 팩토리를 호출한다
-3. **Early return** — 조건이 맞지 않으면 일찍 반환해 중첩을 줄인다
-4. **단일 책임 메서드** — 한 메서드는 한 가지 일만 한다
-5. **의미 있는 이름** — 축약어 없이 의도가 드러나는 이름을 쓴다
-6. **계층·모듈 경계** — Controller는 Repository 직접 import 금지(Service 경유), `@Entity`는 widyu-domain, Repository는 widyu-api, `@Async` 메서드에 `@Transactional` 필수
+3. **Controller → Repository 직접 접근 금지** — Service를 경유한다
+4. **`@Entity`는 widyu-domain에만** 둔다
+5. **Repository는 widyu-api에만** 둔다
+6. **`@Async` 메서드에 `@Transactional` 필수** — 새 스레드는 호출자 트랜잭션을 전파받지 못한다
+
+훅이 검사하지 않는 권장 규칙 — 리뷰에서 확인합니다.
+
+- **Early return** — 조건이 맞지 않으면 일찍 반환해 중첩을 줄인다
+
+<!-- 단일 책임·의미 있는 이름 항목은 검증 기준이 없어 제거했습니다 (#486). 되살릴 때는
+     "PR 리뷰에서 위반을 가리킬 수 있는가" 기준을 통과하는 문장으로 다시 쓰세요. -->
+
+# Compact instructions
+
+압축할 때 아래를 우선 보존합니다.
+
+- 현재 작업의 LLD·ADR 인수조건, 미해결 Codex BLOCKER 지적
+- 확정한 설계와 그 근거 (기각한 대안 포함)
+- 변경한 파일 경로와 남은 작업
+
+탐색 흔적, 막다른 길, 중복된 도구 출력은 버려도 됩니다.
+
+압축 후 백엔드 코드를 계속 다루면 `backend/CLAUDE.md`를 다시 읽으세요. nested CLAUDE.md는
+루트와 달리 자동 재주입되지 않아, 참조 문장만 남고 도메인 규칙·테스트 작성 규칙은 사라집니다.


### PR DESCRIPTION
## 개요

학습 자료 두 편을 기준으로 루트 `CLAUDE.md`를 점검해 세 가지를 고칩니다.

첫째, **Compact instructions 섹션이 없어** auto-compaction이 일반 휴리스틱으로 무엇을 남길지 추측하고 있었습니다. 한 세션에서 결제 로직 구현 → 하네스 스크립트 수정 → 문서 갱신이 섞이는 저장소라, 압축이 셋을 평등하게 다루면 LLD 인수조건이나 미해결 Codex BLOCKER가 날아가고 탐색 흔적이 남을 수 있습니다.

둘째, **nested CLAUDE.md는 압축 후 자동 재주입되지 않습니다.** 루트 첫 줄이 "도메인 상세·테스트 작성 규칙은 backend/CLAUDE.md를 참조하세요"라서, 압축 후에는 포인터만 살아남고 `backend/CLAUDE.md`(103줄)의 내용은 사라집니다. 포인터가 보이기 때문에 모델이 그 사실을 인지하지 못한 채 백엔드 작업을 계속하게 됩니다.

셋째, **"코드 작성 원칙 (훅 강제)" 제목이 사실과 달랐습니다.** `validate-java-rules.sh`가 검사하는 규칙과 CLAUDE.md 목록이 어긋나 있었습니다.

| CLAUDE.md (기존) | 훅 검사 여부 |
|---|---|
| 1. 삼항 연산자 금지 | ✅ 규칙 1 |
| 2. DTO 팩토리 메서드 | ✅ 규칙 2 |
| 3. Early return | ❌ 없음 |
| 4. 단일 책임 메서드 | ❌ 없음 |
| 5. 의미 있는 이름 | ❌ 없음 |
| 6. 계층·모듈 경계 | ✅ 규칙 3·4·5·6이 한 줄로 뭉쳐 있음 |

## 관련 문서
- LLD: - (문서 변경 작업이라 LLD가 없습니다)
- ADR: -
- 참고: `apiDocs/engineering/learning/2-토큰압축도구와-auto-compaction.pdf` (p.04 nested 재주입, p.09 Compact instructions)
- 참고: `apiDocs/engineering/learning/2-CLAUDE.md-완전정복.pdf` (p.07 넣을 것·뺄 것, p.08 검증 가능한 룰, p.10 정기 정리)

## 관련 이슈
Closes #486

## 변경 사항
- 변경 모듈: 문서 (`widyu-api`·`widyu-domain` 변경 없습니다)
- `# Compact instructions` 섹션을 추가했습니다. 보존 대상(LLD·ADR 인수조건, 미해결 BLOCKER, 확정 설계와 근거, 변경 파일·남은 작업)과 폐기 대상(탐색 흔적, 막다른 길, 중복 도구 출력)을 명시했습니다
- 같은 섹션에 압축 후 `backend/CLAUDE.md` 재확인 지시를 넣었습니다
- "코드 작성 원칙"을 **훅이 차단하는 규칙 6개**와 **훅이 검사하지 않는 권장 규칙**으로 분리했습니다. 전자는 `validate-java-rules.sh`의 규칙 1~6과 일대일 대응합니다
- 뭉쳐 있던 6번(계층·모듈 경계)을 스크립트 구조에 맞춰 3·4·5·6번으로 풀어 썼습니다
- 단일 책임 메서드·의미 있는 이름을 삭제하고, 되살릴 조건을 HTML 주석으로 남겼습니다 (주석 블록은 컨텍스트 주입 전에 잘려 토큰을 쓰지 않습니다)
- 하네스 워크플로우 설명의 "아래 코드 작성 원칙을 자동 검사합니다" → "아래 훅이 차단하는 규칙 6개를 검사합니다"로 정정했습니다

## 테스트
- `./gradlew :backend:widyu-api:test`: 실행하지 않았습니다 (Java 코드 변경이 없습니다)
- `./gradlew :backend:widyu-domain:test`: 실행하지 않았습니다 (동일)

이슈 완료 조건 4개를 확인했습니다.

- `# Compact instructions` 섹션 존재 ✅
- nested CLAUDE.md 재확인 지시 포함 ✅
- 훅 강제 항목 6개가 `validate-java-rules.sh` 규칙 1~6과 일대일 대응 ✅ (양쪽 목록을 나란히 출력해 대조했습니다)
- 분량 101줄로 권장 범위(70~120) 유지 ✅ (기존 79줄)

하네스 훅 자체는 건드리지 않아 동작 변경이 없습니다.

## 체크리스트
- [x] 엔티티 변경 시 `./gradlew compileJava` 실행 — 해당 없습니다
- [x] MySQL ENUM 변경 시 ALTER TABLE 명시 — 해당 없습니다
- [x] `@Async` 메서드에 `@Transactional` 확인 — 해당 없습니다
- [x] LLD 인수조건 전체 충족 — LLD가 없어 이슈 #486의 완료 조건 4개로 대체했으며 전부 충족했습니다

## 리뷰 포인트

**"단일 책임 메서드"와 "의미 있는 이름"을 삭제한 판단이 맞는지** 봐주세요. 두 항목은 리뷰에서 위반을 특정하기 어렵고 모델이 이미 아는 표준이라 매 세션 토큰만 소모한다고 봤습니다. 팀 컨벤션으로 명시적 선언이 필요하다고 보시면 되살리되, 검증 가능한 문장으로 다시 써야 합니다.

## Open Questions (LLD 미결정 사항)
- `### DDD Layered Structure`의 디렉터리 트리는 "코드를 읽으면 알 수 있는 것"이라 삭제 후보였지만, 신규 파일 배치 규약도 함께 담고 있어 이번에는 **유지**했습니다.
- Early return은 훅이 검사하지 않지만 문장이 구체적이라 권장 규칙으로 남겼습니다. 함께 삭제할지는 리뷰에서 결정합니다.

## 비고
- 배포 영향은 없습니다.
- 자료 p.10이 권하는 "6주~분기마다 CLAUDE.md 정기 점검"은 이번 범위에 넣지 않았습니다. 필요하면 후속 이슈로 만들 수 있습니다.
