### PR TITLE
[버그] 같은 날 동일 스케줄 복약 인증 중복을 DB 제약으로 차단합니다

### DIFF
--- a/backend/widyu-api/src/main/java/com/widyu/goal/medicineschedule/application/MedicationProofService.java
+++ b/backend/widyu-api/src/main/java/com/widyu/goal/medicineschedule/application/MedicationProofService.java
@@ -17,6 +17,7 @@ import java.util.ArrayList;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
@@ -83,10 +84,21 @@ public class MedicationProofService {
         List<String> imageUrls = uploadProofImages(images, currentMember.getId());
 
         MedicationProof proof = MedicationProof.create(schedule, currentMember, imageUrls);
-        medicationProofRepository.save(proof);
+        saveProof(proof, scheduleId);
 
         log.info("약 복용 인증 완료: scheduleId={}, memberId={}, verifiedAt={}",
                 scheduleId, currentMember.getId(), now);
+    }
+
+    // 위 중복 검사와 저장 사이에 다른 요청이 끼어들 수 있어, 최종 차단은 DB unique 제약이 맡는다.
+    private void saveProof(MedicationProof proof, Long scheduleId) {
+        try {
+            medicationProofRepository.saveAndFlush(proof);
+        } catch (DataIntegrityViolationException e) {
+            log.warn("약 복용 인증 중복 저장 감지: scheduleId={}", scheduleId);
+            throw new BusinessException(ErrorCode.BAD_REQUEST,
+                    "오늘은 이미 해당 약 복용을 인증했습니다.");
+        }
     }
 
     private List<String> uploadProofImages(List<MultipartFile> images, Long memberId) {

--- a/backend/widyu-api/src/test/java/com/widyu/goal/medicineschedule/repository/MedicationProofRepositoryTest.java
+++ b/backend/widyu-api/src/test/java/com/widyu/goal/medicineschedule/repository/MedicationProofRepositoryTest.java
@@ -1,6 +1,7 @@
 package com.widyu.goal.medicineschedule.repository;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import com.widyu.global.config.JpaAuditingConfig;
@@ -18,6 +19,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
 import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.context.annotation.Import;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.util.ReflectionTestUtils;
@@ -74,5 +76,40 @@ class MedicationProofRepositoryTest {
 
         // then
         assertThat(proofs).extracting(MedicationProof::getId).containsExactly(inRange.getId());
+    }
+
+    @Test
+    @DisplayName("같은 날 동일 스케줄에 인증을 두 건 저장하면 예외가 발생한다")
+    void 같은_날_동일_스케줄에_중복_인증하면_예외가_발생한다() {
+        // given
+        Member member = persistSenior("01055556666");
+        MedicineSchedule schedule = persistSchedule(member, LocalDate.of(2026, 8, 1));
+        persistProof(schedule, member, LocalDateTime.of(2026, 8, 10, 8, 5));
+
+        MedicationProof duplicate = MedicationProof.create(schedule, member, List.of());
+        ReflectionTestUtils.setField(duplicate, "verifiedAt", LocalDateTime.of(2026, 8, 10, 8, 25));
+
+        // when & then: 알람 허용창 안이라 시각은 다르지만 같은 날짜다.
+        // 서비스와 동일하게 리포지토리로 저장해 Spring 예외 변환까지 확인한다.
+        assertThatThrownBy(() -> medicationProofRepository.saveAndFlush(duplicate))
+                .isInstanceOf(DataIntegrityViolationException.class);
+    }
+
+    @Test
+    @DisplayName("날짜가 다르거나 스케줄이 다르면 중복 제약에 걸리지 않는다")
+    void 날짜나_스케줄이_다르면_중복_제약에_걸리지_않는다() {
+        // given
+        Member member = persistSenior("01077778888");
+        MedicineSchedule schedule = persistSchedule(member, LocalDate.of(2026, 8, 1));
+        MedicineSchedule anotherSchedule = persistSchedule(member, LocalDate.of(2026, 8, 1));
+        persistProof(schedule, member, LocalDateTime.of(2026, 8, 10, 8, 5));
+
+        // when
+        MedicationProof nextDay = persistProof(schedule, member, LocalDateTime.of(2026, 8, 11, 8, 5));
+        MedicationProof otherSchedule = persistProof(anotherSchedule, member, LocalDateTime.of(2026, 8, 10, 8, 5));
+
+        // then
+        assertThat(nextDay.getId()).isNotNull();
+        assertThat(otherSchedule.getId()).isNotNull();
     }
 }

--- a/backend/widyu-domain/src/main/java/com/widyu/medicine/MedicationProof.java
+++ b/backend/widyu-domain/src/main/java/com/widyu/medicine/MedicationProof.java
@@ -13,7 +13,10 @@ import jakarta.persistence.Id;
 import jakarta.persistence.Index;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
+import jakarta.persistence.PrePersist;
 import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
@@ -28,7 +31,10 @@ import lombok.NoArgsConstructor;
 @Table(
         name = "medication_proof",
         indexes = @Index(name = "idx_medication_proof_member_verified",
-                columnList = "member_id, verified_at")
+                columnList = "member_id, verified_at"),
+        // 같은 날 동일 스케줄 중복 인증 차단 (애플리케이션 검사만으로는 동시 요청을 막지 못한다)
+        uniqueConstraints = @UniqueConstraint(name = "uk_medication_proof_schedule_date",
+                columnNames = {"medicine_schedule_id", "verified_date"})
 )
 public class MedicationProof extends BaseTimeEntity {
 
@@ -53,6 +59,10 @@ public class MedicationProof extends BaseTimeEntity {
     @Column(nullable = false)
     private LocalDateTime verifiedAt;
 
+    // verifiedAt의 일자 부분. datetime으로는 일자 단위 unique 제약을 걸 수 없어 따로 둔다.
+    @Column(name = "verified_date", nullable = false)
+    private LocalDate verifiedDate;
+
     @Builder(access = AccessLevel.PRIVATE)
     private MedicationProof(MedicineSchedule medicineSchedule, Member member,
                             List<String> proofImageUrls, LocalDateTime verifiedAt) {
@@ -60,6 +70,11 @@ public class MedicationProof extends BaseTimeEntity {
         this.member = member;
         this.proofImageUrls = proofImageUrls != null ? proofImageUrls : new ArrayList<>();
         this.verifiedAt = verifiedAt != null ? verifiedAt : LocalDateTime.now();
+    }
+
+    @PrePersist
+    private void applyVerifiedDate() {
+        this.verifiedDate = this.verifiedAt.toLocalDate();
     }
 
     public static MedicationProof create(MedicineSchedule medicineSchedule, Member member,

--- a/scripts/mysql/add_medication_proof_daily_unique.sql
+++ b/scripts/mysql/add_medication_proof_daily_unique.sql
@@ -1,0 +1,39 @@
+-- 운영 DB에서 애플리케이션 배포 전에 1회 실행합니다.
+-- ddl-auto: update는 기존 테이블에 NOT NULL 컬럼과 unique 제약을 안전하게 추가하지 못합니다.
+-- 목적: 같은 날 동일 스케줄의 복약 인증 중복을 DB에서 차단합니다 (이슈 #510).
+
+-- 1. 일자 컬럼을 nullable로 추가합니다.
+ALTER TABLE medication_proof
+    ADD COLUMN verified_date DATE NULL;
+
+-- 2. 기존 행의 일자를 백필합니다.
+UPDATE medication_proof
+SET verified_date = DATE(verified_at)
+WHERE verified_date IS NULL;
+
+-- 3. 중복 행을 확인합니다. 결과가 있으면 4번을 실행하고, 없으면 4번을 건너뜁니다.
+SELECT medicine_schedule_id, verified_date, COUNT(*) AS cnt
+FROM medication_proof
+GROUP BY medicine_schedule_id, verified_date
+HAVING cnt > 1;
+
+-- 4. 중복이 있으면 스케줄·일자별로 verified_at이 가장 이른 행만 남깁니다.
+--    (조회 응답의 대표 인증 선택 기준과 동일합니다.)
+DELETE p
+FROM medication_proof p
+         JOIN (
+    SELECT medicine_schedule_id,
+           verified_date,
+           MIN(verified_at) AS earliest_verified_at
+    FROM medication_proof
+    GROUP BY medicine_schedule_id, verified_date
+    HAVING COUNT(*) > 1
+) d
+              ON p.medicine_schedule_id = d.medicine_schedule_id
+                  AND p.verified_date = d.verified_date
+                  AND p.verified_at > d.earliest_verified_at;
+
+-- 5. NOT NULL로 전환하고 unique 제약을 겁니다.
+ALTER TABLE medication_proof
+    MODIFY COLUMN verified_date DATE NOT NULL,
+    ADD CONSTRAINT uk_medication_proof_schedule_date UNIQUE (medicine_schedule_id, verified_date);


### PR DESCRIPTION
## 개요
같은 날 동일 스케줄의 복약 인증 중복을 DB unique 제약으로 차단합니다.

지금까지 중복 차단은 `MedicationProofService`의 사전 조회(`existsByMedicineScheduleAndVerifiedAtBetween`)뿐이었습니다. 검사와 저장 사이에 다른 요청이 끼어들면 두 요청 모두 검사를 통과해 인증 행이 두 개 생길 수 있었고, `backend/CLAUDE.md`에 명시된 복약 불변식("같은 날 동일 스케줄 중복 불가")이 저장 계층에서 보장되지 않았습니다.

## 관련 문서
- LLD: docs/lld/LLD-0007-medicine-daily-status.md (인증 허용창·상태 계약을 다루며, 중복 방지의 저장 계층 보장은 정의하지 않습니다.)
- ADR: -

## 관련 이슈
Closes #510

## 변경 사항
- 변경 모듈: widyu-domain, widyu-api
- `MedicationProof`에 `verified_date DATE` 컬럼을 추가하고 `(medicine_schedule_id, verified_date)`에 `uk_medication_proof_schedule_date` unique 제약을 걸었습니다. `verifiedAt`이 `datetime`이라 그대로는 일자 단위 제약을 걸 수 없어, `Walk.walk_date`와 같은 방식으로 일자 컬럼을 분리했습니다.
- `verified_date` 값은 `@PrePersist`에서 `verifiedAt`으로부터 파생시킵니다. 두 컬럼이 어긋날 여지를 없애고, 인증 시각을 지정해 저장하는 기존 테스트도 그대로 동작합니다.
- `MedicationProofService`가 `saveAndFlush`로 저장하고 `DataIntegrityViolationException`을 기존 사전 검사와 동일한 안내 메시지("오늘은 이미 해당 약 복용을 인증했습니다.")로 변환합니다. `save`는 커밋 시점에 flush되어 예외를 호출 지점에서 잡을 수 없습니다.
- 기존 사전 검사는 그대로 두었습니다. 정상 경로에서는 제약 위반 없이 안내 메시지를 돌려주고, 제약은 경쟁 조건의 최종 방어선 역할만 합니다.
- `scripts/mysql/add_medication_proof_daily_unique.sql`을 추가했습니다. 컬럼 추가 → 백필 → 중복 확인 → 중복 정리 → NOT NULL 전환 및 제약 추가 순서입니다.
- `MedicationProofRepositoryTest`에 제약 동작 검증 2건(같은 날 중복이면 예외, 날짜·스케줄이 다르면 정상)을 추가했습니다.

## 테스트
- `./gradlew :backend:widyu-api:test --tests "*Medic*" --tests "*Home*" --tests "*Goal*" --tests "*Walk*"`: 통과
- `./gradlew :backend:widyu-domain:test`: 통과
- 참고: 현재 develop 기준 전체 실행 시 `AlbumUnlockServiceTest`·`AlbumPermissionServiceTest` 7건이 실패하지만, 이 PR과 무관한 별개 작업의 미완성 변경입니다.

## 체크리스트
- [x] 엔티티 변경 시 `./gradlew compileJava` 실행
- [x] MySQL ENUM 변경 시 ALTER TABLE 명시 — ENUM 변경은 없고, 컬럼·제약 추가 스크립트를 `scripts/mysql`에 포함했습니다.
- [x] `@Async` 메서드에 `@Transactional` 확인 — `@Async` 변경이 없습니다.
- [x] LLD 인수조건 전체 충족 — 관련 LLD가 없어 이슈 #510의 완료 조건을 기준으로 확인했습니다.

## 리뷰 포인트
`verified_date`를 애플리케이션에서 파생시키는 방식(`@PrePersist`)이 적절한지 봐주시면 좋겠습니다. MySQL 8 generated column(`DATE AS (DATE(verified_at)) STORED`)으로 DB에 맡기는 대안도 있으나, `ddl-auto: update`가 generated column을 만들지 못해 H2 테스트와 스키마가 갈리는 점 때문에 애플리케이션 파생을 택했습니다.

## Open Questions (LLD 미결정 사항)
없습니다.

## 비고
- **배포 전 `scripts/mysql/add_medication_proof_daily_unique.sql`을 운영 DB에서 1회 실행해야 합니다.** 스크립트를 실행하지 않으면 `verified_date`가 없어 인증 저장이 실패합니다.
- 스크립트 3번 단계에서 중복 행을 먼저 확인하고, 있으면 4번으로 `verified_at`이 가장 이른 행만 남깁니다. 이는 #509에서 정한 대표 인증 선택 기준과 동일합니다.
- 후속 작업으로, 제약 위반 시 이미 업로드된 S3 인증 이미지가 정리되지 않고 남습니다. 경쟁 조건에서만 발생하고 기존 코드도 동일하게 동작해 이번 PR에서는 다루지 않았습니다.
