### PR TITLE
[기능 수정] 홈·목표 홈 건강 일정 응답에 위도·경도를 포함합니다

### DIFF
--- a/backend/widyu-api/src/main/java/com/widyu/goal/home/application/GoalHomeService.java
+++ b/backend/widyu-api/src/main/java/com/widyu/goal/home/application/GoalHomeService.java
@@ -260,7 +260,9 @@ public class GoalHomeService {
                 dday,
                 nearest.getScheduledAt(),
                 nearest.getScheduleName(),
-                nearest.getPlaceAddress()
+                nearest.getPlaceAddress(),
+                nearest.getLatitude(),
+                nearest.getLongitude()
         );
     }
 
@@ -472,7 +474,9 @@ public class GoalHomeService {
                 dday,
                 nearest.getScheduledAt(),
                 nearest.getScheduleName(),
-                nearest.getPlaceAddress()
+                nearest.getPlaceAddress(),
+                nearest.getLatitude(),
+                nearest.getLongitude()
         );
     }
 

--- a/backend/widyu-api/src/main/java/com/widyu/goal/home/application/GoalHomeService.java
+++ b/backend/widyu-api/src/main/java/com/widyu/goal/home/application/GoalHomeService.java
@@ -255,15 +255,7 @@ public class GoalHomeService {
 
         int dday = (int) java.time.temporal.ChronoUnit.DAYS.between(now.toLocalDate(), nearest.getScheduledAt().toLocalDate());
 
-        return new SeniorGoalHomeResponse.HospitalInfo(
-                nearest.getId(),
-                dday,
-                nearest.getScheduledAt(),
-                nearest.getScheduleName(),
-                nearest.getPlaceAddress(),
-                nearest.getLatitude(),
-                nearest.getLongitude()
-        );
+        return SeniorGoalHomeResponse.HospitalInfo.from(nearest, dday);
     }
 
     private DailyGoalStatus calculateDailyGoalStatus(GoalPeriodData periodData, LocalDate date, LocalDate today) {
@@ -469,15 +461,7 @@ public class GoalHomeService {
 
         int dday = (int) java.time.temporal.ChronoUnit.DAYS.between(now.toLocalDate(), nearest.getScheduledAt().toLocalDate());
 
-        return new GuardianGoalHomeResponse.HospitalInfo(
-                nearest.getId(),
-                dday,
-                nearest.getScheduledAt(),
-                nearest.getScheduleName(),
-                nearest.getPlaceAddress(),
-                nearest.getLatitude(),
-                nearest.getLongitude()
-        );
+        return GuardianGoalHomeResponse.HospitalInfo.from(nearest, dday);
     }
 
     private Member getMember(Long memberId) {

--- a/backend/widyu-api/src/main/java/com/widyu/goal/home/dto/response/GuardianGoalHomeResponse.java
+++ b/backend/widyu-api/src/main/java/com/widyu/goal/home/dto/response/GuardianGoalHomeResponse.java
@@ -2,6 +2,7 @@ package com.widyu.goal.home.dto.response;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
 import com.widyu.goal.medicineschedule.dto.response.MedicationStatus;
+import com.widyu.healthschedule.HealthSchedule;
 import io.swagger.v3.oas.annotations.media.Schema;
 import java.time.LocalDateTime;
 import java.util.List;
@@ -92,5 +93,16 @@ public record GuardianGoalHomeResponse(
             @Schema(description = "경도", example = "127.0327")
             Double longitude
     ) {
+        public static HospitalInfo from(HealthSchedule schedule, int dday) {
+            return new HospitalInfo(
+                    schedule.getId(),
+                    dday,
+                    schedule.getScheduledAt(),
+                    schedule.getScheduleName(),
+                    schedule.getPlaceAddress(),
+                    schedule.getLatitude(),
+                    schedule.getLongitude()
+            );
+        }
     }
 }

--- a/backend/widyu-api/src/main/java/com/widyu/goal/home/dto/response/GuardianGoalHomeResponse.java
+++ b/backend/widyu-api/src/main/java/com/widyu/goal/home/dto/response/GuardianGoalHomeResponse.java
@@ -84,7 +84,13 @@ public record GuardianGoalHomeResponse(
             String name,
 
             @Schema(description = "병원 주소", example = "병원 주소")
-            String address
+            String address,
+
+            @Schema(description = "위도", example = "37.5894")
+            Double latitude,
+
+            @Schema(description = "경도", example = "127.0327")
+            Double longitude
     ) {
     }
 }

--- a/backend/widyu-api/src/main/java/com/widyu/goal/home/dto/response/SeniorGoalHomeResponse.java
+++ b/backend/widyu-api/src/main/java/com/widyu/goal/home/dto/response/SeniorGoalHomeResponse.java
@@ -3,6 +3,7 @@ package com.widyu.goal.home.dto.response;
 import com.fasterxml.jackson.annotation.JsonFormat;
 import com.widyu.medicine.MedicationProof;
 import com.widyu.medicine.MedicineSchedule;
+import com.widyu.healthschedule.HealthSchedule;
 import io.swagger.v3.oas.annotations.media.Schema;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
@@ -106,5 +107,16 @@ public record SeniorGoalHomeResponse(
             @Schema(description = "경도", example = "127.0327")
             Double longitude
     ) {
+        public static HospitalInfo from(HealthSchedule schedule, int dday) {
+            return new HospitalInfo(
+                    schedule.getId(),
+                    dday,
+                    schedule.getScheduledAt(),
+                    schedule.getScheduleName(),
+                    schedule.getPlaceAddress(),
+                    schedule.getLatitude(),
+                    schedule.getLongitude()
+            );
+        }
     }
 }

--- a/backend/widyu-api/src/main/java/com/widyu/goal/home/dto/response/SeniorGoalHomeResponse.java
+++ b/backend/widyu-api/src/main/java/com/widyu/goal/home/dto/response/SeniorGoalHomeResponse.java
@@ -98,7 +98,13 @@ public record SeniorGoalHomeResponse(
             String name,
 
             @Schema(description = "병원 주소", example = "병원 주소")
-            String address
+            String address,
+
+            @Schema(description = "위도", example = "37.5894")
+            Double latitude,
+
+            @Schema(description = "경도", example = "127.0327")
+            Double longitude
     ) {
     }
 }

--- a/backend/widyu-api/src/main/java/com/widyu/home/dto/response/GuardianHomeCardsResponse.java
+++ b/backend/widyu-api/src/main/java/com/widyu/home/dto/response/GuardianHomeCardsResponse.java
@@ -131,14 +131,22 @@ public record GuardianHomeCardsResponse(
             LocalDateTime scheduledAt,
 
             @Schema(description = "장소 주소", example = "서울특별시 성북구 고려대로 73")
-            String placeAddress
+            String placeAddress,
+
+            @Schema(description = "위도", example = "37.5894")
+            Double latitude,
+
+            @Schema(description = "경도", example = "127.0327")
+            Double longitude
     ) {
         public static HealthScheduleInfo from(HealthSchedule schedule) {
             return new HealthScheduleInfo(
                     schedule.getId(),
                     schedule.getScheduleName(),
                     schedule.getScheduledAt(),
-                    schedule.getPlaceAddress()
+                    schedule.getPlaceAddress(),
+                    schedule.getLatitude(),
+                    schedule.getLongitude()
             );
         }
     }

--- a/backend/widyu-api/src/main/java/com/widyu/home/dto/response/SeniorHomeCardsResponse.java
+++ b/backend/widyu-api/src/main/java/com/widyu/home/dto/response/SeniorHomeCardsResponse.java
@@ -155,7 +155,13 @@ public record SeniorHomeCardsResponse(
             LocalDateTime scheduledAt,
 
             @Schema(description = "장소 주소", example = "서울특별시 성북구 고려대로 73")
-            String placeAddress
+            String placeAddress,
+
+            @Schema(description = "위도", example = "37.5894")
+            Double latitude,
+
+            @Schema(description = "경도", example = "127.0327")
+            Double longitude
     ) {
         public static HealthScheduleInfo from(HealthSchedule schedule, LocalDate today) {
             int dday = (int) ChronoUnit.DAYS.between(today, schedule.getScheduledAt().toLocalDate());
@@ -163,7 +169,9 @@ public record SeniorHomeCardsResponse(
                     schedule.getScheduleName(),
                     dday,
                     schedule.getScheduledAt(),
-                    schedule.getPlaceAddress()
+                    schedule.getPlaceAddress(),
+                    schedule.getLatitude(),
+                    schedule.getLongitude()
             );
         }
     }


### PR DESCRIPTION
## 개요
홈 화면과 목표 홈 화면은 다가오는 건강 일정의 장소 주소(`placeAddress` / `address`)만 내려주고 있어, 클라이언트가 지도에 목적지를 표시하려면 주소를 다시 지오코딩해야 했습니다. 건강 일정 상세·주간 조회 응답은 이미 `latitude`·`longitude`를 내려주고 있으므로, 홈과 목표 홈 응답도 동일한 좌표를 함께 제공하도록 필드만 추가했습니다.

## 관련 문서
- LLD: docs/lld/LLD-0024-goal-home-query-pipeline.md
- ADR: -

## 관련 이슈
Closes #520

## 변경 사항
- 변경 모듈: widyu-api
- `SeniorHomeCardsResponse.HealthScheduleInfo`, `GuardianHomeCardsResponse.HealthScheduleInfo`에 `latitude`, `longitude` 필드를 추가하고 `from()` 팩토리에서 엔티티 값을 매핑했습니다.
- `SeniorGoalHomeResponse.HospitalInfo`, `GuardianGoalHomeResponse.HospitalInfo`에 `latitude`, `longitude` 필드를 추가했습니다.
- `GoalHomeService`의 `getUpcomingHospitalInfo()`, `getGuardianHospitalInfo()` 매핑에 좌표 2개를 전달하도록 수정했습니다.
- 추가한 필드에 Swagger `@Schema` 설명과 예시 값을 함께 작성했습니다.

## 테스트
- `./gradlew :backend:widyu-api:test`: 통과
- `./gradlew :backend:widyu-domain:test`: 해당 없음 (domain 변경 없음)

## 체크리스트
- [x] 엔티티 변경 시 `./gradlew compileJava` 실행 — 엔티티 변경이 없어 해당 없습니다.
- [x] MySQL ENUM 변경 시 ALTER TABLE 명시 — ENUM 변경이 없어 해당 없습니다.
- [x] `@Async` 메서드에 `@Transactional` 확인 — `@Async` 추가가 없어 해당 없습니다.
- [x] LLD 인수조건 전체 충족

## 리뷰 포인트
좌표가 없는 기존 건강 일정은 `latitude`/`longitude`가 `null`로 내려가는데, 홈·목표 홈 응답에서 이대로 `null`을 노출하는 것이 맞을까요? (기본값 대체 없이 클라이언트가 null 분기하는 전제입니다.)

## Open Questions (LLD 미결정 사항)
없습니다.

## 비고
- 응답 필드 추가만 있고 기존 필드·타입 변경은 없어 하위 호환됩니다.
- 스키마 변경이 없어 배포 시 DB 작업이 필요하지 않습니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새로운 기능**
  * 시니어 및 보호자 병원 일정에 병원 주소와 위도·경도 정보가 표시됩니다.
  * 시니어 및 보호자 건강 일정에 장소의 위도·경도 정보가 추가됩니다.
  * 일정 장소 정보를 활용해 지도 기반 위치 확인이 가능해집니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->