### PR TITLE
서버 도메인을 변경합니다

### DIFF
--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -53,7 +53,7 @@ http {
     # [1] HTTP Server - Redirect to HTTPS
     server {
         listen 80;
-        server_name dev.widyu.shop;
+        server_name widyu.store;
 
         # Certbot ACME challenge location (인증 갱신용)
         location /.well-known/acme-challenge/ {
@@ -75,11 +75,11 @@ http {
     # [2] HTTPS Server
     server {
         listen 443 ssl http2;
-        server_name dev.widyu.shop;
+        server_name widyu.store;
 
         # SSL Certificate paths
-        ssl_certificate /etc/letsencrypt/live/dev.widyu.shop/fullchain.pem;
-        ssl_certificate_key /etc/letsencrypt/live/dev.widyu.shop/privkey.pem;
+        ssl_certificate /etc/letsencrypt/live/widyu.store/fullchain.pem;
+        ssl_certificate_key /etc/letsencrypt/live/widyu.store/privkey.pem;
 
         # SSL configuration
         ssl_protocols TLSv1.2 TLSv1.3;
@@ -92,7 +92,7 @@ http {
         # OCSP Stapling
         ssl_stapling on;
         ssl_stapling_verify on;
-        ssl_trusted_certificate /etc/letsencrypt/live/dev.widyu.shop/chain.pem;
+        ssl_trusted_certificate /etc/letsencrypt/live/widyu.store/chain.pem;
 
         # Security headers
         add_header X-Frame-Options "SAMEORIGIN" always;


### PR DESCRIPTION
## 개요
만료된 기존 서버 도메인을 새로 발급받은 `widyu.store`로 전환합니다.

## 관련 문서
- LLD: -
- ADR: -

## 관련 이슈
Closes #496

## 변경 사항
- 변경 모듈: 배포 인프라(Nginx)입니다.
- HTTP와 HTTPS 서버 이름을 `widyu.store`로 변경합니다.
- Let's Encrypt 인증서와 신뢰 체인 경로를 `widyu.store` 기준으로 변경합니다.

## 의도적으로 하지 않은 작업
- DNS 레코드와 EC2 환경변수는 저장소 밖의 운영 설정이므로 변경하지 않습니다.
- 애플리케이션 코드와 배포 구조는 변경하지 않습니다.

## 테스트
- 임시 자체서명 인증서를 마운트한 `nginx:1.25-alpine nginx -t`: 통과했습니다.
- `git diff --check`: 통과했습니다.
- Gradle 테스트: Java 코드 변경이 없어 실행하지 않았습니다.

## 체크리스트
- [x] 엔티티와 MySQL ENUM을 변경하지 않았습니다.
- [x] `@Async` 메서드를 변경하지 않았습니다.
- [x] 이슈 #496의 완료 조건을 충족했습니다.

## 리뷰 포인트
Nginx의 서버 이름과 모든 TLS 인증서 참조가 `widyu.store`로 일관되게 전환되었는지 확인 부탁드립니다.

## Open Questions (LLD 미결정 사항)
없습니다.

## 비고
배포 전에 `/etc/letsencrypt/live/widyu.store/` 인증서가 서버에 발급되어 있어야 합니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **구성 변경**
  * HTTP 및 HTTPS 접속 호스트명이 `widyu.store`로 변경되었습니다.
  * HTTPS 인증서 관련 경로가 새 도메인에 맞게 업데이트되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->