### PR TITLE
앨범 피드 응답에 해금 가격을, 해금 응답에 잔여 포인트를 추가합니다

### DIFF
--- a/backend/widyu-api/src/main/java/com/widyu/album/application/AlbumUnlockService.java
+++ b/backend/widyu-api/src/main/java/com/widyu/album/application/AlbumUnlockService.java
@@ -34,8 +34,6 @@ public class AlbumUnlockService {
     private final SeniorProfileRepository seniorProfileRepository;
     private final FamilyAccessService familyAccessService;
 
-    private static final long DEFAULT_UNLOCK_PRICE = 50;
-
     @Transactional
     public AlbumUnlockResponse unlockAlbum(Long albumId) {
         Member currentMember = memberUtil.getCurrentMember();
@@ -75,7 +73,7 @@ public class AlbumUnlockService {
 
         // 6. 포인트 차감 및 내역 기록
         deductPoints(seniorProfile);
-        pointHistoryRepository.save(PointHistory.use(seniorProfile, DEFAULT_UNLOCK_PRICE, "앨범 해금"));
+        pointHistoryRepository.save(PointHistory.use(seniorProfile, Album.UNLOCK_PRICE, "앨범 해금"));
 
         // 7. 해금 기록 생성
         AlbumUnlock albumUnlock = AlbumUnlock.createUnlock(album, currentMember);
@@ -87,7 +85,7 @@ public class AlbumUnlockService {
                 currentMember.getId()
         ));
 
-        return AlbumUnlockResponse.from(savedUnlock);
+        return AlbumUnlockResponse.from(savedUnlock, seniorProfile.getPoints());
     }
 
     @Transactional(readOnly = true)
@@ -96,10 +94,10 @@ public class AlbumUnlockService {
     }
 
     private boolean hasEnoughBalance(SeniorProfile seniorProfile) {
-        return seniorProfile.hasEnoughPoints(DEFAULT_UNLOCK_PRICE);
+        return seniorProfile.hasEnoughPoints(Album.UNLOCK_PRICE);
     }
 
     private void deductPoints(SeniorProfile seniorProfile) {
-        seniorProfile.deductPoints(DEFAULT_UNLOCK_PRICE);
+        seniorProfile.deductPoints(Album.UNLOCK_PRICE);
     }
 }

--- a/backend/widyu-api/src/main/java/com/widyu/album/controller/docs/AlbumCalendarDocs.java
+++ b/backend/widyu-api/src/main/java/com/widyu/album/controller/docs/AlbumCalendarDocs.java
@@ -100,7 +100,8 @@ public interface AlbumCalendarDocs {
                                                 "name": "김철수",
                                                 "profileImage": null
                                               }
-                                            ]
+                                            ],
+                                            "price": 50
                                           }
                                         ],
                                         "hasNext": true,

--- a/backend/widyu-api/src/main/java/com/widyu/album/controller/docs/AlbumDocs.java
+++ b/backend/widyu-api/src/main/java/com/widyu/album/controller/docs/AlbumDocs.java
@@ -175,6 +175,8 @@ public interface AlbumDocs {
                                                     ],
                                                     "createdAt": "2024-12-21T14:30:00",
                                                     "canEdit": true,
+                                                    "isUnlocked": false,
+                                                    "price": 50,
                                                     "videoDuration": null
                                                   }
                                                 ],
@@ -792,6 +794,7 @@ public interface AlbumDocs {
                                                 "albumId": 123,
                                                 "albumTitle": "오늘 소풍 다녀왔어요!",
                                                 "unlockedAt": "2025-09-13T12:00:00",
+                                                "remainingPoints": 50,
                                                 "message": "앨범이 해금되었습니다."
                                               }
                                             }

--- a/backend/widyu-api/src/main/java/com/widyu/album/dto/FamilyAlbumResponse.java
+++ b/backend/widyu-api/src/main/java/com/widyu/album/dto/FamilyAlbumResponse.java
@@ -15,7 +15,8 @@ public record FamilyAlbumResponse(
         Integer viewCount,
         LocalDateTime createdAt,
         AuthorInfo author,
-        List<ViewerInfo> viewers
+        List<ViewerInfo> viewers,
+        Long price
 ) {
     public static FamilyAlbumResponse from(Album album, List<Member> viewers) {
         Member member = album.getMember();
@@ -37,7 +38,8 @@ public record FamilyAlbumResponse(
                 album.getViewCount(),
                 album.getCreatedAt(),
                 AuthorInfo.from(member),
-                viewerInfos
+                viewerInfos,
+                Album.UNLOCK_PRICE
         );
     }
 

--- a/backend/widyu-api/src/main/java/com/widyu/album/dto/response/AlbumDetailResponse.java
+++ b/backend/widyu-api/src/main/java/com/widyu/album/dto/response/AlbumDetailResponse.java
@@ -17,7 +17,7 @@ public record AlbumDetailResponse(
         LocalDateTime createdAt,
         AuthorInfo author,
         List<ViewerInfo> viewers,
-        Integer price,
+        Long price,
         List<CommentInfo> comments,
         boolean canEdit,
         boolean isUnlocked
@@ -92,8 +92,6 @@ public record AlbumDetailResponse(
         }
     }
 
-    private static final int ALBUM_UNLOCK_PRICE = 50;
-
     public static AlbumDetailResponse from(Album album, Long currentUserId, List<Member> viewers,
                                            List<AlbumComment> comments, boolean isUnlocked) {
         return new AlbumDetailResponse(
@@ -106,7 +104,7 @@ public record AlbumDetailResponse(
                 album.getCreatedAt(),
                 AuthorInfo.from(album.getMember()),
                 viewers.stream().map(ViewerInfo::from).toList(),
-                ALBUM_UNLOCK_PRICE,
+                Album.UNLOCK_PRICE,
                 comments.stream()
                         .map(comment -> CommentInfo.from(comment, currentUserId))
                         .toList(),

--- a/backend/widyu-api/src/main/java/com/widyu/album/dto/response/AlbumFeedResponse.java
+++ b/backend/widyu-api/src/main/java/com/widyu/album/dto/response/AlbumFeedResponse.java
@@ -25,6 +25,7 @@ public record AlbumFeedResponse(
         LocalDateTime createdAt,
         Boolean canEdit,
         Boolean isUnlocked,
+        Long price,
         String videoDuration // 동영상인 경우만
 ) {
     public record ViewerInfo(
@@ -61,6 +62,7 @@ public record AlbumFeedResponse(
                 album.getCreatedAt(),
                 canEdit,
                 isUnlocked,
+                Album.UNLOCK_PRICE,
                 primaryVideoDuration
         );
     }

--- a/backend/widyu-api/src/main/java/com/widyu/album/dto/response/AlbumUnlockResponse.java
+++ b/backend/widyu-api/src/main/java/com/widyu/album/dto/response/AlbumUnlockResponse.java
@@ -9,10 +9,11 @@ public record AlbumUnlockResponse(
         Long albumId,
         String albumTitle,
         LocalDateTime unlockedAt,
+        Long remainingPoints,
         String message
 ) {
     
-    public static AlbumUnlockResponse from(AlbumUnlock albumUnlock) {
+    public static AlbumUnlockResponse from(AlbumUnlock albumUnlock, Long remainingPoints) {
         return new AlbumUnlockResponse(
                 albumUnlock.getId(),
                 albumUnlock.getAlbum().getId(),
@@ -20,6 +21,7 @@ public record AlbumUnlockResponse(
                     ? albumUnlock.getAlbum().getContent().substring(0, 50) + "..." 
                     : albumUnlock.getAlbum().getContent(),
                 albumUnlock.getUnlockedAt(),
+                remainingPoints,
                 "앨범이 해금되었습니다."
         );
     }

--- a/backend/widyu-api/src/main/java/com/widyu/album/repository/AlbumUnlockRepository.java
+++ b/backend/widyu-api/src/main/java/com/widyu/album/repository/AlbumUnlockRepository.java
@@ -19,6 +19,6 @@ public interface AlbumUnlockRepository extends JpaRepository<AlbumUnlock, Long> 
     List<Long> findUnlockedAlbumIdsByMemberAndAlbumIds(@Param("member") Member member,
                                                        @Param("albumIds") List<Long> albumIds);
 
-    @Query("SELECT COUNT(au) * 50 FROM AlbumUnlock au WHERE au.member = :member")
+    @Query("SELECT COUNT(au) * " + Album.UNLOCK_PRICE + " FROM AlbumUnlock au WHERE au.member = :member")
     Long getTotalUnlockPriceByMember(@Param("member") Member member);
 }

--- a/backend/widyu-api/src/test/java/com/widyu/album/application/AlbumUnlockServiceTest.java
+++ b/backend/widyu-api/src/test/java/com/widyu/album/application/AlbumUnlockServiceTest.java
@@ -1,5 +1,6 @@
 package com.widyu.album.application;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
@@ -25,6 +26,7 @@ import com.widyu.member.SeniorProfile;
 import com.widyu.member.application.FamilyAccessService;
 import com.widyu.member.repository.PointHistoryRepository;
 import com.widyu.member.repository.SeniorProfileRepository;
+import java.time.LocalDate;
 import java.util.Optional;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -85,6 +87,41 @@ class AlbumUnlockServiceTest {
         verify(pointHistoryRepository).save(any(PointHistory.class));
         verify(albumUnlockRepository).save(any(AlbumUnlock.class));
         verify(eventPublisher).publishEvent(any(AlbumUnlockedEvent.class));
+    }
+
+    @Test
+    @DisplayName("앨범을 해금하면 포인트 차감 후 잔여 포인트가 응답에 담긴다")
+    void 앨범_해금_시_차감_후_잔여_포인트를_반환한다() {
+        // given
+        Member senior = Member.createMember(MemberType.SENIOR, "시니어", "01011112222");
+        ReflectionTestUtils.setField(senior, "id", 1L);
+        ReflectionTestUtils.setField(senior, "type", MemberType.SENIOR);
+        given(memberUtil.getCurrentMember()).willReturn(senior);
+
+        Member albumOwner = mock(Member.class);
+        given(albumOwner.getId()).willReturn(2L);
+
+        Album album = mock(Album.class);
+        given(album.getMember()).willReturn(albumOwner);
+        given(album.getContent()).willReturn("앨범 내용");
+        given(albumRepository.findByIdAndStatus(10L, Status.ACTIVE)).willReturn(Optional.of(album));
+        given(album.requiresUnlock()).willReturn(true);
+
+        // 가입 시 지급되는 100포인트를 가진 실제 프로필
+        SeniorProfile seniorProfile = SeniorProfile.createSeniorProfile(
+                senior, null, "서울시 강남구", "ABCDEFG", LocalDate.of(1950, 1, 1));
+        given(seniorProfileRepository.findByMemberId(1L)).willReturn(Optional.of(seniorProfile));
+
+        given(albumUnlockRepository.existsByAlbumAndMember(album, senior)).willReturn(false);
+        given(albumUnlockRepository.save(any(AlbumUnlock.class)))
+                .willReturn(AlbumUnlock.createUnlock(album, senior));
+
+        // when
+        AlbumUnlockResponse response = albumUnlockService.unlockAlbum(10L);
+
+        // then
+        assertThat(response.remainingPoints()).isEqualTo(100L - Album.UNLOCK_PRICE);
+        assertThat(seniorProfile.getPoints()).isEqualTo(100L - Album.UNLOCK_PRICE);
     }
 
     @Test

--- a/backend/widyu-domain/src/main/java/com/widyu/album/Album.java
+++ b/backend/widyu-domain/src/main/java/com/widyu/album/Album.java
@@ -37,6 +37,9 @@ import lombok.NoArgsConstructor;
 })
 public class Album extends BaseTimeEntity {
 
+    // 앨범 해금 가격. 상세·피드·해금 응답이 모두 이 값을 참조한다.
+    public static final long UNLOCK_PRICE = 50L;
+
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "album_id")


### PR DESCRIPTION
## 개요
앨범 해금 비용(`price`)이 앨범 상세 조회 응답에만 있어, 피드 화면에서 해금 비용을 보여주려면 상세를 따로 호출해야 했습니다. 또 앨범 해금 API가 차감 후 잔여 포인트를 내려주지 않아 앱이 해금 직후 잔액을 갱신하려면 포인트 조회를 한 번 더 해야 했습니다. 피드 응답 2종에 `price`를, 해금 응답에 `remainingPoints`를 추가하고, 그 과정에서 늘어나는 해금 가격 상수 중복을 함께 정리했습니다.

## 관련 문서
- LLD: -
- ADR: -

## 관련 이슈
Closes #532

## 변경 사항
- 변경 모듈: widyu-api / widyu-domain
- `Album`에 `public static final long UNLOCK_PRICE = 50L` 상수를 추가했습니다. 기존에 해금 가격 `50`은 `AlbumUnlockService.DEFAULT_UNLOCK_PRICE`, `AlbumDetailResponse.ALBUM_UNLOCK_PRICE`, `AlbumUnlockRepository`의 JPQL 세 곳에 하드코딩되어 있었고, 이번에 피드 응답 2곳이 더해지면 5중 정의가 되기 때문에 소비자가 모두 이미 import 하고 있는 `Album` 타입으로 상수를 모았습니다.
- `hasEnoughPoints(Long)`·`deductPoints(Long)` 시그니처와 어긋나지 않도록 상수를 `long`으로 선언했습니다. 컴파일 타임 상수라 `AlbumUnlockRepository`의 JPQL 문자열 연결에도 그대로 사용할 수 있습니다.
- `AlbumFeedResponse`에 `price` 필드를 추가하고 `Album.UNLOCK_PRICE`를 채웁니다.
- `FamilyAlbumResponse`에 `price` 필드를 추가하고 `Album.UNLOCK_PRICE`를 채웁니다.
- `AlbumDetailResponse.price`의 타입을 `Integer`에서 `Long`으로 맞추고 자체 상수를 제거했습니다. 세 응답이 같은 상수를 참조하므로 값이 항상 일치합니다.
- `AlbumUnlockResponse`에 `remainingPoints`를 추가하고, `AlbumUnlockService.unlockAlbum()`이 포인트 차감(`seniorProfile.deductPoints`) 이후의 `SeniorProfile.getPoints()`를 담아 반환합니다.
- 기존 해금 검증(본인 앨범 해금 방지·시니어 전용·중복 해금·잔액 부족)의 동작은 변경하지 않았습니다.
- Swagger 응답 예시(`AlbumDocs`, `AlbumCalendarDocs`)를 새 필드에 맞춰 갱신했습니다.
- `AlbumUnlockServiceTest`에 실제 `SeniorProfile`(가입 시 100포인트)로 해금해 응답의 `remainingPoints`가 차감 후 값인지 확인하는 테스트를 추가했습니다.

## 테스트
- `./gradlew :backend:widyu-api:test`: 통과 (`AlbumUnlockServiceTest` 9건 전부 통과)
- `./gradlew :backend:widyu-domain:test`: 미실행 (도메인 모듈에는 상수 추가만 있어 `./gradlew compileJava`로 확인했습니다)

## 체크리스트
- [x] 엔티티 변경 시 `./gradlew compileJava` 실행
- [x] MySQL ENUM 변경 시 ALTER TABLE 명시 (ENUM 변경 없습니다)
- [x] `@Async` 메서드에 `@Transactional` 확인 (해당 없습니다)
- [x] LLD 인수조건 전체 충족 (LLD 없음, 이슈 완료 조건 기준으로 확인했습니다)

## 리뷰 포인트
해금 가격 상수를 별도 정책 클래스나 설정 프로퍼티가 아니라 `Album` 도메인 타입의 `public static final`로 둔 선택이 적절한지 봐주시면 좋겠습니다.

## Open Questions (LLD 미결정 사항)
없습니다.

## 비고
- `AlbumDetailResponse.price`의 자바 타입이 `Integer`에서 `Long`으로 바뀌었지만 JSON 직렬화 결과는 동일한 숫자 `50`이라 클라이언트 영향은 없습니다.
- 응답에 필드만 추가되어 DB 스키마 변경이나 배포 시 수동 작업은 없습니다.
