### PR TITLE
[버그] 목표 홈 보호자 API에 가족 접근 검증을 추가합니다

### DIFF
--- a/backend/widyu-api/src/main/java/com/widyu/goal/home/controller/GoalHomeController.java
+++ b/backend/widyu-api/src/main/java/com/widyu/goal/home/controller/GoalHomeController.java
@@ -1,5 +1,6 @@
 package com.widyu.goal.home.controller;
 
+import com.widyu.global.annotation.ValidateFamilyAccess;
 import com.widyu.global.response.ApiResponseTemplate;
 import com.widyu.goal.home.application.GoalHomeService;
 import com.widyu.goal.home.controller.docs.GoalHomeDocs;
@@ -55,6 +56,7 @@ public class GoalHomeController implements GoalHomeDocs {
 
     @Override
     @GetMapping("/guardian/stats")
+    @ValidateFamilyAccess(memberIdParam = "memberId")
     public ApiResponseTemplate<GuardianGoalStatsResponse> getGuardianGoalStats(
             @RequestParam(required = false) Long memberId
     ) {
@@ -67,6 +69,7 @@ public class GoalHomeController implements GoalHomeDocs {
 
     @Override
     @GetMapping("/guardian")
+    @ValidateFamilyAccess(memberIdParam = "memberId")
     public ApiResponseTemplate<GuardianGoalHomeResponse> getGuardianGoalHome(
             @RequestParam(required = false) Long memberId
     ) {

--- a/backend/widyu-api/src/test/java/com/widyu/global/security/ControllerFamilyAccessTest.java
+++ b/backend/widyu-api/src/test/java/com/widyu/global/security/ControllerFamilyAccessTest.java
@@ -1,0 +1,128 @@
+package com.widyu.global.security;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.widyu.global.annotation.ValidateFamilyAccess;
+import java.lang.reflect.Method;
+import java.lang.reflect.Parameter;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.config.BeanDefinition;
+import org.springframework.context.annotation.ClassPathScanningCandidateComponentProvider;
+import org.springframework.core.type.filter.AnnotationTypeFilter;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@DisplayName("컨트롤러 가족 접근 검증 회귀 테스트")
+class ControllerFamilyAccessTest {
+
+    private static final String CONTROLLER_PACKAGE = "com.widyu";
+
+    /**
+     * {@code memberId}를 받지만 {@link ValidateFamilyAccess} 없이도 되는 핸들러.
+     *
+     * <p>이 프로젝트의 인가 검증 경로는 두 갈래다 — AOP 애노테이션, 그리고 서비스 계층의 직접 검증.
+     * 어느 쪽도 거치지 않는 엔드포인트가 생기면 조용히 IDOR이 된다(#489 리뷰에서 GoalHomeController가
+     * 실제로 그랬다). 새 핸들러는 애노테이션을 붙이거나, 서비스에서 검증한다는 근거와 함께 아래에 등록한다.
+     */
+    private static final Set<String> SERVICE_LAYER_VALIDATED = Set.of(
+            // SecurityConfig:68 — /api/v1/admin/** 은 hasRole("ADMIN")으로 차단된다
+            "AdminMemberController#getMemberDetail",
+            "AdminMemberController#changeStatus",
+
+            // HealthScheduleService:184,225 — existsByGuardianIdAndSeniorProfileId
+            "HealthScheduleController#getHealthScheduleCalendarForSenior",
+            "HealthScheduleController#getHealthSchedulesByDateForSenior",
+
+            // RealtimeLocationService:190,262 — existsByGuardianIdAndSeniorProfileId
+            "RealtimeLocationRestController#getLastLocation",
+            "RealtimeLocationRestController#getLocationTrail",
+
+            // ParentLocationService:86 — familyAccessService.verifyFamilyAccess (AOP와 같은 검증기)
+            "ParentLocationController#deleteParentLocation",
+
+            // GuardianMyPageService:330 getSeniorProfileWithAccessCheck
+            "GuardianMyPageController#getSeniorProfile",
+            "GuardianMyPageController#updateSeniorName",
+            "GuardianMyPageController#updateSeniorPhone",
+            "GuardianMyPageController#updateSeniorAddress",
+            "GuardianMyPageController#updateSeniorProfileImage",
+            "GuardianMyPageController#updateSeniorInviteCode",
+
+            // GuardianMyPageService:248,270 — 방장 권한 + 대상이 같은 가족인지 확인
+            "GuardianMyPageController#changeLeader",
+            "GuardianMyPageController#deleteFamilyMember",
+
+            // SeniorMyPageService:103 — 대상이 본인 가족의 보호자인지 확인
+            "SeniorMyPageController#updateRepresentativeContact"
+    );
+
+    @Test
+    @DisplayName("memberId를 받는 핸들러는 AOP 검증을 붙이거나 서비스 계층 검증 목록에 등록해야 한다")
+    void memberId를_받는_핸들러는_가족_접근_검증을_거친다() {
+        List<String> unprotected = new ArrayList<>();
+
+        for (Class<?> controller : scanControllers()) {
+            for (Method method : controller.getDeclaredMethods()) {
+                if (!isHandler(method) || !takesMemberId(method)) {
+                    continue;
+                }
+                if (method.isAnnotationPresent(ValidateFamilyAccess.class)) {
+                    continue;
+                }
+                String key = controller.getSimpleName() + "#" + method.getName();
+                if (SERVICE_LAYER_VALIDATED.contains(key)) {
+                    continue;
+                }
+                unprotected.add(key);
+            }
+        }
+
+        assertThat(unprotected)
+                .withFailMessage(
+                        "가족 접근 검증을 거치지 않는 핸들러가 있습니다: %s%n"
+                                + "@ValidateFamilyAccess를 붙이거나, 서비스 계층에서 검증한다면 "
+                                + "SERVICE_LAYER_VALIDATED에 검증 위치와 함께 등록하세요.",
+                        unprotected)
+                .isEmpty();
+    }
+
+    private List<Class<?>> scanControllers() {
+        ClassPathScanningCandidateComponentProvider scanner =
+                new ClassPathScanningCandidateComponentProvider(false);
+        scanner.addIncludeFilter(new AnnotationTypeFilter(RestController.class));
+
+        List<Class<?>> controllers = new ArrayList<>();
+        for (BeanDefinition definition : scanner.findCandidateComponents(CONTROLLER_PACKAGE)) {
+            try {
+                controllers.add(Class.forName(definition.getBeanClassName()));
+            } catch (ClassNotFoundException e) {
+                throw new IllegalStateException(e);
+            }
+        }
+        assertThat(controllers).isNotEmpty();
+        return controllers;
+    }
+
+    private boolean isHandler(Method method) {
+        return method.isAnnotationPresent(RequestMapping.class)
+                || method.getAnnotations().length > 0 && hasMappingMeta(method);
+    }
+
+    private boolean hasMappingMeta(Method method) {
+        return java.util.Arrays.stream(method.getAnnotations())
+                .anyMatch(a -> a.annotationType().isAnnotationPresent(RequestMapping.class));
+    }
+
+    private boolean takesMemberId(Method method) {
+        for (Parameter parameter : method.getParameters()) {
+            if (parameter.getName().equals("memberId") || parameter.getName().equals("seniorId")) {
+                return true;
+            }
+        }
+        return false;
+    }
+}


### PR DESCRIPTION
## 개요

목표 홈 보호자 API 두 개(`GET /api/v1/goals/home/guardian`, `/guardian/stats`)가 `memberId`를 요청 파라미터로 받아 대상 회원을 그대로 조회하면서 가족 관계를 검증하지 않았습니다. 인증된 보호자라면 임의의 `memberId`를 넣어 다른 가족 시니어의 복약·걸음 데이터를 조회할 수 있는 상태였습니다. #489 리뷰 과정에서 발견해 별도 이슈로 분리했습니다.

## 관련 문서
- LLD: - (기존 결함 수정이라 신규 LLD 없이 진행합니다)
- ADR: docs/adr/ADR-0002 (가디언-시니어 접근 권한 AOP 검증)

## 관련 이슈
Closes #491

## 변경 사항
- 변경 모듈: widyu-api
- `GoalHomeController`의 `/guardian`·`/guardian/stats`에 `@ValidateFamilyAccess(memberIdParam = "memberId")`를 추가했습니다. 같은 성격의 보호자 엔드포인트(`WalkController`, `MedicineScheduleController`, `HeartRateController`, `HomeController`)와 동일한 방식입니다.
- `ControllerFamilyAccessTest`를 추가했습니다. `@RestController`를 스캔해 `memberId`·`seniorId`를 받는 핸들러 중 AOP 애노테이션도 없고 서비스 계층 검증 목록에도 없으면 실패합니다. Spring 컨텍스트를 띄우지 않고 `ClassPathScanningCandidateComponentProvider`만 사용하므로 신규 의존성은 없습니다.

## 확인한 내용

`memberId`·`seniorId`를 받는 컨트롤러 핸들러 40개를 전수 확인했습니다. `GoalHomeController` 외 다른 누락은 없었고, 나머지 16개는 아래 경로 중 하나로 검증하고 있어 검증 위치를 근거로 명시해 목록에 등록했습니다.

| 검증 방식 | 대상 |
| --- | --- |
| `SecurityConfig:68` `hasRole("ADMIN")` | AdminMember 2건 |
| `existsByGuardianIdAndSeniorProfileId` | HealthSchedule 2건, RealtimeLocation 2건 |
| `familyAccessService.verifyFamilyAccess` (AOP와 동일 검증기) | ParentLocation 1건 |
| `getSeniorProfileWithAccessCheck` | GuardianMyPage 6건 |
| 방장 권한 + 대상이 같은 가족인지 확인 | GuardianMyPage 2건, SeniorMyPage 1건 |

## 테스트
- `./gradlew :backend:widyu-api:test`: 통과
- `./gradlew :backend:widyu-domain:test`: 해당 없음 (domain 변경 없음)
- 회귀 테스트 검증: `GoalHomeController`에서 애노테이션을 다시 제거하고 실행해 `GoalHomeController#getGuardianGoalHome, #getGuardianGoalStats`를 정확히 짚어내는 것을 확인했습니다.

## 체크리스트
- [x] 엔티티 변경 없음 (`compileJava` 해당 없음)
- [x] MySQL ENUM 변경 없음
- [x] `@Async` 메서드 변경 없음
- [x] 관련 인수조건 충족

## 리뷰 포인트

서비스 계층에서 검증하는 16개 핸들러를 화이트리스트로 등록한 방식이 적절한지 봐주세요. 대안은 이들을 전부 `@ValidateFamilyAccess`로 옮겨 인가 경로를 한 갈래로 일원화하는 것인데, 검증 조건이 단순 가족 관계가 아닌 경우(방장 권한, 대표 연락처 등)가 섞여 있어 이번 범위에서는 제외했습니다.

## Open Questions (LLD 미결정 사항)

인가 검증 경로를 AOP 한 갈래로 일원화할지 여부는 이번 범위에서 다루지 않았습니다. 서비스 계층 검증 15건을 AOP로 옮기는 작업은 별도 이슈로 검토가 필요합니다.

## 비고

DB 마이그레이션이나 배포 영향은 없습니다. 기존에 다른 가족 데이터를 조회하던 클라이언트가 있었다면 이제 `FORBIDDEN`을 받습니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **보안 강화**
  * 보호자 목표 현황 및 목표 홈 조회 시 가족 접근 권한을 확인합니다.
  * 가족 구성원이 아닌 사용자의 목표 정보 접근을 방지합니다.

* **버그 수정**
  * 가족 접근 검증이 누락된 요청을 자동으로 점검해 보안 회귀를 예방합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->