### PR TITLE
[버그] 보호자 홈 건강 일정을 다가오는 일정 기준으로 조회합니다

### DIFF
--- a/backend/widyu-api/src/main/java/com/widyu/goal/healthschedule/repository/HealthScheduleRepository.java
+++ b/backend/widyu-api/src/main/java/com/widyu/goal/healthschedule/repository/HealthScheduleRepository.java
@@ -19,6 +19,9 @@ public interface HealthScheduleRepository extends JpaRepository<HealthSchedule, 
             @Param("endDate") LocalDateTime endDate
     );
 
+    Optional<HealthSchedule> findFirstByMemberIdAndScheduledAtAfterOrderByScheduledAtAsc(
+            Long memberId, LocalDateTime after);
+
     @Query("SELECT h FROM HealthSchedule h WHERE h.member.id = :memberId AND h.scheduledAt >= :startOfDay AND h.scheduledAt < :startOfNextDay")
     List<HealthSchedule> findByMemberIdAndDate(
             @Param("memberId") Long memberId,

--- a/backend/widyu-api/src/main/java/com/widyu/home/application/GuardianHomeService.java
+++ b/backend/widyu-api/src/main/java/com/widyu/home/application/GuardianHomeService.java
@@ -9,7 +9,6 @@ import com.widyu.goal.healthschedule.repository.HealthScheduleRepository;
 import com.widyu.goal.medicineschedule.repository.MedicationProofRepository;
 import com.widyu.goal.medicineschedule.repository.MedicineScheduleRepository;
 import com.widyu.goal.walk.repository.WalkRepository;
-import com.widyu.healthschedule.HealthSchedule;
 import com.widyu.heart.repository.HeartRateResultRepository;
 import com.widyu.home.dto.response.GuardianHomeCardsResponse;
 import com.widyu.home.dto.response.GuardianSeniorListResponse;
@@ -67,7 +66,7 @@ public class GuardianHomeService {
                 getHeartRateInfo(senior),
                 getMedicineInfo(senior, today),
                 getScoredAlbums(senior, today),
-                getHealthScheduleInfo(senior, today),
+                getHealthScheduleInfo(senior),
                 getWalkInfo(senior, today)
         );
     }
@@ -164,10 +163,9 @@ public class GuardianHomeService {
                 .toList();
     }
 
-    private GuardianHomeCardsResponse.HealthScheduleInfo getHealthScheduleInfo(Member senior, LocalDate today) {
-        return healthScheduleRepository.findByMemberIdAndDate(senior.getId(), today.atStartOfDay(), today.plusDays(1).atStartOfDay())
-                .stream()
-                .min(Comparator.comparing(HealthSchedule::getScheduledAt))
+    private GuardianHomeCardsResponse.HealthScheduleInfo getHealthScheduleInfo(Member senior) {
+        return healthScheduleRepository
+                .findFirstByMemberIdAndScheduledAtAfterOrderByScheduledAtAsc(senior.getId(), LocalDateTime.now())
                 .map(GuardianHomeCardsResponse.HealthScheduleInfo::from)
                 .orElse(null);
     }

--- a/backend/widyu-api/src/main/java/com/widyu/home/dto/response/GuardianHomeCardsResponse.java
+++ b/backend/widyu-api/src/main/java/com/widyu/home/dto/response/GuardianHomeCardsResponse.java
@@ -123,6 +123,9 @@ public record GuardianHomeCardsResponse(
             @Schema(description = "건강 일정 ID", example = "3")
             Long scheduleId,
 
+            @Schema(description = "일정 이름", example = "내과 정기검진")
+            String scheduleName,
+
             @Schema(description = "일정 일시", example = "2026-06-16T14:00:00")
             @JsonFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss")
             LocalDateTime scheduledAt,
@@ -133,6 +136,7 @@ public record GuardianHomeCardsResponse(
         public static HealthScheduleInfo from(HealthSchedule schedule) {
             return new HealthScheduleInfo(
                     schedule.getId(),
+                    schedule.getScheduleName(),
                     schedule.getScheduledAt(),
                     schedule.getPlaceAddress()
             );

--- a/backend/widyu-api/src/test/java/com/widyu/home/GuardianHomeServiceTest.java
+++ b/backend/widyu-api/src/test/java/com/widyu/home/GuardianHomeServiceTest.java
@@ -104,7 +104,7 @@ class GuardianHomeServiceTest {
         given(seniorProfileRepository.findAllByFamilyIdWithMember(any())).willReturn(List.of(seniorProfile));
         given(heartRateResultRepository.findByMemberId(any())).willReturn(Optional.empty());
         given(medicineScheduleRepository.findEffectiveByMemberAndDateWithDetails(any(), any(), any())).willReturn(List.of());
-        given(healthScheduleRepository.findByMemberIdAndDate(any(), any(), any())).willReturn(List.of());
+        given(healthScheduleRepository.findFirstByMemberIdAndScheduledAtAfterOrderByScheduledAtAsc(any(), any())).willReturn(Optional.empty());
         given(walkRepository.findByMemberAndWalkDate(any(), any())).willReturn(Optional.empty());
         given(albumRecommendationService.recommendAlbums(any(), any())).willReturn(List.of());
         given(realtimeLocationService.getOutingStatus(any())).willReturn(true);
@@ -118,8 +118,8 @@ class GuardianHomeServiceTest {
     }
 
     @Test
-    @DisplayName("오늘 건강 일정이 없으면 healthSchedule은 null을 반환한다")
-    void 오늘_건강일정이_없으면_healthSchedule은_null을_반환한다() {
+    @DisplayName("다가오는 건강 일정이 없으면 healthSchedule은 null을 반환한다")
+    void 다가오는_건강일정이_없으면_healthSchedule은_null을_반환한다() {
         // given
         Member guardian = Member.createMember(MemberType.GUARDIAN, "보호자", "01099999999");
         Member senior = Member.createMember(MemberType.SENIOR, "부모님", "01011112222");
@@ -133,7 +133,7 @@ class GuardianHomeServiceTest {
         given(seniorProfileRepository.findAllByFamilyIdWithMember(any())).willReturn(List.of(seniorProfile));
         given(heartRateResultRepository.findByMemberId(any())).willReturn(Optional.empty());
         given(medicineScheduleRepository.findEffectiveByMemberAndDateWithDetails(any(), any(), any())).willReturn(List.of());
-        given(healthScheduleRepository.findByMemberIdAndDate(any(), any(), any())).willReturn(List.of());
+        given(healthScheduleRepository.findFirstByMemberIdAndScheduledAtAfterOrderByScheduledAtAsc(any(), any())).willReturn(Optional.empty());
         given(walkRepository.findByMemberAndWalkDate(any(), any())).willReturn(Optional.empty());
         given(albumRecommendationService.recommendAlbums(any(), any())).willReturn(List.of());
 
@@ -160,7 +160,7 @@ class GuardianHomeServiceTest {
         given(seniorProfileRepository.findAllByFamilyIdWithMember(any())).willReturn(List.of(seniorProfile));
         given(heartRateResultRepository.findByMemberId(any())).willReturn(Optional.empty());
         given(medicineScheduleRepository.findEffectiveByMemberAndDateWithDetails(any(), any(), any())).willReturn(List.of());
-        given(healthScheduleRepository.findByMemberIdAndDate(any(), any(), any())).willReturn(List.of());
+        given(healthScheduleRepository.findFirstByMemberIdAndScheduledAtAfterOrderByScheduledAtAsc(any(), any())).willReturn(Optional.empty());
         given(walkRepository.findByMemberAndWalkDate(any(), any())).willReturn(Optional.empty());
         given(albumRecommendationService.recommendAlbums(any(), any())).willReturn(List.of());
 
@@ -197,7 +197,7 @@ class GuardianHomeServiceTest {
                 .willReturn(List.of(schedule1, schedule2));
         given(medicationProofRepository.findByMemberIdAndDateRange(any(), any(), any()))
                 .willReturn(List.of());
-        given(healthScheduleRepository.findByMemberIdAndDate(any(), any(), any())).willReturn(List.of());
+        given(healthScheduleRepository.findFirstByMemberIdAndScheduledAtAfterOrderByScheduledAtAsc(any(), any())).willReturn(Optional.empty());
         given(walkRepository.findByMemberAndWalkDate(any(), any())).willReturn(Optional.empty());
         given(albumRecommendationService.recommendAlbums(any(), any())).willReturn(List.of());
 


### PR DESCRIPTION
## 개요
보호자 홈 카드 통합 조회 API의 `healthSchedule` 카드에서 일정 이름이 빠져 있고, 다가오는 일정이 아니라 당일 일정만 조회되던 문제를 수정합니다.

## 관련 문서
- LLD: -
- ADR: -

## 관련 이슈
Closes #501

## 변경 사항
- 변경 모듈: widyu-api
- `GuardianHomeCardsResponse.HealthScheduleInfo`에 `scheduleName` 필드를 추가하고 팩토리에서 채웁니다. 시니어 홈 카드 응답에는 이미 있던 필드입니다.
- `HealthScheduleRepository`에 `findFirstByMemberIdAndScheduledAtAfterOrderByScheduledAtAsc`를 추가합니다.
- `GuardianHomeService.getHealthScheduleInfo`가 당일 범위 조회(`findByMemberIdAndDate`) 대신 현재 시각 이후 가장 가까운 일정 1건을 조회합니다. 하루치를 모두 읽어 애플리케이션에서 `min`을 구하던 부분이 사라집니다.
- `GuardianHomeServiceTest`의 스텁을 변경된 조회 방식에 맞춰 수정합니다.

## 테스트
- `./gradlew :backend:widyu-api:test`: 통과
- `./gradlew :backend:widyu-domain:test`: 해당 없음 (domain 변경 없음)

## 체크리스트
- [x] 엔티티 변경 없음 (`compileJava` 불필요)
- [x] MySQL ENUM 변경 없음
- [x] `@Async` 변경 없음
- [x] 이슈 완료 조건 충족

## 리뷰 포인트
보호자 홈의 다가오는 일정 조회에 상한을 두지 않았습니다. 시니어 홈(`SeniorHomeService`)은 "1개월 이내"만 노출하는데, 두 화면의 범위를 통일해야 할까요?

## Open Questions (LLD 미결정 사항)
- 관련 LLD가 없습니다. 위 리뷰 포인트의 조회 범위 통일 여부만 확인이 필요합니다.

## 비고
- 응답에 필드가 추가되는 변경이라 클라이언트 호환성에는 영향이 없습니다.
- 시니어 홈의 조회 범위 통일은 이 PR 범위에서 제외했습니다.
