### PR TITLE
[설정] Android App Links 검증 파일을 제공합니다

### DIFF
--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -100,6 +100,10 @@ jobs:
             nginx/ \
             ${{ env.EC2_SSH_USER }}@${{ env.EC2_HOST }}:/home/ec2-user/widyu/nginx/
 
+          rsync -avz -e "ssh -i private_key.pem -o StrictHostKeyChecking=no" \
+            .well-known/ \
+            ${{ env.EC2_SSH_USER }}@${{ env.EC2_HOST }}:/home/ec2-user/widyu/.well-known/
+
           rsync -avz --delete -e "ssh -i private_key.pem -o StrictHostKeyChecking=no" \
             scripts/ \
             ${{ env.EC2_SSH_USER }}@${{ env.EC2_HOST }}:/home/ec2-user/widyu/scripts/

--- a/.gitignore
+++ b/.gitignore
@@ -47,6 +47,7 @@ out/
 src/main/resources/firebase/
 *.json
 !admin/*.json
+!.well-known/assetlinks.json
 
 # claude
 # settings.json 은 Project 스코프(팀 공유 권한·훅)라 추적한다.

--- a/.well-known/assetlinks.json
+++ b/.well-known/assetlinks.json
@@ -7,7 +7,7 @@
       "namespace": "android_app",
       "package_name": "com.example.widyu",
       "sha256_cert_fingerprints": [
-        "93:B0:0C:A6:9A:34:B0:E7:97:50:DE:67:EB:53:8D:AD:A3:63:4D:79:62:B5:F7:AB:E4:DB:E3:10:F2:67:C8:B5"
+        "11:ED:C0:8D:20:EF:2A:F6:FD:1F:B2:C6:AD:45:85:B4:50:74:FD:D3:7C:A6:61:A8:48:BE:45:A9:F5:8B:57:A1"
       ]
     }
   }

--- a/.well-known/assetlinks.json
+++ b/.well-known/assetlinks.json
@@ -1,0 +1,14 @@
+[
+  {
+    "relation": [
+      "delegate_permission/common.handle_all_urls"
+    ],
+    "target": {
+      "namespace": "android_app",
+      "package_name": "com.example.widyu",
+      "sha256_cert_fingerprints": [
+        "93:B0:0C:A6:9A:34:B0:E7:97:50:DE:67:EB:53:8D:AD:A3:63:4D:79:62:B5:F7:AB:E4:DB:E3:10:F2:67:C8:B5"
+      ]
+    }
+  }
+]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -146,6 +146,7 @@ services:
       - "${NGINX_HTTPS_PORT}:443"
     volumes:
       - ./nginx/nginx.conf:/etc/nginx/nginx.conf:ro
+      - ./.well-known:/usr/share/nginx/.well-known:ro
       - ./admin/dist:/usr/share/nginx/admin:ro
       - nginx_logs:/var/log/nginx
       - certbot_webroot:/var/www/certbot:ro

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -101,6 +101,11 @@ http {
         add_header Referrer-Policy "strict-origin-when-cross-origin" always;
         add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;
 
+        location = /.well-known/assetlinks.json {
+            root /usr/share/nginx;
+            default_type application/json;
+        }
+
         # WebSocket Requests
         location /ws/ {
             access_log /var/log/nginx/access.log ws_no_query;


### PR DESCRIPTION
## 개요
Android App Links가 서비스 도메인과 Android 앱의 관계를 검증할 수 있도록 Digital Asset Links 파일을 HTTPS 루트 경로로 제공합니다.

## 관련 문서
- LLD: 없습니다.
- ADR: 없습니다.

## 관련 이슈
Closes #516

## 변경 사항
- 변경 모듈: 저장소 루트 및 Nginx 배포 설정
- `.well-known/assetlinks.json`에 앱 패키지와 SHA-256 인증서 지문을 등록합니다.
- Nginx가 `/.well-known/assetlinks.json`을 `application/json`으로 직접 제공합니다.
- `.well-known` 디렉터리를 Nginx 컨테이너에 읽기 전용으로 마운트합니다.
- 개발 서버 배포 시 `.well-known` 디렉터리를 EC2에 동기화합니다.
- Android 앱의 Manifest, 운영 도메인 및 Google Play 폴백은 포함하지 않습니다.

## 테스트
- `jq` JSON 구조 및 값 검증: 통과했습니다.
- `docker compose config --quiet`: 통과했습니다.
- GitHub Actions workflow YAML 파싱: 통과했습니다.
- Nginx 컨테이너 설정 검사 및 HTTPS 요청: HTTP 200, `Content-Type: application/json`, 파일 내용 일치를 확인했습니다.
- 애플리케이션 코드 변경이 없어 Gradle 테스트는 실행하지 않았습니다.

## 체크리스트
- [x] 엔티티를 변경하지 않았습니다.
- [x] MySQL ENUM을 변경하지 않았습니다.
- [x] `@Async` 메서드를 변경하지 않았습니다.
- [x] 관련 LLD가 없으며 이슈 완료 조건을 충족했습니다.

## 리뷰 포인트

## Open Questions (LLD 미결정 사항)
없습니다.

## 비고
실제 개발 서버 URL의 최종 응답은 배포 후 확인해야 합니다.
