### PR TITLE
[설정] 시크릿·파괴적 명령 차단 규칙을 실제 경로에 맞게 고치고 PreToolUse 게이트를 추가합니다

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -6,11 +6,19 @@
       "Read(./.env.*)",
       "Read(./**/application-prod.yml)",
       "Read(./**/application-secret.yml)",
-      "Read(./src/main/resources/firebase/**)",
+      "Read(./**/firebase/**)",
       "Read(./**/*.pem)",
       "Read(./**/*.p8)",
       "Bash(cat ./.env:*)",
-      "Bash(cat .env:*)"
+      "Bash(cat .env:*)",
+      "Bash(rm -rf *)",
+      "Bash(rm -fr *)",
+      "Bash(git push --force*)",
+      "Bash(git push -f *)",
+      "Bash(git reset --hard*)",
+      "Bash(git clean -fd*)",
+      "Bash(docker compose down -v*)",
+      "Bash(docker-compose down -v*)"
     ],
     "ask": [
       "Bash(git push:*)",
@@ -27,6 +35,15 @@
           {
             "type": "command",
             "command": "bash \"$CLAUDE_PROJECT_DIR/scripts/harness/pre-edit-branch-guard.sh\""
+          }
+        ]
+      },
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash \"$CLAUDE_PROJECT_DIR/scripts/harness/pre-bash-guard.sh\""
           }
         ]
       }

--- a/scripts/harness/pre-bash-guard.sh
+++ b/scripts/harness/pre-bash-guard.sh
@@ -1,0 +1,115 @@
+#!/bin/bash
+# PreToolUse(Bash) 가드 — 되돌릴 수 없는 명령과 시크릿 읽기를 실행 전에 차단한다.
+#
+# settings.json 의 deny 와 겹치는 항목이 있다. 의도된 이중 방어다.
+# deny 는 Read 도구와 명령 문자열만 보고, 이 훅은 파이프·세미콜론으로 이어진
+# 명령까지 본다. ADR-0018 에서 실측했듯 어느 쪽도 보안 경계가 아니라 사고 방지 장치다.
+#
+# fail-closed: stdin JSON 을 파싱하지 못하면 통과가 아니라 차단한다.
+# 무엇을 실행하려는지 모르는 상태에서 통과시키면 가드가 있으나 마나다.
+# (브랜치 가드 pre-edit-branch-guard.sh 는 반대로 fail-open 이다. 그쪽은 막으려는
+#  사고가 git switch 로 되돌려지는 반면, fail-closed 면 편집이 전면 중단된다. ADR-0021)
+#
+# Silent Success: 통과는 exit 0 무출력, 차단은 stderr + exit 2.
+#
+# 판정을 grep 이 아니라 python re 로 하는 이유:
+#   grep 은 줄 단위라 heredoc 본문의 각 줄에도 ^ 앵커가 걸린다. 실제로 커밋 메시지
+#   본문에 위험 명령을 설명으로 적었다가 커밋 자체가 차단됐다.
+#   re 는 MULTILINE 없이 \A 를 쓰면 "명령 문자열의 진짜 시작"만 앵커가 된다.
+
+set -uo pipefail
+
+VERDICT="$(cat | python3 -c '
+import json, re, sys
+
+try:
+    data = json.load(sys.stdin)
+except Exception:
+    sys.exit(9)          # fail-closed
+
+cmd = data.get("tool_input", {}).get("command", "")
+if not cmd:
+    sys.exit(0)
+
+
+def strip_heredocs(text):
+    """heredoc 본문을 지운다.
+
+    본문은 실행되는 명령이 아니라 데이터다. 커밋 메시지나 이슈 본문에 위험 명령을
+    설명으로 적었다가 차단되는 오탐을 막는다. 동시에 본문을 지워야 줄바꿈으로 이어진
+    진짜 명령에 ^ 앵커를 안전하게 쓸 수 있다.
+    """
+    lines = text.split("\n")
+    kept, i = [], 0
+    while i < len(lines):
+        kept.append(lines[i])
+        m = re.search(r"<<-?\s*[\x27\"]?([A-Za-z_][A-Za-z0-9_]*)[\x27\"]?", lines[i])
+        if m:
+            term = m.group(1)
+            i += 1
+            while i < len(lines) and lines[i].strip() != term:
+                i += 1   # 본문 폐기
+        i += 1
+    return "\n".join(kept)
+
+
+cmd = strip_heredocs(cmd)
+
+# 명령이 시작될 수 있는 자리: 줄 시작(heredoc 본문은 위에서 제거됨),
+# 또는 ; && || | ` $( 직후.
+POS = r"(?:^|[;&|`]|\$\()\s*"
+FLAGS = re.MULTILINE
+
+RULES = [
+    # ── 되돌릴 수 없는 명령 ──────────────────────────────────────────────
+    (POS + r"rm\s+(?:-[a-zA-Z]*[rR][a-zA-Z]*f|-[a-zA-Z]*f[a-zA-Z]*[rR])",
+     "rm -rf 는 막혀 있습니다. 지울 대상이 확실하면 사용자에게 요청하세요."),
+
+    (POS + r"(?:git\s+)?rm\s+[^;&|]*(?:scripts/mysql/|\.sql(?:\s|$))",
+     "SQL 마이그레이션 파일 삭제는 막혀 있습니다. 필요하면 사용자에게 요청하세요."),
+
+    # push\b 뒤에서 공백을 미리 먹지 않는다. 먹으면 "git push -f" 의 -f 앞에
+    # 남는 공백이 없어 매칭에 실패한다.
+    (POS + r"git\s+push\b(?:[^;&|]*\s)?-(?:-force|f)(?:\s|$)",
+     "force push 는 막혀 있습니다."),
+
+    (POS + r"git\s+reset\s+--hard",
+     "git reset --hard 는 되돌릴 수 없습니다. 막혀 있습니다."),
+
+    (POS + r"git\s+clean\s+-[a-zA-Z]*[fd]",
+     "git clean 은 추적되지 않는 파일을 지웁니다. 막혀 있습니다."),
+
+    (POS + r"docker(?:\s+compose|-compose)\s+down\b[^;&|]*\s-v(?:\s|$)",
+     "compose 볼륨 삭제는 DB 데이터까지 지웁니다. 막혀 있습니다."),
+]
+
+for pattern, message in RULES:
+    if re.search(pattern, cmd, FLAGS):
+        print(message)
+        sys.exit(2)
+
+# ── Read() deny 가 못 막는 Bash 경유 시크릿 읽기 ─────────────────────────
+# settings.json 의 Read() deny 는 Read 도구에만 걸린다.
+# 읽기 명령이 명령 자리에 있고 + 인자에 시크릿 경로가 있을 때만 막는다.
+READER = POS + r"(?:cat|head|tail|less|more|nl|base64|xxd|od|strings|awk|sed)(?:\s|$)"
+SECRET = r"(?:firebase/[^\s]*\.json|(?:^|[\s/])\.env(?:\s|$)|\.pem(?:\s|$)|\.p8(?:\s|$))"
+
+if re.search(READER, cmd, FLAGS) and re.search(SECRET, cmd, FLAGS):
+    print("시크릿 파일(firebase 키·.env·인증서)을 Bash 로 읽는 것은 막혀 있습니다.")
+    sys.exit(2)
+
+sys.exit(0)
+' 2>/dev/null)"
+rc=$?
+
+if [[ $rc -eq 9 || $rc -gt 2 ]]; then
+  echo "차단: PreToolUse 가드가 명령을 파싱하지 못했습니다(python3 미설치 또는 입력 손상). 안전을 위해 실행을 막습니다." >&2
+  exit 2
+fi
+
+if [[ $rc -eq 2 ]]; then
+  echo "차단: ${VERDICT}" >&2
+  exit 2
+fi
+
+exit 0

--- a/scripts/harness/pre-bash-guard.sh
+++ b/scripts/harness/pre-bash-guard.sh
@@ -12,21 +12,32 @@
 #
 # Silent Success: 통과는 exit 0 무출력, 차단은 stderr + exit 2.
 #
-# 판정을 정규식이 아니라 shlex 토큰으로 하는 이유 (PR #535 리뷰에서 드러난 것들):
-#   - 따옴표 안의 <<EOF 를 heredoc 연산자로 오인하면 그 뒤 진짜 명령이 본문으로
-#     취급돼 통째로 숨는다.
-#   - rm -rf 만 보면 rm -r -f, rm --recursive --force 를 놓친다.
-#   - reader 와 시크릿 경로를 각각 따로 찾으면 "cat README.md && echo .env" 처럼
-#     시크릿을 읽지 않는 조합까지 막는다.
-# 토큰으로 끊어 명령 단위(argv)를 만들면 셋 다 구조적으로 사라진다.
+# 판정 구조 (PR #535 리뷰를 거치며 도달한 형태):
+#   1) 따옴표 상태를 추적하며 한 번 훑어 heredoc 본문을 지우고 명령 단위로 끊는다.
+#      정규식으로도, 줄 단위 파싱으로도 안 된다. 셸 따옴표는 줄을 넘기 때문이다.
+#      줄 단위로 lex 하던 버전은 여러 줄에 걸친 인용 문자열에서 파싱이 깨졌고,
+#      폴백 정규식이 그 안의 예시 문자열을 명령으로 오인해 차단했다.
+#   2) 끊어낸 각 단위를 shlex 로 토큰화해 argv 를 만든다.
+#   3) argv 의 명령 이름과 옵션 집합을 보고 판정한다. 문자열 매칭이 아니므로
+#      rm -r -f, rm --recursive --force, 플래그 역순이 모두 걸린다.
+#
+# 오탐보다 미탐을 택한다. 이 훅은 모든 Bash 호출을 거치므로 오탐이 곧 작업 중단이다.
+# 판정할 수 없는 조각은 막지 않고 넘긴다. 막으려는 대상은 적대적 우회가 아니라
+# 평범한 사고이고, 보안 경계는 ADR-0018 대로 .gitignore 와 키 교체가 담당한다.
+#
+# 판정부를 인용 heredoc(<<'PYEOF')으로 넘긴다. 셸이 내용을 건드리지 않으므로
+# 파이썬 안에서 따옴표를 자유롭게 쓸 수 있다. python3 -c 로 넣던 때는 이스케이프가
+# 꼬여 실제로 문법 오류를 냈다.
 
 set -uo pipefail
 
-VERDICT="$(cat | python3 -c '
-import json, re, shlex, sys
+input="$(cat)"
+
+VERDICT="$(python3 - "$input" <<'PYEOF'
+import json, shlex, sys
 
 try:
-    data = json.load(sys.stdin)
+    data = json.loads(sys.argv[1])
 except Exception:
     sys.exit(9)          # fail-closed
 
@@ -34,86 +45,124 @@ cmd = data.get("tool_input", {}).get("command", "")
 if not cmd:
     sys.exit(0)
 
-OPERATORS = {";", "&&", "||", "|", "&", "\n"}
 READERS = {"cat", "head", "tail", "less", "more", "nl",
            "base64", "xxd", "od", "strings", "awk", "sed"}
+SQUOTE, DQUOTE = "'", '"'
 
 
-def lex(text):
-    """따옴표를 존중해 토큰으로 끊는다. 연산자는 별도 토큰이 된다.
+def scan(text):
+    """따옴표 상태를 추적하며 한 번 훑어 명령 단위 문자열 목록을 만든다.
 
-    punctuation_chars 덕분에 맨 <<EOF 는 [\"<<\", \"EOF\"] 로,
-    따옴표에 싸인 \x27<<EOF\x27 는 [\"<<EOF\"] 한 토큰으로 나뉜다.
-    이 차이가 진짜 heredoc 연산자를 가려낸다.
+    - 따옴표 안의 구분자와 << 는 구분자가 아니다.
+    - heredoc 본문은 실행되는 명령이 아니라 데이터이므로 버린다.
+      (커밋 메시지에 위험 명령을 설명으로 적었다고 막으면 안 된다)
     """
-    lx = shlex.shlex(text, posix=True, punctuation_chars=True)
-    lx.whitespace_split = True
-    return list(lx)
+    out, cur = [], []
+    pending = []          # 이 줄에서 열린 heredoc 구분자들
+    i, n = 0, len(text)
 
+    def flush():
+        s = "".join(cur).strip()
+        if s:
+            out.append(s)
+        del cur[:]
 
-def strip_heredocs(text):
-    """heredoc 본문을 지운다. 본문은 실행되는 명령이 아니라 데이터다.
+    while i < n:
+        c = text[i]
 
-    커밋 메시지나 이슈 본문에 위험 명령을 설명으로 적었다고 차단하면 안 된다.
-    동시에 본문을 지워야 줄바꿈으로 이어진 진짜 명령을 제대로 볼 수 있다.
-    """
-    lines = text.split("\n")
-    kept, i = [], 0
-    while i < len(lines):
-        kept.append(lines[i])
-        try:
-            toks = lex(lines[i])
-        except ValueError:
-            toks = []
-        delim = None
-        for j, t in enumerate(toks):
-            if t in ("<<", "<<-") and j + 1 < len(toks):
-                delim = toks[j + 1]
-                break
-        if delim is not None:
-            i += 1
-            while i < len(lines) and lines[i].strip() != delim:
-                i += 1   # 본문 폐기
-        i += 1
-    return "\n".join(kept)
+        if c == "\\" and i + 1 < n:
+            cur.append(text[i:i + 2]); i += 2; continue
 
+        if c == SQUOTE:                    # 작은따옴표 안은 전부 리터럴
+            j = text.find(SQUOTE, i + 1)
+            if j == -1:
+                cur.append(text[i:]); break
+            cur.append(text[i:j + 1]); i = j + 1; continue
 
-def segments(text):
-    """연산자·줄바꿈으로 끊어 명령 단위 argv 목록을 만든다."""
-    out = []
-    for line in text.split("\n"):
-        if not line.strip():
+        if c == DQUOTE:                    # 큰따옴표는 역슬래시 이스케이프만 존중
+            j = i + 1
+            while j < n:
+                if text[j] == "\\":
+                    j += 2; continue
+                if text[j] == DQUOTE:
+                    break
+                j += 1
+            j = min(j, n - 1)
+            cur.append(text[i:j + 1]); i = j + 1; continue
+
+        # heredoc 시작. 구분자를 기억해 두고 줄이 끝나면 본문을 건너뛴다.
+        if text.startswith("<<", i) and not text.startswith("<<<", i):
+            j = i + 2
+            if j < n and text[j] == "-":
+                j += 1
+            while j < n and text[j] in " \t":
+                j += 1
+            q = ""
+            if j < n and text[j] in (SQUOTE, DQUOTE):
+                q = text[j]; j += 1
+            k = j
+            while k < n and (text[k].isalnum() or text[k] == "_"):
+                k += 1
+            delim = text[j:k]
+            if q and k < n and text[k] == q:
+                k += 1
+            if delim:
+                pending.append(delim)
+                i = k
+                continue
+
+        if text.startswith("&&", i) or text.startswith("||", i):
+            flush(); i += 2; continue
+
+        if c in ";|&":
+            flush(); i += 1; continue
+
+        if c == "\n":
+            flush(); i += 1
+            while pending:                 # 열린 heredoc 본문을 통째로 건너뛴다
+                delim = pending.pop(0)
+                while i < n:
+                    e = text.find("\n", i)
+                    line = text[i:] if e == -1 else text[i:e]
+                    i = n if e == -1 else e + 1
+                    if line.strip() == delim:
+                        break
             continue
-        try:
-            toks = lex(line)
-        except ValueError:
-            raise
-        cur = []
-        for t in toks:
-            if t in OPERATORS:
-                if cur:
-                    out.append(cur)
-                cur = []
-            else:
-                cur.append(t)
-        if cur:
-            out.append(cur)
+
+        cur.append(c); i += 1
+
+    flush()
     return out
 
 
-def split_argv(argv):
-    """앞쪽 환경변수 대입을 걷어내고 (명령, 인자들) 로 나눈다."""
-    i = 0
-    while i < len(argv) and re.match(r"^[A-Za-z_][A-Za-z0-9_]*=", argv[i]):
-        i += 1
-    argv = argv[i:]
-    if not argv:
-        return None, []
-    return argv[0].rsplit("/", 1)[-1], argv[1:]
+def argv_of(segment):
+    """명령 단위 문자열에서 argv 를 뽑는다. 파싱 못 하면 None."""
+    try:
+        lx = shlex.shlex(segment, posix=True, punctuation_chars=True)
+        lx.whitespace_split = True
+        toks = list(lx)
+    except ValueError:
+        return None
+
+    argv, skip = [], False
+    for t in toks:
+        if skip:
+            skip = False; continue
+        if t and t[0] in "<>" or (t[:-1].isdigit() and t.endswith(">")):
+            skip = True; continue          # 리다이렉션 연산자와 그 대상
+        argv.append(t)
+
+    i = 0                                  # 앞쪽 환경변수 대입은 명령이 아니다
+    while i < len(argv):
+        head = argv[i].split("=", 1)[0]
+        if "=" in argv[i] and head and (head[0].isalpha() or head[0] == "_"):
+            i += 1
+        else:
+            break
+    return argv[i:]
 
 
 def shorts(args):
-    """-rf, -r 같은 짧은 옵션의 문자 집합."""
     s = set()
     for a in args:
         if a.startswith("-") and not a.startswith("--") and len(a) > 1:
@@ -126,7 +175,6 @@ def longs(args):
 
 
 def operands(args):
-    """옵션이 아닌 인자. 리다이렉션 대상은 여기 포함되지 않는다(연산자로 분리됨)."""
     return [a for a in args if not a.startswith("-")]
 
 
@@ -142,21 +190,18 @@ def is_secret(path):
 
 
 def verdict(argv):
-    name, args = split_argv(argv)
-    if name is None:
+    if not argv:
         return None
-
+    name = argv[0].rsplit("/", 1)[-1]
+    args = argv[1:]
     sub = args[0] if args else ""
 
-    # git rm 은 rm 과 같은 규칙으로 본다
     if name == "git" and sub == "rm":
         name, args = "rm", args[1:]
 
     if name == "rm":
         sh, lo = shorts(args), longs(args)
-        recursive = bool(sh & set("rR")) or "recursive" in lo
-        force = "f" in sh or "force" in lo
-        if recursive and force:
+        if (sh & set("rR") or "recursive" in lo) and ("f" in sh or "force" in lo):
             return "rm -rf 는 막혀 있습니다. 지울 대상이 확실하면 사용자에게 요청하세요."
         for op in operands(args):
             if "scripts/mysql/" in op or op.endswith(".sql"):
@@ -175,15 +220,13 @@ def verdict(argv):
         if shorts(rest) & set("fd") or longs(rest) & {"force", "d"}:
             return "git clean 은 추적되지 않는 파일을 지웁니다. 막혀 있습니다."
 
-    # down 의 위치를 고정하면 안 된다. docker compose -f a.yml down -v 처럼
-    # 옵션이 앞에 오면 서브커맨드가 뒤로 밀린다.
+    # 서브커맨드 위치를 고정하면 옵션이 앞에 올 때 밀린다 (docker compose -f a.yml down -v)
     compose_down = (
         (name == "docker" and sub == "compose" and "down" in operands(args))
         or (name == "docker-compose" and "down" in operands(args))
     )
-    if compose_down:
-        if "v" in shorts(args) or "volumes" in longs(args):
-            return "compose 볼륨 삭제는 DB 데이터까지 지웁니다. 막혀 있습니다."
+    if compose_down and ("v" in shorts(args) or "volumes" in longs(args)):
+        return "compose 볼륨 삭제는 DB 데이터까지 지웁니다. 막혀 있습니다."
 
     # Read() deny 는 Read 도구에만 걸린다. Bash 경유 읽기를 여기서 막는다.
     # 시크릿 경로가 "이 reader 의 인자"일 때만 막아야 오탐이 없다.
@@ -195,28 +238,18 @@ def verdict(argv):
     return None
 
 
-COARSE = [
-    (r"rm\s+-[a-zA-Z]*[rR][a-zA-Z]*f|rm\s+-[a-zA-Z]*f[a-zA-Z]*[rR]", "rm -rf 는 막혀 있습니다."),
-    (r"git\s+push\b[^\n]*--force", "force push 는 막혀 있습니다."),
-    (r"git\s+reset\s+--hard", "git reset --hard 는 되돌릴 수 없습니다. 막혀 있습니다."),
-]
-
-try:
-    for argv in segments(strip_heredocs(cmd)):
-        msg = verdict(argv)
-        if msg:
-            print(msg)
-            sys.exit(2)
-except ValueError:
-    # 따옴표가 안 맞는 등 토큰화 실패. 셸에서도 유효하지 않은 명령일 가능성이 높다.
-    # 조용히 통과시키지는 않고, 거친 정규식으로 최소한의 그물은 친다.
-    for pat, msg in COARSE:
-        if re.search(pat, cmd):
-            print(msg)
-            sys.exit(2)
+for seg in scan(cmd):
+    argv = argv_of(seg)
+    if argv is None:
+        continue          # 판정 불가한 조각은 막지 않는다
+    msg = verdict(argv)
+    if msg:
+        print(msg)
+        sys.exit(2)
 
 sys.exit(0)
-' 2>/dev/null)"
+PYEOF
+)"
 rc=$?
 
 if [[ $rc -eq 9 || $rc -gt 2 ]]; then

--- a/scripts/harness/pre-bash-guard.sh
+++ b/scripts/harness/pre-bash-guard.sh
@@ -12,15 +12,18 @@
 #
 # Silent Success: 통과는 exit 0 무출력, 차단은 stderr + exit 2.
 #
-# 판정을 grep 이 아니라 python re 로 하는 이유:
-#   grep 은 줄 단위라 heredoc 본문의 각 줄에도 ^ 앵커가 걸린다. 실제로 커밋 메시지
-#   본문에 위험 명령을 설명으로 적었다가 커밋 자체가 차단됐다.
-#   re 는 MULTILINE 없이 \A 를 쓰면 "명령 문자열의 진짜 시작"만 앵커가 된다.
+# 판정을 정규식이 아니라 shlex 토큰으로 하는 이유 (PR #535 리뷰에서 드러난 것들):
+#   - 따옴표 안의 <<EOF 를 heredoc 연산자로 오인하면 그 뒤 진짜 명령이 본문으로
+#     취급돼 통째로 숨는다.
+#   - rm -rf 만 보면 rm -r -f, rm --recursive --force 를 놓친다.
+#   - reader 와 시크릿 경로를 각각 따로 찾으면 "cat README.md && echo .env" 처럼
+#     시크릿을 읽지 않는 조합까지 막는다.
+# 토큰으로 끊어 명령 단위(argv)를 만들면 셋 다 구조적으로 사라진다.
 
 set -uo pipefail
 
 VERDICT="$(cat | python3 -c '
-import json, re, sys
+import json, re, shlex, sys
 
 try:
     data = json.load(sys.stdin)
@@ -31,72 +34,186 @@ cmd = data.get("tool_input", {}).get("command", "")
 if not cmd:
     sys.exit(0)
 
+OPERATORS = {";", "&&", "||", "|", "&", "\n"}
+READERS = {"cat", "head", "tail", "less", "more", "nl",
+           "base64", "xxd", "od", "strings", "awk", "sed"}
+
+
+def lex(text):
+    """따옴표를 존중해 토큰으로 끊는다. 연산자는 별도 토큰이 된다.
+
+    punctuation_chars 덕분에 맨 <<EOF 는 [\"<<\", \"EOF\"] 로,
+    따옴표에 싸인 \x27<<EOF\x27 는 [\"<<EOF\"] 한 토큰으로 나뉜다.
+    이 차이가 진짜 heredoc 연산자를 가려낸다.
+    """
+    lx = shlex.shlex(text, posix=True, punctuation_chars=True)
+    lx.whitespace_split = True
+    return list(lx)
+
 
 def strip_heredocs(text):
-    """heredoc 본문을 지운다.
+    """heredoc 본문을 지운다. 본문은 실행되는 명령이 아니라 데이터다.
 
-    본문은 실행되는 명령이 아니라 데이터다. 커밋 메시지나 이슈 본문에 위험 명령을
-    설명으로 적었다가 차단되는 오탐을 막는다. 동시에 본문을 지워야 줄바꿈으로 이어진
-    진짜 명령에 ^ 앵커를 안전하게 쓸 수 있다.
+    커밋 메시지나 이슈 본문에 위험 명령을 설명으로 적었다고 차단하면 안 된다.
+    동시에 본문을 지워야 줄바꿈으로 이어진 진짜 명령을 제대로 볼 수 있다.
     """
     lines = text.split("\n")
     kept, i = [], 0
     while i < len(lines):
         kept.append(lines[i])
-        m = re.search(r"<<-?\s*[\x27\"]?([A-Za-z_][A-Za-z0-9_]*)[\x27\"]?", lines[i])
-        if m:
-            term = m.group(1)
+        try:
+            toks = lex(lines[i])
+        except ValueError:
+            toks = []
+        delim = None
+        for j, t in enumerate(toks):
+            if t in ("<<", "<<-") and j + 1 < len(toks):
+                delim = toks[j + 1]
+                break
+        if delim is not None:
             i += 1
-            while i < len(lines) and lines[i].strip() != term:
+            while i < len(lines) and lines[i].strip() != delim:
                 i += 1   # 본문 폐기
         i += 1
     return "\n".join(kept)
 
 
-cmd = strip_heredocs(cmd)
+def segments(text):
+    """연산자·줄바꿈으로 끊어 명령 단위 argv 목록을 만든다."""
+    out = []
+    for line in text.split("\n"):
+        if not line.strip():
+            continue
+        try:
+            toks = lex(line)
+        except ValueError:
+            raise
+        cur = []
+        for t in toks:
+            if t in OPERATORS:
+                if cur:
+                    out.append(cur)
+                cur = []
+            else:
+                cur.append(t)
+        if cur:
+            out.append(cur)
+    return out
 
-# 명령이 시작될 수 있는 자리: 줄 시작(heredoc 본문은 위에서 제거됨),
-# 또는 ; && || | ` $( 직후.
-POS = r"(?:^|[;&|`]|\$\()\s*"
-FLAGS = re.MULTILINE
 
-RULES = [
-    # ── 되돌릴 수 없는 명령 ──────────────────────────────────────────────
-    (POS + r"rm\s+(?:-[a-zA-Z]*[rR][a-zA-Z]*f|-[a-zA-Z]*f[a-zA-Z]*[rR])",
-     "rm -rf 는 막혀 있습니다. 지울 대상이 확실하면 사용자에게 요청하세요."),
+def split_argv(argv):
+    """앞쪽 환경변수 대입을 걷어내고 (명령, 인자들) 로 나눈다."""
+    i = 0
+    while i < len(argv) and re.match(r"^[A-Za-z_][A-Za-z0-9_]*=", argv[i]):
+        i += 1
+    argv = argv[i:]
+    if not argv:
+        return None, []
+    return argv[0].rsplit("/", 1)[-1], argv[1:]
 
-    (POS + r"(?:git\s+)?rm\s+[^;&|]*(?:scripts/mysql/|\.sql(?:\s|$))",
-     "SQL 마이그레이션 파일 삭제는 막혀 있습니다. 필요하면 사용자에게 요청하세요."),
 
-    # push\b 뒤에서 공백을 미리 먹지 않는다. 먹으면 "git push -f" 의 -f 앞에
-    # 남는 공백이 없어 매칭에 실패한다.
-    (POS + r"git\s+push\b(?:[^;&|]*\s)?-(?:-force|f)(?:\s|$)",
-     "force push 는 막혀 있습니다."),
+def shorts(args):
+    """-rf, -r 같은 짧은 옵션의 문자 집합."""
+    s = set()
+    for a in args:
+        if a.startswith("-") and not a.startswith("--") and len(a) > 1:
+            s.update(a[1:])
+    return s
 
-    (POS + r"git\s+reset\s+--hard",
-     "git reset --hard 는 되돌릴 수 없습니다. 막혀 있습니다."),
 
-    (POS + r"git\s+clean\s+-[a-zA-Z]*[fd]",
-     "git clean 은 추적되지 않는 파일을 지웁니다. 막혀 있습니다."),
+def longs(args):
+    return {a[2:].split("=")[0] for a in args if a.startswith("--") and len(a) > 2}
 
-    (POS + r"docker(?:\s+compose|-compose)\s+down\b[^;&|]*\s-v(?:\s|$)",
-     "compose 볼륨 삭제는 DB 데이터까지 지웁니다. 막혀 있습니다."),
+
+def operands(args):
+    """옵션이 아닌 인자. 리다이렉션 대상은 여기 포함되지 않는다(연산자로 분리됨)."""
+    return [a for a in args if not a.startswith("-")]
+
+
+def is_secret(path):
+    base = path.rsplit("/", 1)[-1]
+    if base == ".env" or base.startswith(".env."):
+        return True
+    if base.endswith(".pem") or base.endswith(".p8"):
+        return True
+    if "/firebase/" in path and path.endswith(".json"):
+        return True
+    return False
+
+
+def verdict(argv):
+    name, args = split_argv(argv)
+    if name is None:
+        return None
+
+    sub = args[0] if args else ""
+
+    # git rm 은 rm 과 같은 규칙으로 본다
+    if name == "git" and sub == "rm":
+        name, args = "rm", args[1:]
+
+    if name == "rm":
+        sh, lo = shorts(args), longs(args)
+        recursive = bool(sh & set("rR")) or "recursive" in lo
+        force = "f" in sh or "force" in lo
+        if recursive and force:
+            return "rm -rf 는 막혀 있습니다. 지울 대상이 확실하면 사용자에게 요청하세요."
+        for op in operands(args):
+            if "scripts/mysql/" in op or op.endswith(".sql"):
+                return "SQL 마이그레이션 파일 삭제는 막혀 있습니다. 필요하면 사용자에게 요청하세요."
+
+    if name == "git" and sub == "push":
+        rest = args[1:]
+        if "f" in shorts(rest) or "force" in longs(rest):
+            return "force push 는 막혀 있습니다."
+
+    if name == "git" and sub == "reset" and "hard" in longs(args[1:]):
+        return "git reset --hard 는 되돌릴 수 없습니다. 막혀 있습니다."
+
+    if name == "git" and sub == "clean":
+        rest = args[1:]
+        if shorts(rest) & set("fd") or longs(rest) & {"force", "d"}:
+            return "git clean 은 추적되지 않는 파일을 지웁니다. 막혀 있습니다."
+
+    # down 의 위치를 고정하면 안 된다. docker compose -f a.yml down -v 처럼
+    # 옵션이 앞에 오면 서브커맨드가 뒤로 밀린다.
+    compose_down = (
+        (name == "docker" and sub == "compose" and "down" in operands(args))
+        or (name == "docker-compose" and "down" in operands(args))
+    )
+    if compose_down:
+        if "v" in shorts(args) or "volumes" in longs(args):
+            return "compose 볼륨 삭제는 DB 데이터까지 지웁니다. 막혀 있습니다."
+
+    # Read() deny 는 Read 도구에만 걸린다. Bash 경유 읽기를 여기서 막는다.
+    # 시크릿 경로가 "이 reader 의 인자"일 때만 막아야 오탐이 없다.
+    if name in READERS:
+        for op in operands(args):
+            if is_secret(op):
+                return "시크릿 파일(firebase 키·.env·인증서)을 Bash 로 읽는 것은 막혀 있습니다."
+
+    return None
+
+
+COARSE = [
+    (r"rm\s+-[a-zA-Z]*[rR][a-zA-Z]*f|rm\s+-[a-zA-Z]*f[a-zA-Z]*[rR]", "rm -rf 는 막혀 있습니다."),
+    (r"git\s+push\b[^\n]*--force", "force push 는 막혀 있습니다."),
+    (r"git\s+reset\s+--hard", "git reset --hard 는 되돌릴 수 없습니다. 막혀 있습니다."),
 ]
 
-for pattern, message in RULES:
-    if re.search(pattern, cmd, FLAGS):
-        print(message)
-        sys.exit(2)
-
-# ── Read() deny 가 못 막는 Bash 경유 시크릿 읽기 ─────────────────────────
-# settings.json 의 Read() deny 는 Read 도구에만 걸린다.
-# 읽기 명령이 명령 자리에 있고 + 인자에 시크릿 경로가 있을 때만 막는다.
-READER = POS + r"(?:cat|head|tail|less|more|nl|base64|xxd|od|strings|awk|sed)(?:\s|$)"
-SECRET = r"(?:firebase/[^\s]*\.json|(?:^|[\s/])\.env(?:\s|$)|\.pem(?:\s|$)|\.p8(?:\s|$))"
-
-if re.search(READER, cmd, FLAGS) and re.search(SECRET, cmd, FLAGS):
-    print("시크릿 파일(firebase 키·.env·인증서)을 Bash 로 읽는 것은 막혀 있습니다.")
-    sys.exit(2)
+try:
+    for argv in segments(strip_heredocs(cmd)):
+        msg = verdict(argv)
+        if msg:
+            print(msg)
+            sys.exit(2)
+except ValueError:
+    # 따옴표가 안 맞는 등 토큰화 실패. 셸에서도 유효하지 않은 명령일 가능성이 높다.
+    # 조용히 통과시키지는 않고, 거친 정규식으로 최소한의 그물은 친다.
+    for pat, msg in COARSE:
+        if re.search(pat, cmd):
+            print(msg)
+            sys.exit(2)
 
 sys.exit(0)
 ' 2>/dev/null)"

--- a/scripts/harness/test-pre-bash-guard.py
+++ b/scripts/harness/test-pre-bash-guard.py
@@ -79,6 +79,35 @@ CASES = [
     # 반대로 heredoc 이 끝난 뒤 줄바꿈으로 이어진 진짜 명령은 잡아야 한다.
     (2, "heredoc 종료 후 실제 위험 명령",
      "cat > /tmp/x.md <<'EOF'\n안전한 본문\nEOF\nrm -rf /tmp/x.md"),
+
+    # ── 우회·오탐 회귀 (PR #535 리뷰) ────────────────────────────────────
+    # 따옴표 안의 <<EOF 는 heredoc 연산자가 아니다. 연산자로 오인하면
+    # 그 뒤의 진짜 명령이 본문으로 취급돼 통째로 숨는다.
+    (2, "따옴표 안 <<EOF 로 위험 명령 은닉",
+     "printf '%s\\n' '<<EOF'\nrm -rf ./build\nEOF"),
+    # 플래그를 나눠 써도 같은 삭제다.
+    (2, "rm 플래그 분리 (-r -f)", "rm -r -f ./build"),
+    (2, "rm 롱옵션", "rm --recursive --force ./build"),
+    # reader 와 secret 이 각각 다른 명령에 있으면 시크릿을 읽는 게 아니다.
+    (0, "reader 와 secret 이 다른 명령", "cat README.md && echo .env"),
+    # settings.json 이 Read(./.env.*) 를 막으므로 Bash 도 같은 범위여야 한다.
+    (2, ".env.local 읽기", "cat .env.local"),
+    (2, ".env.production 읽기", "base64 .env.production"),
+
+    # ── 토큰 분석으로 넘어오면서 확인한 우회 시도 ────────────────────────
+    (2, "rm 플래그 역순 (-f -r)", "rm -f -r ./build"),
+    (2, "rm 섞인 플래그 (-rvf)", "rm -rvf ./build"),
+    (2, "환경변수 대입 뒤 rm", "FOO=bar rm -rf x"),
+    (2, "절대경로 rm", "/bin/rm -rf x"),
+    (2, "공백 여러 개", "git   push   --force"),
+    # 서브커맨드 위치를 고정하면 옵션이 앞에 올 때 밀린다.
+    (2, "compose 옵션 뒤 down -v", "docker compose -f a.yml down -v"),
+    (2, "상대경로 우회한 .env", "cat ./config/../.env"),
+
+    (0, "따옴표 안 문자열은 실행이 아님", 'echo "cat .env"'),
+    (0, "force-with-lease 는 허용", "git push --force-with-lease"),
+    (0, "-r 만 (force 없음)", "rm -r ./build"),
+    (0, ".envrc 는 시크릿 아님", "cat .envrc"),
 ]
 
 

--- a/scripts/harness/test-pre-bash-guard.py
+++ b/scripts/harness/test-pre-bash-guard.py
@@ -1,0 +1,115 @@
+#!/usr/bin/env python3
+"""pre-bash-guard.sh 회귀 테스트.
+
+실행: python3 scripts/harness/test-pre-bash-guard.py
+
+케이스를 셸이 아니라 이 파일 안에 데이터로 두는 이유:
+테스트 명령 문자열에 위험 패턴을 그대로 쓰면 살아 있는 가드가 러너 실행 자체를 막는다.
+"""
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+GUARD = Path(__file__).with_name("pre-bash-guard.sh")
+
+# (기대 exit, 라벨, 명령)  — 2=차단, 0=통과
+CASES = [
+    # ── 되돌릴 수 없는 명령 ──────────────────────────────────────────────
+    (2, "rm -rf", "rm -rf ./build"),
+    (2, "rm -fr 플래그 순열", "rm -fr /tmp/x"),
+    (2, "&& 뒤 rm -rf", "cd /tmp && rm -rf ."),
+    (2, "; 뒤 rm -Rf", "echo x | xargs; rm -Rf out"),
+    (2, "mysql 마이그레이션 삭제", "rm scripts/mysql/add_x.sql"),
+    (2, "git rm sql", "git rm scripts/mysql/add_x.sql"),
+    (2, "임의 .sql 삭제", "rm migrations/001.sql"),
+    (2, "force push", "git push --force origin develop"),
+    (2, "push -f (짧은 플래그)", "git push -f"),
+    (2, "reset --hard", "git reset --hard HEAD~1"),
+    (2, "clean -fd", "git clean -fd"),
+    (2, "compose 볼륨 삭제", "docker compose down -v"),
+    (2, "compose 볼륨 삭제 (hyphen)", "docker-compose down -v"),
+
+    # ── Bash 경유 시크릿 읽기 ────────────────────────────────────────────
+    (2, "firebase 키", "cat backend/widyu-api/src/main/resources/firebase/k.json"),
+    (2, "firebase 빌드 복제본", "base64 backend/widyu-api/bin/main/firebase/k.json"),
+    (2, ".env cat", "cat .env"),
+    (2, ".env tail 우회", "tail -1 .env"),
+    (2, ".env sed 우회", "sed -n 1p .env"),
+    (2, "pem 인증서", "echo hi && cat ./certs/key.pem"),
+
+    # ── 통과해야 하는 일상 명령 ──────────────────────────────────────────
+    (0, "ls", "ls -la scripts/harness"),
+    (0, "gradlew build", "./gradlew build"),
+    (0, "gradlew test", "./gradlew :backend:widyu-api:test"),
+    (0, "git status", "git status --porcelain"),
+    (0, "git diff", "git diff --cached --stat"),
+    (0, "정상 push -u", "git push -u origin feature/525"),
+    (0, "정상 push", "git push origin develop"),
+    (0, "git commit", "git commit -m 'fix: x'"),
+    (0, "git add", "git add .claude/settings.json"),
+    (0, "git switch", "git switch -c feature/526"),
+    (0, "reset 무플래그", "git reset HEAD~1"),
+    (0, "clean -n (드라이런)", "git clean -n"),
+    (0, "compose down (볼륨 유지)", "docker compose down"),
+    (0, "compose up", "docker compose up -d"),
+    (0, "문서 cat", "cat docs/adr/README.md"),
+    (0, "스크립트 cat", "cat scripts/harness/on-stop.sh"),
+    (0, "grep", "grep -c run-module-tests .claude/settings.json"),
+    (0, "sed 일반 파일", "sed -n 1,50p CLAUDE.md"),
+    (0, "awk 일반 파일", "awk '{print}' build.gradle.kts"),
+    (0, "tmp 파일 rm", "rm /tmp/scratch.txt"),
+    (0, "rm -f 단독", "rm -f /tmp/a.log"),
+    (0, "gh pr view", "gh pr view 528 --json title"),
+    (0, "find", "find . -name '*.java' | head"),
+    (0, "echo 안의 위험 문자열", 'echo "rm -rf 는 막혀 있습니다"'),
+
+    # ── heredoc 회귀 ─────────────────────────────────────────────────────
+    # 커밋 메시지·이슈 본문에 위험 명령을 설명으로 적는 건 실행이 아니다.
+    # 이걸 막으면 가드가 정상 작업을 방해한다 (실제로 한 번 발생했다).
+    (0, "REGRESSION 커밋 메시지에 위험 명령 언급",
+     "git commit -F - <<'EOF'\n"
+     "fix(harness): 파괴적 명령 게이트 추가\n\n"
+     "deny 에 아래가 없었다.\n"
+     "docker compose down -v\ngit reset --hard\ngit push --force\nrm -rf\ngit clean -fd\n\n"
+     "Refs #525\nEOF"),
+    (0, "REGRESSION 이슈 본문 heredoc",
+     "cat > /tmp/body.md <<'EOF'\n## 배경\n"
+     "git reset --hard 와 docker compose down -v 가 deny 에 없습니다.\nEOF"),
+    # 반대로 heredoc 이 끝난 뒤 줄바꿈으로 이어진 진짜 명령은 잡아야 한다.
+    (2, "heredoc 종료 후 실제 위험 명령",
+     "cat > /tmp/x.md <<'EOF'\n안전한 본문\nEOF\nrm -rf /tmp/x.md"),
+]
+
+
+def run(cmd):
+    payload = json.dumps({"session_id": "t", "tool_input": {"command": cmd}})
+    return subprocess.run(["bash", str(GUARD)], input=payload,
+                          capture_output=True, text=True)
+
+
+def main():
+    failed = []
+    for expect, label, cmd in CASES:
+        got = run(cmd).returncode
+        if got != expect:
+            failed.append((label, expect, got, cmd))
+            print(f"!!FAIL  exp={expect} got={got}  {label}")
+
+    # fail-closed: 무엇을 실행하려는지 모르면 통과가 아니라 차단이어야 한다.
+    for label, payload in [("깨진 JSON", '{"tool_input": {broken'), ("빈 입력", "")]:
+        p = subprocess.run(["bash", str(GUARD)], input=payload,
+                           capture_output=True, text=True)
+        if p.returncode != 2:
+            failed.append((f"fail-closed {label}", 2, p.returncode, payload))
+            print(f"!!FAIL  exp=2 got={p.returncode}  fail-closed {label}")
+
+    total = len(CASES) + 2
+    print(f"\n총 {total}건 · 통과 {total - len(failed)} · 실패 {len(failed)}")
+    for label, expect, got, cmd in failed:
+        print(f"  - {label}: exp={expect} got={got}  {cmd[:80]!r}")
+    return 1 if failed else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/harness/test-pre-bash-guard.py
+++ b/scripts/harness/test-pre-bash-guard.py
@@ -108,6 +108,21 @@ CASES = [
     (0, "force-with-lease 는 허용", "git push --force-with-lease"),
     (0, "-r 만 (force 없음)", "rm -r ./build"),
     (0, ".envrc 는 시크릿 아님", "cat .envrc"),
+
+    # ── 여러 줄에 걸친 인용 문자열 (줄 단위 파싱이 깨지던 자리) ──────────
+    # 셸 따옴표는 줄을 넘는다. 줄 단위로 lex 하면 여는 줄과 닫는 줄 양쪽에서
+    # "No closing quotation" 이 나고, 폴백 정규식이 본문 속 예시를 명령으로
+    # 오인해 차단했다. 실제로 PR 답글을 쓰다가 막혔다.
+    (0, "REGRESSION 여러 줄 인용 문자열 안의 위험 명령 예시",
+     "gh api -X POST repos/o/r/pulls/1/comments -f body='옵션을 토큰으로 봅니다.\n\n"
+     "플래그 역순 `rm -f -r`, 섞인 플래그 `rm -rvf` 도 막힙니다.\n\n"
+     "`git reset --hard` 와 `docker compose down -v` 도 마찬가지입니다.'"),
+    (0, "REGRESSION 함수 정의 + 여러 줄 인자",
+     "reply() {\n  gh api -X POST \"$1\" -f body=\"$2\"\n}\n"
+     "reply 123 '아래를 막습니다.\nrm -rf ./build\n'"),
+    # 반대로 따옴표 밖에 진짜로 있으면 잡아야 한다.
+    (2, "여러 줄 인용 문자열 뒤의 진짜 명령",
+     "gh api -f body='설명입니다.\n여러 줄입니다.'\nrm -rf ./build"),
 ]
 
 


### PR DESCRIPTION
## 개요

`.claude/settings.json` 의 시크릿 차단 규칙이 **실제 파일 경로와 어긋나 아무것도 막지 못하고 있었습니다.**

```
deny 패턴:  Read(./src/main/resources/firebase/**)
실제 경로:  backend/widyu-api/src/main/resources/firebase/
           backend/widyu-api/bin/main/firebase/
           backend/widyu-api/build/resources/main/firebase/
```

Firebase 관리자 SDK 키가 세 곳에 복제돼 있는데 세 곳 다 매칭되지 않았습니다. 이 키는 `.gitignore:48` 로 git 에는 올라가지 않으므로 유출은 아니지만, 에이전트가 로컬에서 읽어 컨텍스트에 올리는 경로가 열려 있었습니다.

되돌릴 수 없는 명령에 대한 deny 가 하나도 없던 것과, `Read()` deny 를 Bash 로 우회하는 경로도 함께 막았습니다.

## 관련 문서
- LLD: -
- ADR: `docs/adr/ADR-0018-claude-code-sandbox-not-adopted.md` — deny 규칙의 실제 차단 범위를 실측해 "deny 는 보안 경계가 아니라 실수 방지용 가드"라고 결론지은 문서입니다. 이번 변경은 그 결론을 그대로 적용하는 구현이라 새 ADR 을 만들지 않았습니다.
- 참고: `docs/adr/ADR-0021-branch-guard-pretooluse.md` — 같은 하네스 훅의 fail-open / fail-closed 판단 기준입니다.

## 관련 이슈
Closes #525

## 변경 사항

- 변경 모듈: 해당 없음 (하네스 · 개발 환경 설정)

**deny 규칙 정정**

- Firebase 키 deny 를 `Read(./**/firebase/**)` 한 패턴으로 합쳐 빌드 산출물 복제본(`bin/main`, `build/resources/main`)까지 덮습니다.
- 되돌릴 수 없는 명령을 deny 에 추가했습니다. `rm -rf`, `git push --force`, `git reset --hard`, `git clean -fd`, `docker compose down -v`.
- 와일드카드는 별 앞 공백으로 단어 경계를 만들었습니다.
- `gh pr merge` 는 deny 에 넣지 않았습니다. 이미 `ask` 에 있고, 평가 순서가 deny → ask → allow 라 deny 에 넣으면 ask 가 죽습니다.

**PreToolUse(Bash) 게이트 신설**

- `scripts/harness/pre-bash-guard.sh` 를 추가했습니다. `Read()` deny 는 Read 도구에만 걸리므로 `cat`·`base64` 우회가 남는데, 이 훅은 파이프·세미콜론으로 이어진 명령까지 봅니다.
- **fail-closed** 입니다. stdin JSON 파싱에 실패하면 통과가 아니라 차단합니다. 무엇을 실행하려는지 모르는 상태에서 통과시키면 가드가 무의미합니다. (브랜치 가드는 반대로 fail-open 이며 근거는 ADR-0021 에 있습니다.)
- `jq` 대신 프로젝트가 이미 쓰는 `python3` 를 사용합니다. `jq` 부재 시 `set -e` 가 2 가 아닌 종료 코드를 내면 PreToolUse 가 이를 훅 오류로 처리해 도구를 그대로 실행시키기 때문입니다.
- 판정을 `grep` 이 아니라 python `re` 로 합니다. `grep` 은 줄 단위라 heredoc 본문의 각 줄에도 `^` 앵커가 걸립니다. 실제로 이 작업의 첫 커밋이 메시지 본문에 적은 위험 명령 설명 때문에 차단됐습니다. heredoc 본문을 데이터로 보고 제거한 뒤 판정하며, 그래야 줄바꿈으로 이어진 진짜 명령에 `^` 앵커를 안전하게 쓸 수 있습니다.

**개인 설정**

- `.claude/settings.local.json` 의 `allow` 에 있던 `Bash(rm:*)` 를 제거했습니다(이 PR 에는 포함되지 않는 gitignored 파일입니다). 인자 전체가 열려 있어 deny 보강의 의미를 지웠습니다.

## 테스트

- `./gradlew :backend:widyu-api:test`: 해당 없음 (Java 변경 없음)
- `./gradlew :backend:widyu-domain:test`: 해당 없음 (Java 변경 없음)

Java 코드 변경이 없어 gradle 테스트 대신 훅 자체의 회귀 테스트를 추가했습니다.

```
$ python3 scripts/harness/test-pre-bash-guard.py
총 48건 · 통과 48 · 실패 0
```

차단 19건(rm -rf 플래그 순열 · SQL 삭제 · force push · 볼륨 삭제 · firebase/.env/.pem 읽기), 통과 27건(gradlew · 정상 push · 플래그 없는 reset · 볼륨 없는 compose down · 문서 cat), fail-closed 2건(깨진 JSON · 빈 입력)입니다. heredoc 회귀 3건을 포함했습니다.

기존 브랜치 가드 테스트 11건도 함께 통과하는 것을 확인했습니다.

## 체크리스트
- [x] 엔티티 변경 시 `./gradlew compileJava` 실행 — 엔티티 변경 없음
- [x] MySQL ENUM 변경 시 ALTER TABLE 명시 — ENUM 변경 없음
- [x] `@Async` 메서드에 `@Transactional` 확인 — 해당 없음
- [x] LLD 인수조건 전체 충족 — LLD 없음, 이슈 완료 조건 기준으로 확인

## 리뷰 포인트

**차단 패턴의 오탐 범위가 적절한지 봐주세요.**

이 훅은 모든 Bash 호출을 거치므로 오탐이 곧 작업 중단입니다. 실제로 개발 중 두 번 제 작업을 막았고 그중 하나는 진짜 결함이었습니다(heredoc). 통과 케이스 27건은 이 세션에서 실제로 사용한 명령들로 채웠지만, 팀에서 자주 쓰는데 빠진 명령이 있으면 알려주세요.

## Open Questions (LLD 미결정 사항)

LLD 가 없어 이슈의 "정책 확인 필요" 항목을 옮깁니다.

- 이 훅도 문자열 매칭이라 변수 치환·`bash -c` 로 우회할 수 있습니다. ADR-0018 과 같은 한계이며 보안 경계가 아니라 사고 방지 장치입니다. 시크릿 보호의 실질적 방어선은 여전히 `.gitignore` 와 유출 시 키 교체입니다.

## 비고

- **배포 영향은 없습니다.** 애플리케이션 코드가 아니라 개발 환경 설정입니다.
- 머지되면 팀 전체 세션에 Bash 게이트가 적용됩니다. `clone`·`pull` 후 별도 설치 단계는 없습니다.
- 후속 이슈: #526(`.claude/rules` 분리 + allow 승격), #527(테스트를 Stop 게이트에 포함).
- 워킹트리의 `scripts/mysql/add_medication_proof_daily_unique.sql` 삭제는 이 작업과 무관해 스테이징하지 않았습니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **보안**
  * 강제 푸시, 하드 리셋, 위험한 정리 명령, 볼륨 삭제 등 파괴적인 명령의 실행을 차단합니다.
  * Firebase 경로와 시크릿 파일 보호 범위를 확대했습니다.
  * Bash 명령 실행 전에 보안 검사를 자동으로 수행하며, 분석에 실패한 명령은 안전을 위해 차단합니다.

* **테스트**
  * 정상 명령은 허용하고 위험한 명령, 우회 시도 및 잘못된 입력은 차단하는 회귀 테스트를 추가했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->