### PR TITLE
[버그] 남은 복약 알람이 없을 때 마지막 알람과 인증 이미지를 반환하도록 수정합니다

### DIFF
--- a/backend/widyu-api/src/main/java/com/widyu/goal/home/application/GoalHomeService.java
+++ b/backend/widyu-api/src/main/java/com/widyu/goal/home/application/GoalHomeService.java
@@ -39,6 +39,7 @@ import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
+import java.util.function.BinaryOperator;
 import java.util.Set;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
@@ -188,7 +189,8 @@ public class GoalHomeService {
                 .collect(Collectors.toMap(
                         proof -> proof.getMedicineSchedule().getId(),
                         proof -> proof,
-                        (first, second) -> first
+                        // 조회 쿼리에 정렬이 없어 중복 인증 시 대표를 verifiedAt 최초순으로 고정한다.
+                        BinaryOperator.minBy(Comparator.comparing(MedicationProof::getVerifiedAt))
                 ));
 
         MedicineSchedule nextSchedule = findNextSchedule(schedules, LocalTime.now());
@@ -376,7 +378,8 @@ public class GoalHomeService {
                 .collect(Collectors.toMap(
                         p -> p.getMedicineSchedule().getId(),
                         p -> p,
-                        (p1, p2) -> p1 // 중복 시 첫 번째 선택
+                        // 조회 쿼리에 정렬이 없어 중복 인증 시 대표를 verifiedAt 최초순으로 고정한다.
+                        BinaryOperator.minBy(Comparator.comparing(MedicationProof::getVerifiedAt))
                 ));
 
         int totalCount = 0;

--- a/backend/widyu-api/src/main/java/com/widyu/goal/home/application/GoalHomeService.java
+++ b/backend/widyu-api/src/main/java/com/widyu/goal/home/application/GoalHomeService.java
@@ -181,34 +181,32 @@ public class GoalHomeService {
         LocalDateTime startOfDay = today.atStartOfDay();
         LocalDateTime endOfDay = today.atTime(LocalTime.MAX);
 
-        // 오늘 복용한 횟수
-        int todayTakenCount = (int) medicationProofRepository
+        // 오늘 복용 인증 정보 (스케줄별 1건)
+        Map<Long, MedicationProof> proofsByScheduleId = medicationProofRepository
                 .findByMemberIdAndDateRange(member.getId(), startOfDay, endOfDay)
-                .size();
+                .stream()
+                .collect(Collectors.toMap(
+                        proof -> proof.getMedicineSchedule().getId(),
+                        proof -> proof,
+                        (first, second) -> first
+                ));
 
-        // 오늘 총 복용 예정 횟수
-        int todayTotalCount = schedules.size();
+        MedicineSchedule nextSchedule = findNextSchedule(schedules, LocalTime.now());
 
-        // 다음 알람 시간 찾기
-        LocalTime now = LocalTime.now();
-        MedicineSchedule nextSchedule = schedules.stream()
+        return SeniorGoalHomeResponse.MedicineInfo.from(
+                nextSchedule,
+                proofsByScheduleId.size(),
+                schedules.size(),
+                proofsByScheduleId.get(nextSchedule.getId())
+        );
+    }
+
+    // 알람 시간 오름차순 정렬된 목록 기준. 오늘 남은 알람이 없으면 마지막 알람을 그대로 노출한다.
+    static MedicineSchedule findNextSchedule(List<MedicineSchedule> schedules, LocalTime now) {
+        return schedules.stream()
                 .filter(s -> s.getAlarmTime().isAfter(now))
                 .min(Comparator.comparing(MedicineSchedule::getAlarmTime))
-                .orElse(schedules.get(0)); // 오늘 남은 알람이 없으면 첫 번째 스케줄
-
-        // 다음 복용 예정 개수
-        int nextDoseCount = nextSchedule.getTotalCount();
-
-        // 알람 시간을 HH:mm 형태로 포맷
-        String nextAlarmTime = nextSchedule.getAlarmTime().format(TIME_FORMATTER);
-
-        return new SeniorGoalHomeResponse.MedicineInfo(
-                nextSchedule.getId(),
-                todayTakenCount,
-                todayTotalCount,
-                nextDoseCount,
-                nextAlarmTime
-        );
+                .orElse(schedules.getLast());
     }
 
     private SeniorGoalHomeResponse.StepsInfo getStepsInfo(Member member, LocalDate today) {

--- a/backend/widyu-api/src/main/java/com/widyu/goal/home/application/GoalHomeService.java
+++ b/backend/widyu-api/src/main/java/com/widyu/goal/home/application/GoalHomeService.java
@@ -39,8 +39,8 @@ import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
-import java.util.function.BinaryOperator;
 import java.util.Set;
+import java.util.function.BinaryOperator;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -182,10 +182,16 @@ public class GoalHomeService {
         LocalDateTime startOfDay = today.atStartOfDay();
         LocalDateTime endOfDay = today.atTime(LocalTime.MAX);
 
+        // 스케줄 수정·삭제로 오늘 유효 목록에서 빠진 버전의 인증은 제외한다 (takenCount가 totalCount를 넘지 않도록)
+        Set<Long> scheduleIds = schedules.stream()
+                .map(MedicineSchedule::getId)
+                .collect(Collectors.toSet());
+
         // 오늘 복용 인증 정보 (스케줄별 1건)
         Map<Long, MedicationProof> proofsByScheduleId = medicationProofRepository
                 .findByMemberIdAndDateRange(member.getId(), startOfDay, endOfDay)
                 .stream()
+                .filter(proof -> scheduleIds.contains(proof.getMedicineSchedule().getId()))
                 .collect(Collectors.toMap(
                         proof -> proof.getMedicineSchedule().getId(),
                         proof -> proof,

--- a/backend/widyu-api/src/main/java/com/widyu/goal/home/controller/docs/GoalHomeDocs.java
+++ b/backend/widyu-api/src/main/java/com/widyu/goal/home/controller/docs/GoalHomeDocs.java
@@ -97,7 +97,8 @@ public interface GoalHomeDocs {
                                                   "takenCount": 2,
                                                   "totalCount": 3,
                                                   "nextDoseCount": 4,
-                                                  "nextAlarmTime": "17:00"
+                                                  "nextAlarmTime": "17:00",
+                                                  "proofImageUrl": "https://www.widyu.shop/img"
                                                 },
                                                 "steps": {
                                                   "steps": 9829,

--- a/backend/widyu-api/src/main/java/com/widyu/goal/home/dto/response/SeniorGoalHomeResponse.java
+++ b/backend/widyu-api/src/main/java/com/widyu/goal/home/dto/response/SeniorGoalHomeResponse.java
@@ -1,8 +1,11 @@
 package com.widyu.goal.home.dto.response;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
+import com.widyu.medicine.MedicationProof;
+import com.widyu.medicine.MedicineSchedule;
 import io.swagger.v3.oas.annotations.media.Schema;
 import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
 
 public record SeniorGoalHomeResponse(
         @Schema(description = "약 스케줄 정보")
@@ -38,8 +41,35 @@ public record SeniorGoalHomeResponse(
             Integer nextDoseCount,
 
             @Schema(description = "다음 알람 시간", example = "17:00")
-            String nextAlarmTime
+            String nextAlarmTime,
+
+            @Schema(description = "해당 스케줄의 복용 인증 이미지 (미복용 시 null)")
+            String proofImageUrl
     ) {
+        private static final DateTimeFormatter TIME_FORMATTER = DateTimeFormatter.ofPattern("HH:mm");
+
+        public static MedicineInfo from(
+                MedicineSchedule nextSchedule,
+                int takenCount,
+                int totalCount,
+                MedicationProof proof
+        ) {
+            return new MedicineInfo(
+                    nextSchedule.getId(),
+                    takenCount,
+                    totalCount,
+                    nextSchedule.getTotalCount(),
+                    nextSchedule.getAlarmTime().format(TIME_FORMATTER),
+                    firstProofImageUrl(proof)
+            );
+        }
+
+        private static String firstProofImageUrl(MedicationProof proof) {
+            if (proof == null || proof.getProofImageUrls().isEmpty()) {
+                return null;
+            }
+            return proof.getProofImageUrls().getFirst();
+        }
     }
 
     @Schema(description = "걸음 수 정보")

--- a/backend/widyu-api/src/main/java/com/widyu/home/application/SeniorHomeService.java
+++ b/backend/widyu-api/src/main/java/com/widyu/home/application/SeniorHomeService.java
@@ -11,6 +11,7 @@ import com.widyu.goal.walk.repository.WalkRepository;
 import com.widyu.healthschedule.HealthSchedule;
 import com.widyu.heart.repository.HeartRateResultRepository;
 import com.widyu.home.dto.response.SeniorHomeCardsResponse;
+import com.widyu.medicine.MedicationProof;
 import com.widyu.medicine.MedicineSchedule;
 import com.widyu.member.Member;
 import com.widyu.member.MemberType;
@@ -21,8 +22,8 @@ import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.util.Comparator;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
-import java.util.Set;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -75,33 +76,37 @@ public class SeniorHomeService {
         LocalDateTime startOfDay = today.atStartOfDay();
         LocalDateTime endOfDay = today.atTime(LocalTime.MAX);
 
-        Set<Long> takenScheduleIds = medicationProofRepository
+        Map<Long, MedicationProof> proofsByScheduleId = medicationProofRepository
                 .findByMemberIdAndDateRange(member.getId(), startOfDay, endOfDay)
                 .stream()
-                .map(proof -> proof.getMedicineSchedule().getId())
-                .collect(java.util.stream.Collectors.toSet());
+                .collect(java.util.stream.Collectors.toMap(
+                        proof -> proof.getMedicineSchedule().getId(),
+                        proof -> proof,
+                        (first, second) -> first
+                ));
 
         List<SeniorHomeCardsResponse.ScheduleStatus> scheduleStatuses = schedules.stream()
                 .sorted(Comparator.comparing(MedicineSchedule::getAlarmTime))
-                .map(s -> SeniorHomeCardsResponse.ScheduleStatus.from(s, takenScheduleIds.contains(s.getId())))
+                .map(s -> SeniorHomeCardsResponse.ScheduleStatus.from(s, proofsByScheduleId.containsKey(s.getId())))
                 .toList();
 
-        MedicineSchedule nextSchedule = findNextSchedule(schedules);
+        MedicineSchedule nextSchedule = findNextSchedule(schedules, LocalTime.now());
 
         return SeniorHomeCardsResponse.MedicineInfo.from(
                 nextSchedule,
-                takenScheduleIds.size(),
+                proofsByScheduleId.size(),
                 schedules.size(),
-                scheduleStatuses
+                scheduleStatuses,
+                proofsByScheduleId.get(nextSchedule.getId())
         );
     }
 
-    private MedicineSchedule findNextSchedule(List<MedicineSchedule> schedules) {
-        LocalTime now = LocalTime.now();
+    // 알람 시간 오름차순 정렬된 목록 기준. 오늘 남은 알람이 없으면 마지막 알람을 그대로 노출한다.
+    static MedicineSchedule findNextSchedule(List<MedicineSchedule> schedules, LocalTime now) {
         return schedules.stream()
                 .filter(s -> s.getAlarmTime().isAfter(now))
                 .min(Comparator.comparing(MedicineSchedule::getAlarmTime))
-                .orElse(schedules.getFirst());
+                .orElse(schedules.getLast());
     }
 
     private List<SeniorHomeCardsResponse.AlbumInfo> getScoredAlbums(Member senior, LocalDate today) {

--- a/backend/widyu-api/src/main/java/com/widyu/home/application/SeniorHomeService.java
+++ b/backend/widyu-api/src/main/java/com/widyu/home/application/SeniorHomeService.java
@@ -24,6 +24,7 @@ import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.function.BinaryOperator;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -82,7 +83,8 @@ public class SeniorHomeService {
                 .collect(java.util.stream.Collectors.toMap(
                         proof -> proof.getMedicineSchedule().getId(),
                         proof -> proof,
-                        (first, second) -> first
+                        // 조회 쿼리에 정렬이 없어 중복 인증 시 대표를 verifiedAt 최초순으로 고정한다.
+                        BinaryOperator.minBy(Comparator.comparing(MedicationProof::getVerifiedAt))
                 ));
 
         List<SeniorHomeCardsResponse.ScheduleStatus> scheduleStatuses = schedules.stream()

--- a/backend/widyu-api/src/main/java/com/widyu/home/application/SeniorHomeService.java
+++ b/backend/widyu-api/src/main/java/com/widyu/home/application/SeniorHomeService.java
@@ -24,6 +24,7 @@ import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 import java.util.function.BinaryOperator;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -77,9 +78,15 @@ public class SeniorHomeService {
         LocalDateTime startOfDay = today.atStartOfDay();
         LocalDateTime endOfDay = today.atTime(LocalTime.MAX);
 
+        // 스케줄 수정·삭제로 오늘 유효 목록에서 빠진 버전의 인증은 제외한다 (takenCount가 totalCount를 넘지 않도록)
+        Set<Long> scheduleIds = schedules.stream()
+                .map(MedicineSchedule::getId)
+                .collect(java.util.stream.Collectors.toSet());
+
         Map<Long, MedicationProof> proofsByScheduleId = medicationProofRepository
                 .findByMemberIdAndDateRange(member.getId(), startOfDay, endOfDay)
                 .stream()
+                .filter(proof -> scheduleIds.contains(proof.getMedicineSchedule().getId()))
                 .collect(java.util.stream.Collectors.toMap(
                         proof -> proof.getMedicineSchedule().getId(),
                         proof -> proof,

--- a/backend/widyu-api/src/main/java/com/widyu/home/dto/response/SeniorHomeCardsResponse.java
+++ b/backend/widyu-api/src/main/java/com/widyu/home/dto/response/SeniorHomeCardsResponse.java
@@ -5,6 +5,7 @@ import com.widyu.album.Album;
 import com.widyu.healthschedule.HealthSchedule;
 import com.widyu.heart.HeartRateResult;
 import com.widyu.heart.HeartRateStatus;
+import com.widyu.medicine.MedicationProof;
 import com.widyu.medicine.MedicineSchedule;
 import com.widyu.walk.Walk;
 import io.swagger.v3.oas.annotations.media.Schema;
@@ -84,13 +85,17 @@ public record SeniorHomeCardsResponse(
             String nextAlarmTime,
 
             @Schema(description = "스케줄별 복용 상태 (동그라미 색상용, 알람 시간 오름차순)")
-            List<ScheduleStatus> scheduleStatuses
+            List<ScheduleStatus> scheduleStatuses,
+
+            @Schema(description = "해당 스케줄의 복용 인증 이미지 (미복용 시 null)")
+            String proofImageUrl
     ) {
         public static MedicineInfo from(
                 MedicineSchedule nextSchedule,
                 int todayTakenCount,
                 int todayTotalCount,
-                List<ScheduleStatus> scheduleStatuses
+                List<ScheduleStatus> scheduleStatuses,
+                MedicationProof proof
         ) {
             return new MedicineInfo(
                     nextSchedule.getId(),
@@ -98,8 +103,16 @@ public record SeniorHomeCardsResponse(
                     todayTotalCount,
                     nextSchedule.getTotalCount(),
                     nextSchedule.getAlarmTime().format(TIME_FORMATTER),
-                    scheduleStatuses
+                    scheduleStatuses,
+                    firstProofImageUrl(proof)
             );
+        }
+
+        private static String firstProofImageUrl(MedicationProof proof) {
+            if (proof == null || proof.getProofImageUrls().isEmpty()) {
+                return null;
+            }
+            return proof.getProofImageUrls().getFirst();
         }
     }
 

--- a/backend/widyu-api/src/test/java/com/widyu/goal/home/application/GoalHomeServiceTest.java
+++ b/backend/widyu-api/src/test/java/com/widyu/goal/home/application/GoalHomeServiceTest.java
@@ -12,6 +12,7 @@ import com.widyu.global.util.MemberUtil;
 import com.widyu.goal.DailyGoalStatus;
 import com.widyu.goal.healthschedule.repository.HealthScheduleRepository;
 import com.widyu.goal.home.dto.response.GuardianGoalStatsResponse;
+import com.widyu.goal.home.dto.response.SeniorGoalHomeResponse;
 import com.widyu.goal.home.dto.response.SeniorWeeklyGoalStatusResponse;
 import com.widyu.goal.medicineschedule.repository.MedicationProofRepository;
 import com.widyu.goal.medicineschedule.repository.MedicineScheduleRepository;
@@ -230,6 +231,41 @@ class GoalHomeServiceTest {
         // then
         assertThat(nextSchedule.getId()).isEqualTo(2L);
         assertThat(nextSchedule.getAlarmTime()).isEqualTo(LocalTime.of(13, 0));
+    }
+
+    @Test
+    @DisplayName("한 스케줄에 인증이 여러 건이면 조회 순서와 무관하게 최초 인증 이미지를 반환한다")
+    void 중복_인증이면_최초_인증_이미지를_반환한다() {
+        // given
+        LocalDate today = LocalDate.now();
+        Member member = mock(Member.class);
+        MedicineSchedule schedule = alarmSchedule(member, 1L, LocalTime.of(8, 0));
+        MedicationProof earlier = proof(schedule, member, today.atTime(8, 5), "https://cdn.widyu.shop/earlier.jpg");
+        MedicationProof later = proof(schedule, member, today.atTime(8, 25), "https://cdn.widyu.shop/later.jpg");
+
+        given(memberUtil.getCurrentMember()).willReturn(member);
+        given(member.getId()).willReturn(11L);
+        given(medicineScheduleRepository.findEffectiveByMemberAndDateWithDetails(
+                member, Status.ACTIVE, today)).willReturn(List.of(schedule));
+        // 조회 쿼리에 정렬이 없으므로 늦은 인증이 먼저 반환되는 순서를 재현한다.
+        given(medicationProofRepository.findByMemberIdAndDateRange(
+                11L, today.atStartOfDay(), today.atTime(LocalTime.MAX)))
+                .willReturn(List.of(later, earlier));
+        given(walkRepository.findByMemberAndWalkDate(member, today)).willReturn(Optional.empty());
+        given(healthScheduleRepository.findByMemberIdAndWeek(any(), any(), any())).willReturn(List.of());
+
+        // when
+        SeniorGoalHomeResponse response = goalHomeService.getSeniorGoalHome();
+
+        // then
+        assertThat(response.medicine().proofImageUrl()).isEqualTo("https://cdn.widyu.shop/earlier.jpg");
+        assertThat(response.medicine().takenCount()).isEqualTo(1);
+    }
+
+    private MedicationProof proof(MedicineSchedule schedule, Member member, LocalDateTime verifiedAt, String imageUrl) {
+        MedicationProof proof = MedicationProof.create(schedule, member, List.of(imageUrl));
+        ReflectionTestUtils.setField(proof, "verifiedAt", verifiedAt);
+        return proof;
     }
 
     private MedicineSchedule alarmSchedule(Member member, Long id, LocalTime alarmTime) {

--- a/backend/widyu-api/src/test/java/com/widyu/goal/home/application/GoalHomeServiceTest.java
+++ b/backend/widyu-api/src/test/java/com/widyu/goal/home/application/GoalHomeServiceTest.java
@@ -262,6 +262,35 @@ class GoalHomeServiceTest {
         assertThat(response.medicine().takenCount()).isEqualTo(1);
     }
 
+    @Test
+    @DisplayName("오늘 유효 목록에서 빠진 스케줄의 인증은 복용 횟수에 포함하지 않는다")
+    void 유효하지_않은_스케줄의_인증은_복용_횟수에서_제외한다() {
+        // given: 오전에 인증한 뒤 스케줄을 수정해 구 버전이 오늘 유효 목록에서 빠진 상황
+        LocalDate today = LocalDate.now();
+        Member member = mock(Member.class);
+        MedicineSchedule closedSchedule = alarmSchedule(member, 1L, LocalTime.of(8, 0));
+        MedicineSchedule currentSchedule = alarmSchedule(member, 2L, LocalTime.of(9, 0));
+        MedicationProof closedProof = proof(closedSchedule, member, today.atTime(8, 5), "https://cdn.widyu.shop/old.jpg");
+
+        given(memberUtil.getCurrentMember()).willReturn(member);
+        given(member.getId()).willReturn(11L);
+        given(medicineScheduleRepository.findEffectiveByMemberAndDateWithDetails(
+                member, Status.ACTIVE, today)).willReturn(List.of(currentSchedule));
+        given(medicationProofRepository.findByMemberIdAndDateRange(
+                11L, today.atStartOfDay(), today.atTime(LocalTime.MAX)))
+                .willReturn(List.of(closedProof));
+        given(walkRepository.findByMemberAndWalkDate(member, today)).willReturn(Optional.empty());
+        given(healthScheduleRepository.findByMemberIdAndWeek(any(), any(), any())).willReturn(List.of());
+
+        // when
+        SeniorGoalHomeResponse response = goalHomeService.getSeniorGoalHome();
+
+        // then
+        assertThat(response.medicine().takenCount()).isZero();
+        assertThat(response.medicine().totalCount()).isEqualTo(1);
+        assertThat(response.medicine().proofImageUrl()).isNull();
+    }
+
     private MedicationProof proof(MedicineSchedule schedule, Member member, LocalDateTime verifiedAt, String imageUrl) {
         MedicationProof proof = MedicationProof.create(schedule, member, List.of(imageUrl));
         ReflectionTestUtils.setField(proof, "verifiedAt", verifiedAt);

--- a/backend/widyu-api/src/test/java/com/widyu/goal/home/application/GoalHomeServiceTest.java
+++ b/backend/widyu-api/src/test/java/com/widyu/goal/home/application/GoalHomeServiceTest.java
@@ -196,6 +196,48 @@ class GoalHomeServiceTest {
         assertThat(response.thisWeekGoalRates()).containsExactlyElementsOf(expected);
     }
 
+    @Test
+    @DisplayName("오늘 남은 알람이 없으면 마지막 알람을 다음 알람으로 반환한다")
+    void 오늘_남은_알람이_없으면_마지막_알람을_반환한다() {
+        // given
+        Member member = mock(Member.class);
+        List<MedicineSchedule> schedules = List.of(
+                alarmSchedule(member, 1L, LocalTime.of(8, 0)),
+                alarmSchedule(member, 2L, LocalTime.of(13, 0)),
+                alarmSchedule(member, 3L, LocalTime.of(20, 0)));
+
+        // when
+        MedicineSchedule nextSchedule = GoalHomeService.findNextSchedule(schedules, LocalTime.of(23, 0));
+
+        // then
+        assertThat(nextSchedule.getId()).isEqualTo(3L);
+        assertThat(nextSchedule.getAlarmTime()).isEqualTo(LocalTime.of(20, 0));
+    }
+
+    @Test
+    @DisplayName("오늘 남은 알람이 있으면 가장 가까운 알람을 다음 알람으로 반환한다")
+    void 오늘_남은_알람이_있으면_가장_가까운_알람을_반환한다() {
+        // given
+        Member member = mock(Member.class);
+        List<MedicineSchedule> schedules = List.of(
+                alarmSchedule(member, 1L, LocalTime.of(8, 0)),
+                alarmSchedule(member, 2L, LocalTime.of(13, 0)),
+                alarmSchedule(member, 3L, LocalTime.of(20, 0)));
+
+        // when
+        MedicineSchedule nextSchedule = GoalHomeService.findNextSchedule(schedules, LocalTime.of(9, 0));
+
+        // then
+        assertThat(nextSchedule.getId()).isEqualTo(2L);
+        assertThat(nextSchedule.getAlarmTime()).isEqualTo(LocalTime.of(13, 0));
+    }
+
+    private MedicineSchedule alarmSchedule(Member member, Long id, LocalTime alarmTime) {
+        MedicineSchedule schedule = MedicineSchedule.create(member, alarmTime);
+        ReflectionTestUtils.setField(schedule, "id", id);
+        return schedule;
+    }
+
     private MedicineSchedule schedule(Member member, Long id, LocalDate effectiveFrom, LocalDate effectiveTo) {
         MedicineSchedule schedule = MedicineSchedule.create(member, LocalTime.of(8, 0));
         ReflectionTestUtils.setField(schedule, "id", id);


### PR DESCRIPTION
## 개요
시니어 홈 카드 조회와 시니어 목표 홈 조회에서, 오늘 남은 복약 알람이 없을 때 그날 가장 이른 알람이 "다음 알람"으로 내려가던 문제를 수정합니다. 두 서비스 모두 남은 알람을 찾지 못하면 목록의 첫 원소로 폴백했는데, 조회 쿼리(`findEffectiveByMemberAndDateWithDetails`)가 `ORDER BY ms.alarmTime ASC`이므로 첫 원소가 그날 가장 이른 알람이었습니다. 그 결과 23시에 조회해도 `nextAlarmTime`이 `"08:00"`으로 응답되었습니다.

남은 알람이 없는 시점은 대개 하루 복약을 마친 뒤이므로, 두 응답에 복용 인증 이미지(`proofImageUrl`)를 함께 내려 보호자 목표 홈 응답과 계약을 맞춥니다.

## 관련 문서
- LLD: - (LLD-0007은 인증 허용창·상태 계약, LLD-0024는 주간 조회 파이프라인을 다루며 다음 알람 폴백 규칙은 정의하지 않습니다.)
- ADR: -

## 관련 이슈
Closes #508

## 변경 사항
- 변경 모듈: widyu-api
- `SeniorHomeService`·`GoalHomeService`의 폴백을 첫 알람에서 마지막 알람으로 변경했습니다.
- 폴백 분기를 `LocalTime`을 인자로 받는 `findNextSchedule(schedules, now)`로 분리해, 실행 시각에 의존하지 않고 검증할 수 있게 했습니다.
- `SeniorHomeCardsResponse.MedicineInfo`와 `SeniorGoalHomeResponse.MedicineInfo`에 `proofImageUrl` 필드를 추가했습니다. 응답에 담긴 스케줄에 복용 인증이 있으면 첫 이미지 URL을, 없으면 `null`을 내려줍니다.
- `SeniorGoalHomeResponse.MedicineInfo`에 정적 팩토리 `from`을 추가하고, `GoalHomeService`가 DTO를 직접 생성하던 부분을 대체했습니다.
- 복용 인증 조회를 스케줄별 1건 `Map`으로 정규화했습니다. `SeniorHomeService`는 스케줄 ID `Set`만 수집해 이미지 URL을 꺼낼 수 없었고, `GoalHomeService`는 인증 목록 크기를 그대로 `takenCount`로 사용해 한 스케줄에 인증이 2건이면 중복 집계되었습니다.
- Swagger 예시(`GoalHomeDocs`)에 `proofImageUrl`을 반영했습니다.
- `GoalHomeServiceTest`에 남은 알람이 없는 경우와 있는 경우의 선택 결과를 검증하는 테스트 2건을 추가했습니다.

## 테스트
- `./gradlew :backend:widyu-api:test`: 통과 (`GoalHomeServiceTest` 5건 전체 통과)
- `./gradlew :backend:widyu-domain:test`: 해당 없음 (domain 모듈 변경 없습니다.)

## 체크리스트
- [x] 엔티티 변경 시 `./gradlew compileJava` 실행 — 엔티티 변경이 없어 해당하지 않으나 컴파일은 확인했습니다.
- [x] MySQL ENUM 변경 시 ALTER TABLE 명시 — ENUM 변경이 없습니다.
- [x] `@Async` 메서드에 `@Transactional` 확인 — `@Async` 변경이 없습니다.
- [x] LLD 인수조건 전체 충족 — 관련 LLD가 없어 이슈 #508의 완료 조건을 기준으로 확인했습니다.

## 리뷰 포인트
남은 알람이 없을 때 마지막 알람을 그대로 노출하는 것이 맞는지 봐주시면 좋겠습니다. 이 경우 `nextAlarmTime`이라는 필드명과 실제 의미(이미 지난 마지막 알람)가 어긋나므로, 클라이언트가 "오늘 복약 완료" 상태를 구분하려면 별도 플래그가 필요할 수 있습니다.

## Open Questions (LLD 미결정 사항)
없습니다.

## 비고
- 응답에 필드가 추가되는 변경이라 기존 클라이언트에는 하위 호환됩니다.
- 후속 작업으로 `findNextSchedule`이 두 서비스에 중복되어 있어 공통 컴포넌트로 분리할 여지가 있으나, 이번 PR 범위에서는 제외했습니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 시니어 홈 및 목표 홈에서 복용 인증 이미지 URL을 확인할 수 있습니다.
  * 다음 복용 일정과 알람 시간이 정확히 표시됩니다.
  * 복용 횟수가 복용 인증 기록을 기준으로 집계됩니다.

* **버그 수정**
  * 오늘 남은 알람이 없을 때 가장 늦은 알람이 표시되도록 개선했습니다.
  * 중복 복용 인증 시 최초 인증 정보가 대표로 표시됩니다.
  * 복용 인증이 없는 경우 이미지 정보가 안정적으로 처리됩니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->