### PR TITLE
[리팩터링] 기간 복약 인증 조회가 전체 이력을 검사하지 않도록 개선합니다

### DIFF
--- a/backend/widyu-api/src/main/java/com/widyu/goal/medicineschedule/repository/MedicationProofRepository.java
+++ b/backend/widyu-api/src/main/java/com/widyu/goal/medicineschedule/repository/MedicationProofRepository.java
@@ -21,7 +21,7 @@ public interface MedicationProofRepository extends JpaRepository<MedicationProof
     );
 
     @Query("SELECT mp FROM MedicationProof mp " +
-           "WHERE mp.medicineSchedule.member.id = :memberId " +
+           "WHERE mp.member.id = :memberId " +
            "AND mp.verifiedAt BETWEEN :startDate AND :endDate")
     List<MedicationProof> findByMemberIdAndDateRange(
             @Param("memberId") Long memberId,

--- a/backend/widyu-api/src/test/java/com/widyu/goal/medicineschedule/repository/MedicationProofRepositoryTest.java
+++ b/backend/widyu-api/src/test/java/com/widyu/goal/medicineschedule/repository/MedicationProofRepositoryTest.java
@@ -1,0 +1,78 @@
+package com.widyu.goal.medicineschedule.repository;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import com.widyu.global.config.JpaAuditingConfig;
+import com.widyu.medicine.MedicationProof;
+import com.widyu.medicine.MedicineSchedule;
+import com.widyu.member.Member;
+import com.widyu.member.MemberType;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.util.ReflectionTestUtils;
+
+@DataJpaTest
+@ActiveProfiles("test")
+@Import(JpaAuditingConfig.class)
+@DisplayName("MedicationProofRepository 기간 조회 테스트")
+class MedicationProofRepositoryTest {
+
+    @Autowired private MedicationProofRepository medicationProofRepository;
+    @Autowired private TestEntityManager entityManager;
+    @MockBean private JPAQueryFactory jpaQueryFactory;
+
+    private Member persistSenior(String phoneNumber) {
+        Member member = Member.createMember(MemberType.SENIOR, "부모님", phoneNumber);
+        entityManager.persistAndFlush(member);
+        return member;
+    }
+
+    private MedicineSchedule persistSchedule(Member member, LocalDate effectiveFrom) {
+        MedicineSchedule schedule = MedicineSchedule.create(member, LocalTime.of(8, 0));
+        ReflectionTestUtils.setField(schedule, "effectiveFrom", effectiveFrom);
+        entityManager.persistAndFlush(schedule);
+        return schedule;
+    }
+
+    private MedicationProof persistProof(MedicineSchedule schedule, Member member, LocalDateTime verifiedAt) {
+        MedicationProof proof = MedicationProof.create(schedule, member, List.of());
+        ReflectionTestUtils.setField(proof, "verifiedAt", verifiedAt);
+        entityManager.persistAndFlush(proof);
+        return proof;
+    }
+
+    @Test
+    @DisplayName("본인의 기간 내 인증만 조회하고 다른 회원·기간 밖 인증은 제외한다")
+    void 본인의_기간_내_인증만_조회한다() {
+        // given
+        Member member = persistSenior("01011112222");
+        Member other = persistSenior("01033334444");
+        MedicineSchedule schedule = persistSchedule(member, LocalDate.of(2026, 8, 1));
+        MedicineSchedule otherSchedule = persistSchedule(other, LocalDate.of(2026, 8, 1));
+
+        MedicationProof inRange = persistProof(schedule, member, LocalDateTime.of(2026, 8, 10, 8, 5));
+        persistProof(schedule, member, LocalDateTime.of(2026, 7, 31, 8, 5));   // 기간 밖
+        persistProof(otherSchedule, other, LocalDateTime.of(2026, 8, 10, 8, 5)); // 다른 회원
+
+        // when
+        List<MedicationProof> proofs = medicationProofRepository.findByMemberIdAndDateRange(
+                member.getId(),
+                LocalDateTime.of(2026, 8, 1, 0, 0),
+                LocalDateTime.of(2026, 8, 14, 23, 59, 59)
+        );
+
+        // then
+        assertThat(proofs).extracting(MedicationProof::getId).containsExactly(inRange.getId());
+    }
+}

--- a/backend/widyu-domain/src/main/java/com/widyu/medicine/MedicationProof.java
+++ b/backend/widyu-domain/src/main/java/com/widyu/medicine/MedicationProof.java
@@ -10,8 +10,10 @@ import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.Index;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
@@ -23,6 +25,11 @@ import lombok.NoArgsConstructor;
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(
+        name = "medication_proof",
+        indexes = @Index(name = "idx_medication_proof_member_verified",
+                columnList = "member_id, verified_at")
+)
 public class MedicationProof extends BaseTimeEntity {
 
     @Id


### PR DESCRIPTION
## 개요

`MedicationProofRepository.findByMemberIdAndDateRange`의 조회 비용이 요청한 날짜 범위가 아니라 해당 시니어의 전체 인증 이력에 비례합니다. #489가 요청당 SQL 횟수를 20→3, 76→3으로 줄였지만, 이 쿼리는 SQL 한 건의 비용이 시간이 갈수록 자라므로 방치하면 개선분이 다시 잠식됩니다.

ADR-0019의 후속 항목("운영 데이터에서 병목이 확인되면 복합 인덱스를 별도 이슈로 검토한다")에 해당합니다. LLD-0024가 인덱스 추가를 Out of scope로 두었으므로 #489와 분리해 올립니다.

## 관련 문서
- LLD: docs/lld/LLD-0024-goal-home-query-pipeline.md (인덱스 추가는 Out of scope — 본 PR에서 다룹니다)
- ADR: docs/adr/ADR-0019-goal-home-query-pipeline.md (후속/미결정 항목)

## 관련 이슈
Closes #492

## 변경 사항
- 변경 모듈: widyu-api, widyu-domain
- JPQL 조건을 `mp.medicineSchedule.member.id`에서 `mp.member.id`로 변경해 `medicine_schedule` 조인을 제거했습니다.
- `MedicationProof`에 `idx_medication_proof_member_verified (member_id, verified_at)` 인덱스를 선언했습니다.
- `MedicationProofRepositoryTest`를 추가했습니다. 기존 사용처가 전부 mock이라 이 JPQL을 실제로 실행하는 테스트가 없었습니다.

## 근거

`MedicationProof`는 이미 자체 `member_id` FK를 보유하는데도 `mp.medicineSchedule.member.id`로 필터링해 조인을 강제했고, 그 결과 `verified_at`이 인덱스 조건이 아니라 후처리 필터로만 적용됐습니다.

두 컬럼의 값이 항상 같은지는 저장 경로에서 확인했습니다. `MedicationProofService.verifyMedication`이 저장 전에 `schedule.getMember().getId().equals(currentMember.getId())`를 강제하므로 `proof.member`와 `proof.medicineSchedule.member`는 언제나 동일합니다.

**재측정** — 로컬 시드 데이터(인증 37건)로는 차이가 드러나지 않아 별도 스키마에 시니어 50명 × 하루 4회 × 730일 = 인증 14.6만 건을 적재해 측정했습니다. 14일 창, 반환 56건 고정, 변형별 50회입니다.

| 변형 | SQL | 인덱스 | 검사 행 | 평균 |
| --- | --- | --- | ---: | ---: |
| A | 조인 (변경 전) | 없음 | 2,924 | 2.773ms |
| B | `mp.member_id` 직접 | 없음 | 2,920 | 2.090ms |
| C | 직접 | `(member_id, verified_at)` | 56 | 0.037ms |
| D | 조인 (변경 전) | `(member_id, verified_at)` | 2,924 | 2.053ms |

A→C로 검사 행 2,924 → 56, 평균 2.773ms → 0.037ms입니다.

**D가 두 변경을 함께 해야 하는 이유입니다.** 조인을 남긴 채 인덱스만 추가하면 옵티마이저가 `medicine_schedule`을 드라이빙 테이블로 잡고 `medicine_schedule_id` FK 인덱스로만 접근하므로 새 복합 인덱스를 아예 선택하지 않습니다(검사 행이 A와 동일).

**스케일 특성** — 같은 14일 창에서 회원 이력만 절반으로 줄여 재측정했습니다.

| 변형 | 이력 2,920건 | 이력 1,460건 |
| --- | ---: | ---: |
| A (조인, 인덱스 없음) | 2.773ms | 1.019ms |
| B (직접, 인덱스 없음) | 2.090ms | 1.023ms |
| C (직접 + 복합 인덱스) | 0.037ms | 0.035ms |

A·B는 이력 크기에 정비례하고 C만 평평합니다.

측정 한계는 합성 데이터라 인증이 매일 정확히 4건씩 균등 분포한다는 점, 순수 SQL 실행 시간이라 애플리케이션 왕복·직렬화를 포함하지 않는다는 점입니다. #489의 k6 API 응답시간 재측정은 하지 않았습니다.

## 테스트
- `./gradlew :backend:widyu-api:test`: 통과
- `./gradlew :backend:widyu-domain:test`: 통과
- `./gradlew compileJava`: 실행 (엔티티 변경)

## 체크리스트
- [x] 엔티티 변경 시 `./gradlew compileJava` 실행
- [x] MySQL ENUM 변경 없음
- [x] `@Async` 메서드 변경 없음
- [x] 이슈 완료 조건 충족

## 리뷰 포인트

`mp.member.id`로 조건을 바꾼 것이 안전한지 봐주세요. 근거는 저장 경로의 소유권 검증(`MedicationProofService:47`)이며, 이 불변식이 깨지면 두 조건의 결과가 달라집니다. 데이터 정합성을 한 번 더 확인할 필요가 있는지 판단 부탁드립니다.

## Open Questions (LLD 미결정 사항)

없습니다.

## 비고

인덱스는 `ddl-auto: update`로 다음 기동 시 자동 생성됩니다. 운영 환경에 별도 마이그레이션 절차가 있다면 아래를 수동 실행해야 합니다.

```sql
CREATE INDEX idx_medication_proof_member_verified ON medication_proof (member_id, verified_at);
```

기존 `medication_proof` 데이터가 많으면 인덱스 생성에 시간이 걸릴 수 있습니다.
