### PR TITLE
[수정] 결제 복구 인덱스를 엔티티 스키마와 동기화합니다

### DIFF
--- a/backend/widyu-domain/src/main/java/com/widyu/pay/PaymentCancel.java
+++ b/backend/widyu-domain/src/main/java/com/widyu/pay/PaymentCancel.java
@@ -9,6 +9,7 @@ import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.Index;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
@@ -24,6 +25,10 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Table(
         name = "payment_cancel",
+        indexes = @Index(
+                name = "idx_payment_cancel_recovery",
+                columnList = "status, next_retry_at"
+        ),
         uniqueConstraints = @UniqueConstraint(
                 name = "uk_payment_cancel_payment_idempotency_key",
                 columnNames = {"payment_id", "idempotency_key"}

--- a/backend/widyu-domain/src/main/java/com/widyu/pay/PaymentOrder.java
+++ b/backend/widyu-domain/src/main/java/com/widyu/pay/PaymentOrder.java
@@ -10,6 +10,7 @@ import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.Index;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
@@ -23,7 +24,13 @@ import lombok.NoArgsConstructor;
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-@Table(name = "payment_order")
+@Table(
+        name = "payment_order",
+        indexes = @Index(
+                name = "idx_payment_order_approval_recovery",
+                columnList = "status, approval_next_retry_at"
+        )
+)
 public class PaymentOrder extends BaseTimeEntity {
 
     @Id

--- a/docs/erd/ERD-0001-initial-domain.md
+++ b/docs/erd/ERD-0001-initial-domain.md
@@ -355,6 +355,8 @@ erDiagram
 | `family_membership` | UK | `(guardian_id)` | 보호자는 하나의 가족에만 속함 |
 | `album_like` | UK | `(album_id, member_id)` | 중복 좋아요 방지 |
 | `album_unlock` | UK | `(album_id, member_id)` | 중복 해금 방지 |
+| `payment_order` | `idx_payment_order_approval_recovery` | `(status, approval_next_retry_at)` | 승인 복구 대상 범위 조회 |
+| `payment_cancel` | `idx_payment_cancel_recovery` | `(status, next_retry_at)` | 취소 복구 대상 범위 조회 |
 | `payment_cancel` | UK `uk_payment_cancel_pg_idempotency_key` | `(pg_idempotency_key)` | PG 요청 재실행 식별 |
 | `payment_cancel` | UK `uk_payment_cancel_payment_idempotency_key` | `(payment_id, idempotency_key)` | 클라이언트 멱등 키 중복 방지 (ADR-0012) |
 

--- a/docs/lld/LLD-0022-payment-pg-call-transaction-separation.md
+++ b/docs/lld/LLD-0022-payment-pg-call-transaction-separation.md
@@ -159,7 +159,8 @@ ALTER TABLE payment_order
     ADD COLUMN approval_retry_count INT NOT NULL DEFAULT 0,
     ADD COLUMN approval_next_retry_at DATETIME NULL,
     ADD COLUMN approval_last_error_code VARCHAR(100) NULL,
-    ADD COLUMN approval_recovery_stopped_at DATETIME NULL;
+    ADD COLUMN approval_recovery_stopped_at DATETIME NULL,
+    ADD INDEX idx_payment_order_approval_recovery (status, approval_next_retry_at);
 
 ALTER TABLE payment_cancel
     ADD COLUMN status ENUM('PENDING', 'COMPLETED', 'ABORTED') NOT NULL DEFAULT 'COMPLETED',
@@ -168,7 +169,8 @@ ALTER TABLE payment_cancel
     ADD COLUMN retry_count INT NOT NULL DEFAULT 0,
     ADD COLUMN next_retry_at DATETIME NULL,
     ADD COLUMN last_error_code VARCHAR(100) NULL,
-    ADD COLUMN recovery_stopped_at DATETIME NULL;
+    ADD COLUMN recovery_stopped_at DATETIME NULL,
+    ADD INDEX idx_payment_cancel_recovery (status, next_retry_at);
 
 UPDATE payment_cancel
 SET pg_idempotency_key = UUID()


### PR DESCRIPTION
## 개요
결제 승인·취소 복구 조회용 복합 인덱스가 운영 DB 마이그레이션에만 정의되어 있어 신규 스키마 생성 시 누락될 수 있는 문제를 해결합니다. SQL 마이그레이션과 동일한 인덱스를 JPA 엔티티에 선언합니다.

## 관련 문서
- LLD: docs/lld/LLD-0022-payment-pg-call-transaction-separation.md
- ADR: docs/adr/ADR-0016-payment-pg-call-transaction-separation.md

## 관련 이슈
Closes #536

## 변경 사항
- 변경 모듈: `widyu-domain`
- `PaymentOrder`에 `(status, approval_next_retry_at)` 복합 인덱스를 선언합니다.
- `PaymentCancel`에 `(status, next_retry_at)` 복합 인덱스를 선언합니다.
- LLD와 ERD의 인덱스 정의를 엔티티 및 운영 마이그레이션과 동기화합니다.
- 기존 DB의 컬럼·ENUM·백필을 담당하는 운영 마이그레이션은 변경하지 않습니다.

## 테스트
- `./gradlew compileJava`: 통과
- `./gradlew :backend:widyu-api:test`: 통과
- `./gradlew :backend:widyu-domain:test`: 통과

## 체크리스트
- [x] 엔티티 변경 후 `./gradlew compileJava`를 실행했습니다.
- [x] MySQL ENUM 변경은 없습니다.
- [x] `@Async` 메서드 변경은 없습니다.
- [x] LLD 인수조건을 유지합니다.

## 리뷰 포인트
엔티티의 인덱스 이름과 컬럼 순서가 운영 마이그레이션의 정의와 정확히 일치하는지 확인해 주세요.

## Open Questions (LLD 미결정 사항)
없습니다.

## 비고
기존 운영 DB에는 엔티티 애노테이션 대신 기존 SQL 마이그레이션을 계속 적용해야 합니다.
