### PR TITLE
[알림] 건강 일정·걷기 알림 제목을 실제 내용으로 개선합니다

### DIFF
--- a/backend/widyu-api/src/main/java/com/widyu/fcm/event/goal/healthschedule/listener/HealthScheduleNotificationListener.java
+++ b/backend/widyu-api/src/main/java/com/widyu/fcm/event/goal/healthschedule/listener/HealthScheduleNotificationListener.java
@@ -66,9 +66,9 @@ public class HealthScheduleNotificationListener {
      */
     private void sendScheduleNotification(HealthSchedule schedule) {
         String scheduledTime = schedule.getScheduledAt().format(TIME_FORMATTER);
-        String title = "건강 일정 알림";
-        String content = String.format("%s에 '%s' 일정이 있어요!",
+        String title = String.format("%s에 '%s' 일정이 있어요!",
                 scheduledTime, schedule.getScheduleName());
+        String content = "건강 일정을 잊지 말고 확인해주세요.";
 
         FcmSendDto fcmSendDto = FcmSendDto.builder()
                 .title(title)

--- a/backend/widyu-api/src/main/java/com/widyu/fcm/event/goal/walk/listener/WalkNotificationListener.java
+++ b/backend/widyu-api/src/main/java/com/widyu/fcm/event/goal/walk/listener/WalkNotificationListener.java
@@ -57,9 +57,9 @@ public class WalkNotificationListener {
      * 개별 미달성자에게 알림 발송
      */
     private void sendUnachievedNotification(Walk walk) {
-        String title = "오늘의 걷기 목표를 달성하지 못했어요";
-        String content = String.format("목표 %d보 중 %d보를 걸으셨어요. 조금만 더 힘내세요!",
+        String title = String.format("목표 %d보 중 %d보를 걸으셨어요. 조금만 더 힘내세요!",
                 walk.getGoalSteps(), walk.getActualSteps());
+        String content = "오늘의 걷기 목표를 확인해주세요.";
 
         FcmSendDto fcmSendDto = FcmSendDto.builder()
                 .title(title)

--- a/backend/widyu-api/src/test/java/com/widyu/fcm/event/goal/healthschedule/listener/HealthScheduleNotificationListenerTest.java
+++ b/backend/widyu-api/src/test/java/com/widyu/fcm/event/goal/healthschedule/listener/HealthScheduleNotificationListenerTest.java
@@ -1,0 +1,58 @@
+package com.widyu.fcm.event.goal.healthschedule.listener;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+
+import com.widyu.fcm.application.FcmService;
+import com.widyu.fcm.dto.FcmSendDto;
+import com.widyu.goal.healthschedule.repository.HealthScheduleRepository;
+import com.widyu.healthschedule.HealthSchedule;
+import com.widyu.member.Member;
+import com.widyu.member.MemberType;
+import java.time.LocalDateTime;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("HealthScheduleNotificationListener 단위 테스트")
+class HealthScheduleNotificationListenerTest {
+
+    @Mock private FcmService fcmService;
+    @Mock private HealthScheduleRepository healthScheduleRepository;
+
+    @InjectMocks private HealthScheduleNotificationListener listener;
+
+    @Test
+    @DisplayName("건강 일정 알림을 보내면 시간과 일정명이 제목에 포함된다")
+    void 건강_일정_알림을_보내면_시간과_일정명이_제목에_포함된다() {
+        // given
+        Member member = Member.createMember(MemberType.SENIOR, "부모님", "01011112222");
+        HealthSchedule schedule = HealthSchedule.create(
+                member,
+                "병원 진료",
+                null,
+                null,
+                null,
+                LocalDateTime.of(2026, 8, 25, 15, 30)
+        );
+        given(healthScheduleRepository.findUpcomingSchedulesInTimeRange(any(), any()))
+                .willReturn(List.of(schedule));
+        ArgumentCaptor<FcmSendDto> notificationCaptor = ArgumentCaptor.forClass(FcmSendDto.class);
+
+        // when
+        listener.sendHealthScheduleReminder();
+
+        // then
+        then(fcmService).should().sendMessageToUser(any(), notificationCaptor.capture());
+        assertThat(notificationCaptor.getValue().title()).isEqualTo("15:30에 '병원 진료' 일정이 있어요!");
+        assertThat(notificationCaptor.getValue().content()).isEqualTo("건강 일정을 잊지 말고 확인해주세요.");
+    }
+}

--- a/backend/widyu-api/src/test/java/com/widyu/fcm/event/goal/walk/listener/WalkNotificationListenerTest.java
+++ b/backend/widyu-api/src/test/java/com/widyu/fcm/event/goal/walk/listener/WalkNotificationListenerTest.java
@@ -1,0 +1,52 @@
+package com.widyu.fcm.event.goal.walk.listener;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+
+import com.widyu.fcm.application.FcmService;
+import com.widyu.fcm.dto.FcmSendDto;
+import com.widyu.goal.walk.repository.WalkRepository;
+import com.widyu.member.Member;
+import com.widyu.member.MemberType;
+import com.widyu.walk.Walk;
+import java.time.LocalDate;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("WalkNotificationListener 단위 테스트")
+class WalkNotificationListenerTest {
+
+    @Mock private FcmService fcmService;
+    @Mock private WalkRepository walkRepository;
+
+    @InjectMocks private WalkNotificationListener listener;
+
+    @Test
+    @DisplayName("걷기 목표 미달성 알림을 보내면 걸음 수가 제목에 포함된다")
+    void 걷기_목표_미달성_알림을_보내면_걸음_수가_제목에_포함된다() {
+        // given
+        Member member = Member.createMember(MemberType.SENIOR, "부모님", "01011112222");
+        Walk walk = Walk.createWithGoal(member, LocalDate.now(), 10000);
+        walk.updateActualSteps(6500);
+        given(walkRepository.findUnachievedWalksByDate(any())).willReturn(List.of(walk));
+        ArgumentCaptor<FcmSendDto> notificationCaptor = ArgumentCaptor.forClass(FcmSendDto.class);
+
+        // when
+        listener.sendWalkGoalReminderToUnachieved();
+
+        // then
+        then(fcmService).should().sendMessageToUser(any(), notificationCaptor.capture());
+        assertThat(notificationCaptor.getValue().title())
+                .isEqualTo("목표 10000보 중 6500보를 걸으셨어요. 조금만 더 힘내세요!");
+        assertThat(notificationCaptor.getValue().content()).isEqualTo("오늘의 걷기 목표를 확인해주세요.");
+    }
+}


### PR DESCRIPTION
## 개요
LLD-0002의 건강 일정·걷기 알림에서 사용자가 푸시 제목만 보고도 알림 상황을 파악할 수 있도록 구체적인 정보를 제목에 포함합니다.

## 관련 문서
- LLD: docs/lld/LLD-0002-fcm-notification.md
- ADR: -

## 관련 이슈
Closes #529

## 변경 사항
- 변경 모듈: widyu-api
- HEALTH_SCHEDULE 제목에 예정 시간과 일정명을 포함합니다.
- WALK 제목에 목표 걸음 수와 실제 걸음 수를 포함합니다.
- 두 알림 문구를 단위 테스트로 검증합니다.

## 테스트
- `./gradlew :backend:widyu-api:test`: 통과

## 체크리스트
- [x] 엔티티 변경이 없습니다.
- [x] MySQL ENUM 변경이 없습니다.
- [x] `@Async` 메서드 변경이 없습니다.
- [x] LLD 범위 내 변경임을 확인했습니다.

## 리뷰 포인트
푸시 제목에 포함한 일정·걸음 수 정보가 사용자가 즉시 상황을 파악하기에 적절한지 확인 부탁드립니다.

## Open Questions (LLD 미결정 사항)
없습니다.

## 비고
FCM 발송 구조와 데이터베이스 스키마는 변경하지 않습니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **개선 사항**
  * 건강 일정 알림 제목에 일정 시간과 이름을 표시하고, 일정 확인 안내 문구를 제공합니다.
  * 미달성 걷기 알림에 목표 걸음 수와 실제 걸음 수를 표시하고, 목표 확인 안내 문구를 제공합니다.

* **테스트**
  * 건강 일정 및 걷기 알림 메시지가 올바르게 전송되고 표시되는지 검증하는 테스트를 추가했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->