### PR TITLE
[버그] App Links 배포와 미설치 폴백을 수정합니다

### DIFF
--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -100,10 +100,6 @@ jobs:
             nginx/ \
             ${{ env.EC2_SSH_USER }}@${{ env.EC2_HOST }}:/home/ec2-user/widyu/nginx/
 
-          rsync -avz -e "ssh -i private_key.pem -o StrictHostKeyChecking=no" \
-            .well-known/ \
-            ${{ env.EC2_SSH_USER }}@${{ env.EC2_HOST }}:/home/ec2-user/widyu/.well-known/
-
           rsync -avz --delete -e "ssh -i private_key.pem -o StrictHostKeyChecking=no" \
             scripts/ \
             ${{ env.EC2_SSH_USER }}@${{ env.EC2_HOST }}:/home/ec2-user/widyu/scripts/
@@ -111,6 +107,10 @@ jobs:
           rsync -avz --delete -e "ssh -i private_key.pem -o StrictHostKeyChecking=no" \
             admin/dist/ \
             ${{ env.EC2_SSH_USER }}@${{ env.EC2_HOST }}:/home/ec2-user/widyu/admin/dist/
+
+          rsync -avz -e "ssh -i private_key.pem -o StrictHostKeyChecking=no" \
+            .well-known/ \
+            ${{ env.EC2_SSH_USER }}@${{ env.EC2_HOST }}:/home/ec2-user/widyu/admin/dist/.well-known/
 
           # rsync -avz --delete -e "ssh -i private_key.pem -o StrictHostKeyChecking=no" \
           #   monitoring/ \

--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -104,13 +104,11 @@ jobs:
             scripts/ \
             ${{ env.EC2_SSH_USER }}@${{ env.EC2_HOST }}:/home/ec2-user/widyu/scripts/
 
+          rsync -av --delete .well-known/ admin/dist/.well-known/
+
           rsync -avz --delete -e "ssh -i private_key.pem -o StrictHostKeyChecking=no" \
             admin/dist/ \
             ${{ env.EC2_SSH_USER }}@${{ env.EC2_HOST }}:/home/ec2-user/widyu/admin/dist/
-
-          rsync -avz -e "ssh -i private_key.pem -o StrictHostKeyChecking=no" \
-            .well-known/ \
-            ${{ env.EC2_SSH_USER }}@${{ env.EC2_HOST }}:/home/ec2-user/widyu/admin/dist/.well-known/
 
           # rsync -avz --delete -e "ssh -i private_key.pem -o StrictHostKeyChecking=no" \
           #   monitoring/ \

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -146,7 +146,6 @@ services:
       - "${NGINX_HTTPS_PORT}:443"
     volumes:
       - ./nginx/nginx.conf:/etc/nginx/nginx.conf:ro
-      - ./.well-known:/usr/share/nginx/.well-known:ro
       - ./admin/dist:/usr/share/nginx/admin:ro
       - nginx_logs:/var/log/nginx
       - certbot_webroot:/var/www/certbot:ro

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -106,6 +106,11 @@ http {
             default_type application/json;
         }
 
+        # 앱이 설치되지 않아 브라우저로 열린 App Link는 Google Play로 보낸다.
+        location / {
+            return 302 https://play.google.com/store/apps;
+        }
+
         # WebSocket Requests
         location /ws/ {
             access_log /var/log/nginx/access.log ws_no_query;

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -102,7 +102,7 @@ http {
         add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;
 
         location = /.well-known/assetlinks.json {
-            root /usr/share/nginx;
+            root /usr/share/nginx/admin;
             default_type application/json;
         }
 


### PR DESCRIPTION
## 개요
실행 중인 Nginx에 App Links 검증 파일이 반영되도록 배포 경로를 수정하고, 미설치 사용자를 Google Play 홈으로 안내합니다.

## 관련 문서
- LLD: 없습니다.
- ADR: 없습니다.

## 관련 이슈
Closes #518

## 변경 사항
- 변경 모듈: Nginx 및 개발 배포 설정
- `.well-known` 파일을 `admin/dist/.well-known` 산출물에 먼저 포함하고 원격 rsync 한 번으로 배포합니다.
- Nginx가 기존 Admin 정적 파일 마운트에서 검증 파일을 제공합니다.
- Nginx 재생성이 필요한 별도 `.well-known` 바인드 마운트를 제거합니다.
- 앱이 처리하지 않은 일반 경로를 Google Play 홈으로 리다이렉트합니다.
- 기존 API, WebSocket, Admin, Swagger 및 Actuator 경로는 그대로 유지합니다.

## 테스트
- `jq` JSON 구조 및 인증서 지문 검증: 통과했습니다.
- `docker compose config --quiet`: 통과했습니다.
- GitHub Actions workflow YAML 파싱: 통과했습니다.
- 로컬 rsync 결과와 원본 `assetlinks.json` 내용 일치: 통과했습니다.
- Nginx 설정 검사: 통과했습니다.
- `/.well-known/assetlinks.json`: HTTP 200, `Content-Type: application/json`, 원본 파일 일치를 확인했습니다.
- `/invite/example`: Google Play 홈으로 HTTP 302 응답을 확인했습니다.
- `/api/example`: Google Play로 리다이렉트되지 않고 기존 API location을 사용하는지 확인했습니다.
- 애플리케이션 코드 변경이 없어 Gradle 테스트는 실행하지 않았습니다.

## 체크리스트
- [x] 엔티티를 변경하지 않았습니다.
- [x] MySQL ENUM을 변경하지 않았습니다.
- [x] `@Async` 메서드를 변경하지 않았습니다.
- [x] 이슈 완료 조건을 충족했습니다.

## 리뷰 포인트
일반 경로 폴백이 기존 서버 경로를 침범하지 않고 검증 파일과 API location이 우선 적용되는지 확인해 주세요.

## Open Questions (LLD 미결정 사항)
없습니다.

## 비고
Google Play 등록 후 리다이렉트 목적지를 WIDYU 앱 상세 페이지 URL로 변경해야 합니다.
