### PR TITLE
[버그] 앨범 피드 뷰어 프로필 이미지를 응답에 반영합니다

### DIFF
--- a/backend/widyu-api/src/main/java/com/widyu/album/application/AlbumFeedService.java
+++ b/backend/widyu-api/src/main/java/com/widyu/album/application/AlbumFeedService.java
@@ -173,10 +173,7 @@ public class AlbumFeedService {
                 .collect(Collectors.groupingBy(
                         view -> view.getAlbum().getId(),
                         Collectors.mapping(
-                                view -> new AlbumFeedResponse.ViewerInfo(
-                                        view.getMember().getName(),
-                                        null // TODO: 프로필 이미지 경로 추가 시 반영
-                                ),
+                                view -> AlbumFeedResponse.ViewerInfo.from(view.getMember()),
                                 Collectors.toList()
                         )
                 ));

--- a/backend/widyu-api/src/main/java/com/widyu/album/dto/response/AlbumFeedResponse.java
+++ b/backend/widyu-api/src/main/java/com/widyu/album/dto/response/AlbumFeedResponse.java
@@ -1,6 +1,7 @@
 package com.widyu.album.dto.response;
 
 import com.widyu.album.Album;
+import com.widyu.member.Member;
 import com.widyu.album.MediaType;
 import java.time.LocalDateTime;
 import java.util.List;
@@ -28,7 +29,11 @@ public record AlbumFeedResponse(
     public record ViewerInfo(
             String name,
             String profileImage
-    ) {}
+    ) {
+        public static ViewerInfo from(Member member) {
+            return new ViewerInfo(member.getName(), member.getProfileImage());
+        }
+    }
 
     public static AlbumFeedResponse from(Album album, Boolean canEdit, List<ViewerInfo> viewers) {
         String primaryVideoDuration = album.getDurations().stream()


### PR DESCRIPTION
## 개요
앨범 피드 조회 API의 `viewers` 목록에서 `profileImage`가 항상 `null`로 내려가던 문제를 수정합니다.

## 관련 문서
- LLD: -
- ADR: -

## 관련 이슈
Closes #503

## 변경 사항
- 변경 모듈: widyu-api
- `AlbumFeedResponse.ViewerInfo`에 `from(Member)` 정적 팩토리를 추가합니다(서비스에서 DTO를 직접 생성하지 않는 코드 규칙을 따릅니다).
- `AlbumFeedService.convertToFeedResponsesBulk`에서 프로필 이미지 자리에 하드코딩돼 있던 `null`과 TODO 주석을 제거하고, 조회한 멤버의 `profileImage`를 담습니다.

## 테스트
- `./gradlew :backend:widyu-api:test`: 통과
- `./gradlew :backend:widyu-domain:test`: 해당 없음 (domain 변경 없음)

## 체크리스트
- [x] 엔티티 변경 없음 (`compileJava` 불필요)
- [x] MySQL ENUM 변경 없음
- [x] `@Async` 변경 없음
- [x] 이슈 완료 조건 충족

## 리뷰 포인트
같은 뷰어의 `getName()`이 이미 같은 트랜잭션에서 프록시를 초기화하므로 `getProfileImage()`로 추가 쿼리는 발생하지 않는다고 판단했습니다. 뷰어 조회(`findTop3ViewersForAlbums`)가 네이티브 쿼리라 fetch join이 없는데, 이 판단이 맞는지 확인 부탁드립니다.

## Open Questions (LLD 미결정 사항)
- 없습니다.

## 비고
- 기존에 항상 `null`이던 필드가 실제 값으로 채워집니다. 클라이언트에서 `null` 전제로 처리하던 부분이 있으면 확인이 필요합니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **개선**
  * 앨범 피드에서 조회자 이름과 프로필 이미지가 보다 일관된 방식으로 표시되도록 개선했습니다.
  * 조회자 정보 생성 로직을 정리해 앨범 피드 응답의 안정성과 유지보수성을 높였습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->