### PR TITLE
[버그] 복약 월간 달성일을 전량 인증한 날만 집계합니다

### DIFF
--- a/backend/widyu-api/src/main/java/com/widyu/goal/medicineschedule/application/MedicineScheduleService.java
+++ b/backend/widyu-api/src/main/java/com/widyu/goal/medicineschedule/application/MedicineScheduleService.java
@@ -105,10 +105,10 @@ public class MedicineScheduleService {
         YearMonth requestedMonth = YearMonth.of(year, month);
         YearMonth previousMonth = requestedMonth.minusMonths(1);
 
-        int lastMonthCount = countAchievedInMonth(targetMember.getId(), previousMonth);
-        int currentMonthCount = countAchievedInMonth(targetMember.getId(), requestedMonth);
-
         List<Double> monthlyGoalRates = calculateMonthlyGoalRates(targetMember.getId(), requestedMonth);
+
+        int lastMonthCount = countAchievedInMonth(targetMember.getId(), previousMonth);
+        int currentMonthCount = countFullyAchievedDays(monthlyGoalRates);
 
         return MedicineMonthlyResponse.of(lastMonthCount, currentMonthCount, monthlyGoalRates);
     }
@@ -281,16 +281,14 @@ public class MedicineScheduleService {
                         "존재하지 않는 사용자입니다."));
     }
 
+    // 그날 유효했던 스케줄을 모두 인증한 날만 달성일로 센다
     private int countAchievedInMonth(Long memberId, YearMonth month) {
-        LocalDateTime startDate = month.atDay(1).atStartOfDay();
-        LocalDateTime endDate = month.atEndOfMonth().atTime(LocalTime.MAX);
+        return countFullyAchievedDays(calculateMonthlyGoalRates(memberId, month));
+    }
 
-        List<com.widyu.medicine.MedicationProof> proofs = medicationProofRepository
-                .findByMemberIdAndDateRange(memberId, startDate, endDate);
-
-        return (int) proofs.stream()
-                .map(proof -> proof.getVerifiedAt().toLocalDate())
-                .distinct()
+    private int countFullyAchievedDays(List<Double> dailyRates) {
+        return (int) dailyRates.stream()
+                .filter(rate -> rate >= 1.0)
                 .count();
     }
 


### PR DESCRIPTION
## 개요
약 복용 홈 - 날짜별 약 조회 API의 `currentMonthAchieveCount`가 하루 스케줄을 일부만 인증한 날까지 달성일로 세던 문제를 수정합니다.

## 관련 문서
- LLD: [docs/lld/LLD-0007-medicine-daily-status.md](../blob/develop/docs/lld/LLD-0007-medicine-daily-status.md), [docs/lld/LLD-0008-medicine-schedule-versioning.md](../blob/develop/docs/lld/LLD-0008-medicine-schedule-versioning.md)
- ADR: -

## 관련 이슈
Closes #502

## 변경 사항
- 변경 모듈: widyu-api
- `MedicineScheduleService.countAchievedInMonth`가 `MedicationProof`를 날짜 단위로 `distinct` 세던 방식을 버리고, 일별 달성률을 기준으로 집계하도록 변경합니다.
- 달성률 계산은 이미 있는 `calculateMonthlyGoalRates`(분모 = 그날 유효했던 스케줄 수, LLD-0008의 버전 유효 구간 기준)를 재사용합니다.
- `countFullyAchievedDays`를 추가해 달성률이 `1.0`인 날만 셉니다.
- 이번 달 카운트는 응답에 이미 계산해 둔 `monthlyGoalRates`를 그대로 재사용해 중복 계산을 없앴습니다. 지난 달도 같은 기준을 따릅니다.

## 테스트
- `./gradlew :backend:widyu-api:test`: 통과
- `./gradlew :backend:widyu-domain:test`: 해당 없음 (domain 변경 없음)

## 체크리스트
- [x] 엔티티 변경 없음 (`compileJava` 불필요)
- [x] MySQL ENUM 변경 없음
- [x] `@Async` 변경 없음
- [x] 이슈 완료 조건 충족

## 리뷰 포인트
"달성일"의 정의를 "그날 유효했던 스케줄을 전량 인증한 날"로 확정했습니다. `monthlyGoalRates`가 이미 같은 분모를 쓰고 있어 두 값의 정합성이 맞춰지는데, 기획 의도와 일치하는지 확인 부탁드립니다.

## Open Questions (LLD 미결정 사항)
- 없습니다.

## 비고
- 지난 달 카운트는 `calculateMonthlyGoalRates`를 한 번 더 호출합니다. 스케줄·인증 조회가 각각 한 번씩 늘지만 월 단위 조회라 영향은 크지 않습니다.
- 기존 응답값보다 카운트가 낮아집니다(과다 집계 교정). 클라이언트에 노출되는 수치가 달라지는 점 참고 부탁드립니다.
