### PR TITLE
[버그] 임시 토큰 회원가입 인증 충돌을 수정합니다

### DIFF
--- a/backend/widyu-api/src/main/java/com/widyu/global/filter/JwtAuthenticationFilter.java
+++ b/backend/widyu-api/src/main/java/com/widyu/global/filter/JwtAuthenticationFilter.java
@@ -15,6 +15,7 @@ import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -30,8 +31,21 @@ import org.springframework.web.filter.OncePerRequestFilter;
 @RequiredArgsConstructor
 public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
+    private static final Set<String> TEMPORARY_TOKEN_PATHS = Set.of(
+            "/api/v1/auth/guardians/sign-up/local",
+            "/api/v1/auth/guardians/password",
+            "/api/v1/auth/guardians/apple/phone-number",
+            "/api/v1/auth/guardians/profile/temporary",
+            "/api/v1/auth/guardians/social/integration"
+    );
+
     private final JwtTokenProvider jwtTokenProvider;
     private final ObjectMapper objectMapper = new ObjectMapper();
+
+    @Override
+    protected boolean shouldNotFilter(@NonNull HttpServletRequest request) {
+        return TEMPORARY_TOKEN_PATHS.contains(request.getRequestURI());
+    }
 
     @Override
     protected void doFilterInternal(

--- a/backend/widyu-api/src/test/java/com/widyu/auth/controller/GuardianAuthTemporaryTokenSecurityTest.java
+++ b/backend/widyu-api/src/test/java/com/widyu/auth/controller/GuardianAuthTemporaryTokenSecurityTest.java
@@ -1,0 +1,96 @@
+package com.widyu.auth.controller;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.widyu.auth.application.guardian.GuardianAuthService;
+import com.widyu.auth.dto.request.LocalGuardianSignupRequest;
+import com.widyu.auth.dto.response.LocalSignupResponse;
+import com.widyu.auth.dto.response.SignUpUserInfo;
+import com.widyu.auth.dto.response.TokenPairResponse;
+import com.widyu.global.config.SecurityConfig;
+import com.widyu.global.error.BusinessException;
+import com.widyu.global.error.ErrorCode;
+import com.widyu.global.security.JwtTokenProvider;
+import jakarta.servlet.http.HttpServletRequest;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+@WebMvcTest(GuardianAuthController.class)
+@Import(SecurityConfig.class)
+@DisplayName("보호자 임시 토큰 HTTP 인증")
+class GuardianAuthTemporaryTokenSecurityTest {
+
+    private static final String TEMPORARY_TOKEN = "temporary-token";
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private GuardianAuthService guardianAuthService;
+
+    @MockBean
+    private JwtTokenProvider jwtTokenProvider;
+
+    @Test
+    @DisplayName("임시 토큰으로 이메일 회원가입하면 서비스까지 요청을 전달한다")
+    void 임시_토큰으로_이메일_회원가입하면_서비스까지_요청을_전달한다() throws Exception {
+        // given
+        LocalSignupResponse response = LocalSignupResponse.ofTokenPair(
+                TokenPairResponse.of(1L, "access-token", "refresh-token"),
+                SignUpUserInfo.of("홍길동", "01012345678", "guardian@example.com")
+        );
+        given(jwtTokenProvider.retrieveAccessToken(TEMPORARY_TOKEN))
+                .willThrow(new BusinessException(ErrorCode.INVALID_ACCESS_TOKEN));
+        given(guardianAuthService.localGuardianSignup(
+                any(HttpServletRequest.class),
+                any(LocalGuardianSignupRequest.class)
+        )).willReturn(response);
+
+        // when & then
+        mockMvc.perform(post("/api/v1/auth/guardians/sign-up/local")
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + TEMPORARY_TOKEN)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                  "email": "guardian@example.com",
+                                  "password": "Password1!",
+                                  "name": "홍길동",
+                                  "phoneNumber": "01012345678"
+                                }
+                                """))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.code").value("AUTH_2002"));
+
+        then(guardianAuthService).should().localGuardianSignup(
+                any(HttpServletRequest.class),
+                any(LocalGuardianSignupRequest.class)
+        );
+    }
+
+    @Test
+    @DisplayName("일반 API에 유효하지 않은 액세스 토큰을 전달하면 기존 오류를 반환한다")
+    void 일반_API에_유효하지_않은_액세스_토큰을_전달하면_기존_오류를_반환한다() throws Exception {
+        // given
+        String invalidAccessToken = "invalid-access-token";
+        given(jwtTokenProvider.retrieveAccessToken(invalidAccessToken))
+                .willThrow(new BusinessException(ErrorCode.INVALID_ACCESS_TOKEN));
+
+        // when & then
+        mockMvc.perform(post("/api/v1/ws/token")
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + invalidAccessToken))
+                .andExpect(status().isUnauthorized())
+                .andExpect(jsonPath("$.code").value("AUTH_4018"));
+    }
+}

--- a/backend/widyu-api/src/test/java/com/widyu/global/filter/JwtAuthenticationFilterTest.java
+++ b/backend/widyu-api/src/test/java/com/widyu/global/filter/JwtAuthenticationFilterTest.java
@@ -1,0 +1,52 @@
+package com.widyu.global.filter;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.then;
+
+import com.widyu.global.security.JwtTokenProvider;
+import jakarta.servlet.ServletException;
+import java.io.IOException;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpHeaders;
+import org.springframework.mock.web.MockFilterChain;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("JWT 인증 필터 단위 테스트")
+class JwtAuthenticationFilterTest {
+
+    @Mock
+    private JwtTokenProvider jwtTokenProvider;
+
+    @ParameterizedTest
+    @ValueSource(strings = {
+            "/api/v1/auth/guardians/sign-up/local",
+            "/api/v1/auth/guardians/password",
+            "/api/v1/auth/guardians/apple/phone-number",
+            "/api/v1/auth/guardians/profile/temporary",
+            "/api/v1/auth/guardians/social/integration"
+    })
+    @DisplayName("임시 토큰 API를 호출하면 액세스 토큰 검증을 건너뛴다")
+    void 임시_토큰_API를_호출하면_액세스_토큰_검증을_건너뛴다(String requestUri)
+            throws IOException, ServletException {
+        // given
+        JwtAuthenticationFilter filter = new JwtAuthenticationFilter(jwtTokenProvider);
+        MockHttpServletRequest request = new MockHttpServletRequest("POST", requestUri);
+        request.addHeader(HttpHeaders.AUTHORIZATION, "Bearer temporary-token");
+        MockHttpServletResponse response = new MockHttpServletResponse();
+        MockFilterChain filterChain = new MockFilterChain();
+
+        // when
+        filter.doFilter(request, response, filterChain);
+
+        // then
+        assertThat(filterChain.getRequest()).isSameAs(request);
+        then(jwtTokenProvider).shouldHaveNoInteractions();
+    }
+}

--- a/docs/lld/LLD-0025-temporary-token-auth-filter.md
+++ b/docs/lld/LLD-0025-temporary-token-auth-filter.md
@@ -1,0 +1,114 @@
+# LLD-0025: 임시 토큰 인증 API의 액세스 토큰 필터 분리
+
+> Low-Level Design. 이 문서는 해당 기능 구현과 PR 본문의 **오라클(ground truth)** 이다.
+
+| 항목 | 값 |
+| --- | --- |
+| 상태 | Approved |
+| Issue | #522 |
+| 관련 ADR | ADR-0002 |
+| 작성자 | dongkyunKim |
+| 작성일 | 2026-08-24 |
+
+## 1. 목적 / 배경
+
+SMS 인증 후 발급한 임시 토큰을 `Authorization: Bearer`로 전달하면 공통 `JwtAuthenticationFilter`가 이를 액세스 토큰으로 먼저 검증한다. 두 토큰은 서로 다른 서명키를 사용하므로 요청은 `AUTH_4018`로 차단되고, 회원가입 서비스의 임시 토큰 검증까지 도달하지 못한다.
+
+임시 토큰을 소비하는 인증 API에서는 액세스 토큰 필터만 건너뛰고, 기존 서비스가 임시 토큰의 서명·만료·역할·임시 회원 존재 여부를 검증하도록 책임을 분리한다.
+
+## 2. 범위
+
+### In scope
+
+- 변경 모듈: `widyu-api`
+- 임시 토큰을 소비하는 기존 인증 API의 액세스 토큰 필터 제외
+- 이메일 회원가입 요청이 실제 HTTP 필터 체인을 통과하는 테스트
+- 일반 API의 액세스 토큰 필터 동작 보존 테스트
+
+### Out of scope
+
+- 토큰 발급·서명키·만료시간 변경
+- `Authorization: Bearer` 이외의 신규 임시 토큰 헤더 도입
+- 인증 API URL·요청·응답 변경
+- `SecurityConfig`의 인가 정책 전면 개편
+- 소셜·로컬 회원가입 비즈니스 로직 변경
+
+## 3. 인터페이스 / API
+
+기존 API 계약을 변경하지 않는다.
+
+```http
+POST /api/v1/auth/guardians/sign-up/local
+Authorization: Bearer {temporaryToken}
+Content-Type: application/json
+```
+
+다음 기존 API도 임시 토큰을 자체 검증하므로 동일하게 액세스 토큰 필터에서 제외한다.
+
+```text
+PATCH /api/v1/auth/guardians/password
+PATCH /api/v1/auth/guardians/apple/phone-number
+GET   /api/v1/auth/guardians/profile/temporary
+POST  /api/v1/auth/guardians/social/integration
+```
+
+## 4. 데이터 모델
+
+엔티티·테이블·Redis 키·토큰 claim 변경은 없다.
+
+- `TemporaryMember`: 기존 Redis TTL과 조회 방식을 유지한다.
+- Temporary Token: 기존 `TEMPORARY` 타입, 임시 토큰 서명키와 만료시간을 유지한다.
+- Access Token: 기존 액세스 토큰 서명키와 인증 필터 동작을 유지한다.
+
+## 5. 처리 흐름
+
+### 임시 토큰 API
+
+1. 요청이 `JwtAuthenticationFilter`에 진입한다.
+2. 필터가 요청 경로를 임시 토큰 API의 명시적 목록과 비교한다.
+3. 일치하면 액세스 토큰 파싱을 건너뛰고 다음 필터로 전달한다.
+4. Controller와 Service가 `Authorization` 헤더에서 임시 토큰을 추출한다.
+5. `TemporaryTokenService` 또는 기존 임시 토큰 유틸리티가 임시 토큰 서명과 만료를 검증한다.
+6. 임시 회원 또는 소셜 임시 토큰 정보를 확인한 뒤 기존 작업을 수행한다.
+
+### 그 외 API
+
+1. 기존과 동일하게 `Authorization` 헤더의 Bearer 토큰을 액세스 토큰으로 파싱한다.
+2. 유효하면 `SecurityContext`에 인증을 설정한다.
+3. 유효하지 않으면 기존 액세스 토큰 오류를 반환한다.
+
+## 6. 예외 / 에러 처리
+
+- 임시 토큰 누락·형식 오류·서명 불일치: 기존 `INVALID_TEMPORARY_TOKEN`을 유지한다.
+- 임시 토큰 만료: 기존 `TEMPORARY_TOKEN_EXPIRED`를 유지한다.
+- 임시 회원 없음: 기존 `TEMPORARY_MEMBER_NOT_FOUND`를 유지한다.
+- 일반 API의 액세스 토큰 오류: 기존 `INVALID_ACCESS_TOKEN`과 `EXPIRED_ACCESS_TOKEN`을 유지한다.
+
+필터 제외는 임시 토큰 검증 생략이 아니다. 액세스 토큰 필터와 임시 토큰 검증의 중복 충돌만 제거한다.
+
+## 7. 인수조건 (Acceptance Criteria)
+
+- [x] SMS 인증으로 발급한 임시 토큰을 `Authorization: Bearer {temporaryToken}`으로 전달하면 이메일 회원가입 요청이 서비스까지 도달한다.
+- [x] 이메일 회원가입 요청의 임시 토큰을 액세스 토큰으로 파싱하지 않는다.
+- [x] 임시 토큰 누락·서명 오류·만료·임시 회원 부재는 기존 오류로 거절한다.
+- [x] 비밀번호 변경, Apple 전화번호 보강, 임시 프로필 조회, 소셜 계정 연동도 액세스 토큰 필터와 충돌하지 않는다.
+- [x] 임시 토큰 API 이외의 요청은 기존 액세스 토큰 필터를 그대로 적용한다.
+- [x] 실제 Spring Security 필터 체인을 거치는 HTTP 테스트가 회원가입 필터 동작을 검증한다.
+- [x] `./gradlew :backend:widyu-api:test`가 통과한다.
+
+## 8. 영향 범위 / 마이그레이션
+
+- `JwtAuthenticationFilter`의 경로별 적용 여부와 관련 테스트만 변경한다.
+- DB·Redis·환경변수·배포 설정 마이그레이션은 없다.
+- 모바일 앱은 기존 요청 URL과 `Authorization: Bearer` 헤더를 유지한다.
+
+## 9. 미결정 사항 (Open Questions)
+
+없음.
+
+## 10. 참고
+
+- Issue #522
+- ADR-0002
+- `JwtAuthenticationFilter`
+- `TemporaryTokenService`

--- a/docs/lld/README.md
+++ b/docs/lld/README.md
@@ -70,3 +70,4 @@ LLD가 필요 없는 PR은 PR 본문에 `LLD: N/A - <사유>`를 남긴다.
 | LLD-0019 | 개인화 심박 이상 감지 AI 연동 | Approved | #446 |
 | LLD-0021 | 앨범 Presigned Multipart 직접 업로드 | Approved | #450 |
 | LLD-0024 | 목표 홈 주간 통계 조회 파이프라인 최적화 | Approved | #489, #491, #492 |
+| LLD-0025 | 임시 토큰 인증 API의 액세스 토큰 필터 분리 | Approved | #522 |


### PR DESCRIPTION
## 개요

임시 토큰이 공통 JWT 필터에서 액세스 토큰으로 먼저 검증되어 이메일 회원가입이 `AUTH_4018`로 차단되는 문제를 수정합니다.

## 설계 문서

- LLD: `docs/lld/LLD-0025-temporary-token-auth-filter.md`
- ADR: `docs/adr/ADR-0002-auth-jwt-family-access.md`

Closes #522

## 변경 사항

- 임시 토큰을 소비하는 기존 5개 인증 API만 액세스 토큰 필터에서 제외했습니다.
- 임시 토큰의 서명·만료·회원 검증은 기존 서비스 책임을 유지합니다.
- 이메일 회원가입 HTTP 필터 체인과 5개 제외 경로를 검증하는 회귀 테스트를 추가했습니다.
- 일반 API의 액세스 토큰 검증이 유지되는지 함께 확인했습니다.

## 테스트

- `./gradlew :backend:widyu-api:test`
- 임시 토큰 HTTP 보안 테스트 및 JWT 필터 단위 테스트
- Java 하네스 규칙 검사

## 체크리스트

- [x] LLD 인수조건을 모두 충족했습니다.
- [x] API URL·요청·응답 형식을 변경하지 않았습니다.
- [x] 엔티티·DB·Redis·환경변수 변경이 없습니다.
- [x] 임시 토큰 API 외의 액세스 토큰 인증 동작을 유지했습니다.

## 리뷰 포인트

- 명시한 5개 임시 토큰 API만 필터를 건너뛰고, 나머지 API는 기존 액세스 토큰 검증을 계속 적용하는지 확인 부탁드립니다.

## 미결정 사항

없습니다.
