### PR TITLE
의약품 인증 응답에 현재 포인트와 적립 예정 포인트를 추가합니다

### DIFF
--- a/backend/widyu-api/src/main/java/com/widyu/goal/medicineschedule/application/MedicationPointPolicy.java
+++ b/backend/widyu-api/src/main/java/com/widyu/goal/medicineschedule/application/MedicationPointPolicy.java
@@ -1,0 +1,33 @@
+package com.widyu.goal.medicineschedule.application;
+
+/**
+ * 의약품 복용 포인트 계산 규칙.
+ * 자정 정산(MedicineScheduleRewardScheduler)과 인증 응답의 적립 예정 포인트가
+ * 같은 계산식을 쓰도록 상수와 보너스 조건을 여기 한 곳에 둔다.
+ */
+public final class MedicationPointPolicy {
+
+    private static final long POINTS_PER_MEDICATION = 10L;
+    private static final long BONUS_POINTS_FOR_COMPLETION = 20L;
+
+    private MedicationPointPolicy() {
+    }
+
+    /** 하루치 정산 포인트: 인증 1회당 10p, 그날 유효한 일정을 모두 채우면 보너스 20p. */
+    public static long calculateDailyPoints(long proofCount, long totalSchedules) {
+        long points = proofCount * POINTS_PER_MEDICATION;
+        if (proofCount == totalSchedules && totalSchedules > 0) {
+            return points + BONUS_POINTS_FOR_COMPLETION;
+        }
+        return points;
+    }
+
+    /**
+     * 이번 인증 한 건으로 늘어나는 포인트.
+     * proofCountAfter는 이번 인증을 저장한 뒤의 그날 인증 횟수다.
+     */
+    public static long calculateEarnedPoints(long proofCountAfter, long totalSchedules) {
+        return calculateDailyPoints(proofCountAfter, totalSchedules)
+                - calculateDailyPoints(proofCountAfter - 1, totalSchedules);
+    }
+}

--- a/backend/widyu-api/src/main/java/com/widyu/goal/medicineschedule/application/MedicationProofService.java
+++ b/backend/widyu-api/src/main/java/com/widyu/goal/medicineschedule/application/MedicationProofService.java
@@ -5,16 +5,20 @@ import com.widyu.global.error.BusinessException;
 import com.widyu.global.error.ErrorCode;
 import com.widyu.global.infrastructure.s3.S3Service;
 import com.widyu.global.util.MemberUtil;
+import com.widyu.goal.medicineschedule.dto.response.MedicationProofResponse;
 import com.widyu.goal.medicineschedule.dto.response.MedicationStatus;
 import com.widyu.goal.medicineschedule.repository.MedicationProofRepository;
 import com.widyu.goal.medicineschedule.repository.MedicineScheduleRepository;
 import com.widyu.member.Member;
+import com.widyu.member.SeniorProfile;
 import com.widyu.medicine.MedicationProof;
 import com.widyu.medicine.MedicineSchedule;
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.dao.DataIntegrityViolationException;
@@ -37,7 +41,7 @@ public class MedicationProofService {
     private final S3Service s3Service;
 
     @Transactional
-    public void verifyMedication(Long scheduleId, List<MultipartFile> images) {
+    public MedicationProofResponse verifyMedication(Long scheduleId, List<MultipartFile> images) {
         Member currentMember = memberUtil.getCurrentMember();
 
         MedicineSchedule schedule = medicineScheduleRepository
@@ -86,8 +90,30 @@ public class MedicationProofService {
         MedicationProof proof = MedicationProof.create(schedule, currentMember, imageUrls);
         saveProof(proof, scheduleId);
 
-        log.info("약 복용 인증 완료: scheduleId={}, memberId={}, verifiedAt={}",
-                scheduleId, currentMember.getId(), now);
+        long earnedPoints = calculateEarnedPoints(currentMember, now.toLocalDate());
+
+        log.info("약 복용 인증 완료: scheduleId={}, memberId={}, verifiedAt={}, earnedPoints={}",
+                scheduleId, currentMember.getId(), now, earnedPoints);
+
+        return MedicationProofResponse.of(currentPoints(currentMember), earnedPoints);
+    }
+
+    // 인증을 저장한 뒤의 오늘 인증 횟수로 계산해야 마지막 일정 인증에 보너스가 반영된다.
+    private long calculateEarnedPoints(Member member, LocalDate date) {
+        long proofCount = medicationProofRepository.countByMemberAndVerifiedAtBetween(
+                member, date.atStartOfDay(), date.atTime(LocalTime.MAX));
+        long totalSchedules = medicineScheduleRepository.countEffectiveByMemberAndDate(
+                member, Status.ACTIVE, date);
+        return MedicationPointPolicy.calculateEarnedPoints(proofCount, totalSchedules);
+    }
+
+    // 시니어 프로필이 없는 회원도 인증 자체는 성공해야 하므로 잔액은 0으로 내려준다.
+    private long currentPoints(Member member) {
+        SeniorProfile seniorProfile = member.getSeniorProfile();
+        if (seniorProfile == null) {
+            return 0L;
+        }
+        return Objects.requireNonNullElse(seniorProfile.getPoints(), 0L);
     }
 
     // 위 중복 검사와 저장 사이에 다른 요청이 끼어들 수 있어, 최종 차단은 DB unique 제약이 맡는다.

--- a/backend/widyu-api/src/main/java/com/widyu/goal/medicineschedule/controller/MedicineScheduleController.java
+++ b/backend/widyu-api/src/main/java/com/widyu/goal/medicineschedule/controller/MedicineScheduleController.java
@@ -8,6 +8,7 @@ import com.widyu.goal.medicineschedule.application.MedicineScheduleService;
 import com.widyu.goal.medicineschedule.controller.docs.MedicineScheduleDocs;
 import com.widyu.goal.medicineschedule.dto.request.CreateMedicineScheduleRequest;
 import com.widyu.goal.medicineschedule.dto.request.UpdateMedicineScheduleRequest;
+import com.widyu.goal.medicineschedule.dto.response.MedicationProofResponse;
 import com.widyu.goal.medicineschedule.dto.response.MedicineHomeResponse;
 import com.widyu.goal.medicineschedule.dto.response.MedicineMonthlyResponse;
 import com.widyu.goal.medicineschedule.dto.response.MedicineScheduleDetailResponse;
@@ -143,15 +144,15 @@ public class MedicineScheduleController implements MedicineScheduleDocs {
 
     @Override
     @PostMapping("/{scheduleId}/verify")
-    public ApiResponseTemplate<Void> verifyMedication(
+    public ApiResponseTemplate<MedicationProofResponse> verifyMedication(
             @PathVariable Long scheduleId,
             @RequestPart(required = false) List<MultipartFile> medicationProofImage
     ) {
-        medicationProofService.verifyMedication(scheduleId, medicationProofImage);
+        MedicationProofResponse response = medicationProofService.verifyMedication(scheduleId, medicationProofImage);
         return ApiResponseTemplate.ok()
                 .code("MEDICINE_2008")
                 .message("약 복용 인증 성공")
-                .build();
+                .body(response);
     }
 
     @Override

--- a/backend/widyu-api/src/main/java/com/widyu/goal/medicineschedule/controller/docs/MedicineScheduleDocs.java
+++ b/backend/widyu-api/src/main/java/com/widyu/goal/medicineschedule/controller/docs/MedicineScheduleDocs.java
@@ -3,6 +3,7 @@ package com.widyu.goal.medicineschedule.controller.docs;
 import com.widyu.global.response.ApiResponseTemplate;
 import com.widyu.goal.medicineschedule.dto.request.CreateMedicineScheduleRequest;
 import com.widyu.goal.medicineschedule.dto.request.UpdateMedicineScheduleRequest;
+import com.widyu.goal.medicineschedule.dto.response.MedicationProofResponse;
 import com.widyu.goal.medicineschedule.dto.response.MedicineHomeResponse;
 import com.widyu.goal.medicineschedule.dto.response.MedicineMonthlyResponse;
 import com.widyu.goal.medicineschedule.dto.response.MedicineScheduleDetailResponse;
@@ -466,6 +467,13 @@ public interface MedicineScheduleDocs {
                     - 알람 시간 전후 30분 이내에만 인증 가능
                     - 당일 중복 인증 불가
 
+                    **응답:**
+                    - `currentPoints`: 응답 시점의 보유 포인트입니다. 이번 인증분은 아직 반영되지 않았습니다.
+                      (시니어 프로필이 없는 회원은 0)
+                    - `earnedPoints`: 이번 인증으로 적립될 예정 포인트입니다. 기본 10p이며,
+                      이번 인증으로 그날 유효한 복용 일정을 모두 채우면 보너스 20p를 더해 30p입니다.
+                    - 포인트는 매일 자정 정산 시 실제로 적립됩니다.
+
                     **권한:**
                     - 시니어 본인만 가능
                     """
@@ -476,7 +484,7 @@ public interface MedicineScheduleDocs {
             @ApiResponse(responseCode = "401", description = "인증 실패"),
             @ApiResponse(responseCode = "403", description = "권한 없음")
     })
-    ApiResponseTemplate<Void> verifyMedication(
+    ApiResponseTemplate<MedicationProofResponse> verifyMedication(
             @Parameter(description = "약 복용 스케줄 ID", required = true)
             @PathVariable Long scheduleId,
             @Parameter(description = "약 복용 인증 이미지")

--- a/backend/widyu-api/src/main/java/com/widyu/goal/medicineschedule/dto/response/MedicationProofResponse.java
+++ b/backend/widyu-api/src/main/java/com/widyu/goal/medicineschedule/dto/response/MedicationProofResponse.java
@@ -1,0 +1,10 @@
+package com.widyu.goal.medicineschedule.dto.response;
+
+public record MedicationProofResponse(
+        Long currentPoints,
+        Long earnedPoints
+) {
+    public static MedicationProofResponse of(Long currentPoints, Long earnedPoints) {
+        return new MedicationProofResponse(currentPoints, earnedPoints);
+    }
+}

--- a/backend/widyu-api/src/main/java/com/widyu/goal/medicineschedule/scheduler/MedicineScheduleRewardScheduler.java
+++ b/backend/widyu-api/src/main/java/com/widyu/goal/medicineschedule/scheduler/MedicineScheduleRewardScheduler.java
@@ -1,6 +1,7 @@
 package com.widyu.goal.medicineschedule.scheduler;
 
 import com.widyu.global.entity.Status;
+import com.widyu.goal.medicineschedule.application.MedicationPointPolicy;
 import com.widyu.goal.medicineschedule.repository.MedicationProofRepository;
 import com.widyu.goal.medicineschedule.repository.MedicineScheduleRepository;
 import com.widyu.member.Member;
@@ -18,9 +19,6 @@ import org.springframework.stereotype.Component;
 @RequiredArgsConstructor
 @Slf4j
 public class MedicineScheduleRewardScheduler {
-
-    private static final long POINTS_PER_MEDICATION = 10L;
-    private static final long BONUS_POINTS_FOR_COMPLETION = 20L;
 
     private final MedicationProofRepository medicationProofRepository;
     private final MedicineScheduleRepository medicineScheduleRepository;
@@ -79,15 +77,8 @@ public class MedicineScheduleRewardScheduler {
             return;
         }
 
-        // 포인트 계산: 1회당 10p
-        long points = proofCount * POINTS_PER_MEDICATION;
-
-        // 모든 일정 완료 시 보너스 20p 추가
-        if (proofCount == totalSchedules && totalSchedules > 0) {
-            points += BONUS_POINTS_FOR_COMPLETION;
-            log.info("모든 복용 일정 완료 보너스 적용: memberId={}, proofCount={}/{}",
-                    member.getId(), proofCount, totalSchedules);
-        }
+        // 포인트 계산: 1회당 10p, 그날 유효한 일정을 모두 채우면 보너스 20p
+        long points = MedicationPointPolicy.calculateDailyPoints(proofCount, totalSchedules);
 
         // 포인트 적립
         seniorProfileService.addPointsToMember(member.getId(), points);

--- a/backend/widyu-api/src/test/java/com/widyu/goal/medicineschedule/application/MedicationProofServiceTest.java
+++ b/backend/widyu-api/src/test/java/com/widyu/goal/medicineschedule/application/MedicationProofServiceTest.java
@@ -1,6 +1,9 @@
 package com.widyu.goal.medicineschedule.application;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.never;
 import static org.mockito.BDDMockito.then;
@@ -10,8 +13,10 @@ import com.widyu.global.error.BusinessException;
 import com.widyu.global.infrastructure.s3.S3Service;
 import com.widyu.global.util.MemberUtil;
 import com.widyu.goal.medicineschedule.repository.MedicationProofRepository;
+import com.widyu.goal.medicineschedule.dto.response.MedicationProofResponse;
 import com.widyu.goal.medicineschedule.repository.MedicineScheduleRepository;
 import com.widyu.member.Member;
+import com.widyu.member.SeniorProfile;
 import com.widyu.medicine.MedicationProof;
 import com.widyu.medicine.MedicineSchedule;
 import java.time.LocalDate;
@@ -57,5 +62,105 @@ class MedicationProofServiceTest {
         assertThatThrownBy(() -> medicationProofService.verifyMedication(scheduleId, List.of()))
                 .isInstanceOf(BusinessException.class);
         then(medicationProofRepository).should(never()).save(org.mockito.ArgumentMatchers.any(MedicationProof.class));
+    }
+
+    @Test
+    @DisplayName("아직 남은 복용 일정이 있는 상태로 인증하면 적립 예정 포인트가 10이다")
+    void 남은_일정이_있으면_10포인트가_적립될_예정이다() {
+        // given
+        Long scheduleId = 1L;
+        Member member = org.mockito.Mockito.mock(Member.class);
+        given(member.getId()).willReturn(10L);
+        given(memberUtil.getCurrentMember()).willReturn(member);
+
+        MedicineSchedule schedule = MedicineSchedule.create(member, LocalTime.now());
+        given(medicineScheduleRepository.findByIdAndStatusWithDetails(scheduleId, Status.ACTIVE))
+                .willReturn(Optional.of(schedule));
+        given(medicationProofRepository.countByMemberAndVerifiedAtBetween(eq(member), any(), any()))
+                .willReturn(1L);
+        given(medicineScheduleRepository.countEffectiveByMemberAndDate(eq(member), eq(Status.ACTIVE), any()))
+                .willReturn(3L);
+
+        // when
+        MedicationProofResponse response = medicationProofService.verifyMedication(scheduleId, List.of());
+
+        // then
+        assertThat(response.earnedPoints()).isEqualTo(10L);
+    }
+
+    @Test
+    @DisplayName("그날 마지막 남은 일정을 인증하면 완료 보너스가 더해져 적립 예정 포인트가 30이다")
+    void 마지막_일정을_인증하면_30포인트가_적립될_예정이다() {
+        // given
+        Long scheduleId = 2L;
+        Member member = org.mockito.Mockito.mock(Member.class);
+        given(member.getId()).willReturn(10L);
+        given(memberUtil.getCurrentMember()).willReturn(member);
+
+        MedicineSchedule schedule = MedicineSchedule.create(member, LocalTime.now());
+        given(medicineScheduleRepository.findByIdAndStatusWithDetails(scheduleId, Status.ACTIVE))
+                .willReturn(Optional.of(schedule));
+        given(medicationProofRepository.countByMemberAndVerifiedAtBetween(eq(member), any(), any()))
+                .willReturn(3L);
+        given(medicineScheduleRepository.countEffectiveByMemberAndDate(eq(member), eq(Status.ACTIVE), any()))
+                .willReturn(3L);
+
+        // when
+        MedicationProofResponse response = medicationProofService.verifyMedication(scheduleId, List.of());
+
+        // then
+        assertThat(response.earnedPoints()).isEqualTo(30L);
+    }
+
+    @Test
+    @DisplayName("복용 인증하면 이번 적립분이 반영되지 않은 현재 보유 포인트를 반환한다")
+    void 인증하면_현재_보유_포인트를_반환한다() {
+        // given
+        Long scheduleId = 3L;
+        SeniorProfile seniorProfile = org.mockito.Mockito.mock(SeniorProfile.class);
+        given(seniorProfile.getPoints()).willReturn(120L);
+        Member member = org.mockito.Mockito.mock(Member.class);
+        given(member.getId()).willReturn(10L);
+        given(member.getSeniorProfile()).willReturn(seniorProfile);
+        given(memberUtil.getCurrentMember()).willReturn(member);
+
+        MedicineSchedule schedule = MedicineSchedule.create(member, LocalTime.now());
+        given(medicineScheduleRepository.findByIdAndStatusWithDetails(scheduleId, Status.ACTIVE))
+                .willReturn(Optional.of(schedule));
+        given(medicationProofRepository.countByMemberAndVerifiedAtBetween(eq(member), any(), any()))
+                .willReturn(1L);
+        given(medicineScheduleRepository.countEffectiveByMemberAndDate(eq(member), eq(Status.ACTIVE), any()))
+                .willReturn(2L);
+
+        // when
+        MedicationProofResponse response = medicationProofService.verifyMedication(scheduleId, List.of());
+
+        // then
+        assertThat(response.currentPoints()).isEqualTo(120L);
+    }
+
+    @Test
+    @DisplayName("시니어 프로필이 없는 회원이 복용 인증하면 현재 보유 포인트를 0으로 반환한다")
+    void 시니어_프로필이_없으면_현재_보유_포인트는_0이다() {
+        // given
+        Long scheduleId = 4L;
+        Member member = org.mockito.Mockito.mock(Member.class);
+        given(member.getId()).willReturn(10L);
+        given(member.getSeniorProfile()).willReturn(null);
+        given(memberUtil.getCurrentMember()).willReturn(member);
+
+        MedicineSchedule schedule = MedicineSchedule.create(member, LocalTime.now());
+        given(medicineScheduleRepository.findByIdAndStatusWithDetails(scheduleId, Status.ACTIVE))
+                .willReturn(Optional.of(schedule));
+        given(medicationProofRepository.countByMemberAndVerifiedAtBetween(eq(member), any(), any()))
+                .willReturn(1L);
+        given(medicineScheduleRepository.countEffectiveByMemberAndDate(eq(member), eq(Status.ACTIVE), any()))
+                .willReturn(2L);
+
+        // when
+        MedicationProofResponse response = medicationProofService.verifyMedication(scheduleId, List.of());
+
+        // then
+        assertThat(response.currentPoints()).isZero();
     }
 }

--- a/backend/widyu-api/src/test/java/com/widyu/goal/medicineschedule/scheduler/MedicineScheduleRewardSchedulerTest.java
+++ b/backend/widyu-api/src/test/java/com/widyu/goal/medicineschedule/scheduler/MedicineScheduleRewardSchedulerTest.java
@@ -49,5 +49,7 @@ class MedicineScheduleRewardSchedulerTest {
         // then: 전날(어제) 유효했던 스케줄 수 기준으로 집계한다
         then(medicineScheduleRepository).should()
                 .countEffectiveByMemberAndDate(eq(member), eq(Status.ACTIVE), eq(LocalDate.now().minusDays(1)));
+        // 2회 인증 * 10p + 모든 일정 완료 보너스 20p
+        then(seniorProfileService).should().addPointsToMember(1L, 40L);
     }
 }


### PR DESCRIPTION
## 개요
의약품 인증하기 API(`POST /api/v1/goals/medicine-schedules/{scheduleId}/verify`)는 응답 본문이 없어, 앱이 인증 직후 "포인트 획득" 피드백을 보여주려면 포인트 조회를 한 번 더 호출해야 했습니다. 인증 응답에서 바로 현재 보유 포인트와 이번 인증으로 적립될 예정 포인트를 내려주도록 변경했습니다.

## 관련 문서
- LLD: -
- ADR: -

## 관련 이슈
Closes #531

## 변경 사항
- 변경 모듈: widyu-api
- `MedicationProofResponse`(신규 DTO)를 추가해 `currentPoints`·`earnedPoints`를 반환합니다.
- `MedicationProofService.verifyMedication()`의 반환 타입을 `void`에서 `MedicationProofResponse`로 변경했습니다. 기존 검증 로직(권한·유효 기간·알람 전후 30분·중복 인증)은 그대로입니다.
- `MedicationPointPolicy`(신규)에 포인트 상수(1회 10p, 완료 보너스 20p)와 "그날 유효한 일정을 모두 달성" 판정 조건을 모았습니다. 자정 정산 스케줄러와 인증 응답이 같은 계산식을 사용합니다.
- `MedicineScheduleRewardScheduler`는 자체 상수·분기를 제거하고 `MedicationPointPolicy.calculateDailyPoints()`를 호출합니다. 정산 결과값은 기존과 동일합니다.
- `earnedPoints`는 인증을 저장(`saveAndFlush`)한 뒤의 오늘 인증 횟수를 기준으로 계산하므로, 그날 마지막 남은 일정을 인증하면 30(10 + 보너스 20)이 되고 그 외에는 10입니다.
- `MedicineScheduleController`·`MedicineScheduleDocs`의 시그니처와 Swagger 설명을 함께 수정했습니다.
- 테스트: 적립 예정 포인트 10/30 분기, 현재 포인트 반환, 시니어 프로필이 없는 경우를 `MedicationProofServiceTest`에 추가했고, 정산 스케줄러 테스트에 적립 포인트(40p) 검증을 보강했습니다.

## 의도적으로 하지 않은 것
- 포인트 적립 시점은 바꾸지 않았습니다. 실제 적립은 기존대로 매일 자정 정산 시 이루어지며, 응답의 `earnedPoints`는 "적립될 예정" 값입니다. 따라서 `currentPoints`에는 이번 인증분이 아직 반영되어 있지 않습니다.

## 테스트
- `./gradlew :backend:widyu-api:test`: 통과
- `./gradlew :backend:widyu-domain:test`: 해당 없음 (domain 변경 없음)

## 체크리스트
- [x] 엔티티 변경 없음 (`compileJava`는 빌드 과정에서 실행됨)
- [x] MySQL ENUM 변경 없음
- [x] `@Async` 메서드 추가 없음
- [x] 이슈 완료 조건 전체 충족

## 리뷰 포인트
시니어 프로필이 없는 회원(가드레일 상 인증 자체는 실패하지 않아야 합니다)의 `currentPoints`를 예외 대신 `0`으로 내려주는 처리가 적절할까요?

## Open Questions (LLD 미결정 사항)
없습니다.

## 비고
응답 본문이 `null`에서 객체로 바뀌므로 클라이언트의 응답 파싱 확인이 필요합니다. 추가 마이그레이션이나 배포 순서 제약은 없습니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새로운 기능**
  * 복약 인증 후 현재 포인트와 이번 인증으로 획득한 포인트를 확인할 수 있습니다.
  * 복약 인증 포인트가 인증 횟수에 따라 지급되며, 모든 유효 복약 일정을 완료하면 추가 보너스 포인트가 지급됩니다.
  * 포인트가 없거나 프로필이 없는 경우 현재 포인트가 0점으로 표시됩니다.

* **문서**
  * 복약 인증 API 응답에 포인트 정보와 정산 규칙을 반영했습니다.

* **테스트**
  * 인증 횟수별 포인트, 완료 보너스, 현재 포인트 반환을 검증했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->