### PR TITLE
개발 서버 HTTPS 도메인을 dev.widyu.store로 변경합니다

### DIFF
--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -53,7 +53,7 @@ http {
     # [1] HTTP Server - Redirect to HTTPS
     server {
         listen 80;
-        server_name widyu.store;
+        server_name dev.widyu.store;
 
         # Certbot ACME challenge location (인증 갱신용)
         location /.well-known/acme-challenge/ {
@@ -75,11 +75,11 @@ http {
     # [2] HTTPS Server
     server {
         listen 443 ssl http2;
-        server_name widyu.store;
+        server_name dev.widyu.store;
 
         # SSL Certificate paths
-        ssl_certificate /etc/letsencrypt/live/widyu.store/fullchain.pem;
-        ssl_certificate_key /etc/letsencrypt/live/widyu.store/privkey.pem;
+        ssl_certificate /etc/letsencrypt/live/dev.widyu.store/fullchain.pem;
+        ssl_certificate_key /etc/letsencrypt/live/dev.widyu.store/privkey.pem;
 
         # SSL configuration
         ssl_protocols TLSv1.2 TLSv1.3;
@@ -92,7 +92,7 @@ http {
         # OCSP Stapling
         ssl_stapling on;
         ssl_stapling_verify on;
-        ssl_trusted_certificate /etc/letsencrypt/live/widyu.store/chain.pem;
+        ssl_trusted_certificate /etc/letsencrypt/live/dev.widyu.store/chain.pem;
 
         # Security headers
         add_header X-Frame-Options "SAMEORIGIN" always;


### PR DESCRIPTION
## 개요
개발 서버의 유일한 HTTPS 호스트를 `dev.widyu.store`로 맞춥니다.

## 관련 문서
- LLD: -
- ADR: -

## 관련 이슈
Closes #498

## 변경 사항
- 변경 모듈: 배포 인프라(Nginx)입니다.
- HTTP와 HTTPS 서버 이름을 `dev.widyu.store`로 변경합니다.
- Let's Encrypt 인증서와 신뢰 체인 경로를 `dev.widyu.store` 기준으로 변경합니다.

## 의도적으로 하지 않은 작업
- DNS 레코드와 EC2 환경변수는 저장소 밖의 운영 설정이므로 변경하지 않습니다.
- 루트 도메인을 추가 호스트로 유지하지 않습니다.

## 테스트
- 임시 자체서명 인증서를 마운트한 `nginx:1.25-alpine nginx -t`: 통과했습니다.
- `git diff --check`: 통과했습니다.
- Gradle 테스트: Java 코드 변경이 없어 실행하지 않았습니다.

## 체크리스트
- [x] 엔티티와 MySQL ENUM을 변경하지 않았습니다.
- [x] `@Async` 메서드를 변경하지 않았습니다.
- [x] 이슈 #498의 완료 조건을 충족했습니다.

## 리뷰 포인트
개발 서버 호스트와 모든 TLS 인증서 참조가 `dev.widyu.store`로 일관되게 설정되었는지 확인 부탁드립니다.

## Open Questions (LLD 미결정 사항)
없습니다.

## 비고
배포 전에 `/etc/letsencrypt/live/dev.widyu.store/` 인증서가 서버에 발급되어 있어야 합니다.
