### PR TITLE
fix(auth): 실시간 위치 WebSocket 구독 인가 우회 수정

### DIFF
--- a/backend/widyu-api/src/main/java/com/widyu/global/websocket/JwtChannelInterceptor.java
+++ b/backend/widyu-api/src/main/java/com/widyu/global/websocket/JwtChannelInterceptor.java
@@ -27,7 +27,7 @@ import org.springframework.stereotype.Component;
 @RequiredArgsConstructor
 public class JwtChannelInterceptor implements ChannelInterceptor {
 
-    private static final Pattern LOCATION_TOPIC = Pattern.compile("^/topic/location/(\\d+)$");
+    private static final Pattern LOCATION_TOPIC = Pattern.compile("^/topic/location/senior/(\\d+)$");
     private static final Pattern HEART_RATE_TOPIC = Pattern.compile("^/topic/heart-rate/(\\d+)$");
 
     private final JwtTokenProvider jwtTokenProvider;

--- a/backend/widyu-api/src/test/java/com/widyu/global/websocket/JwtChannelInterceptorTest.java
+++ b/backend/widyu-api/src/test/java/com/widyu/global/websocket/JwtChannelInterceptorTest.java
@@ -52,7 +52,7 @@ class JwtChannelInterceptorTest {
     @DisplayName("가족으로 연결된 보호자가 위치 topic 구독 시 메시지를 통과시킨다")
     void 가족_보호자가_위치_topic_구독_시_메시지를_통과시킨다() {
         // given
-        Message<?> message = buildSubscribeMessage("/topic/location/42", 100L);
+        Message<?> message = buildSubscribeMessage("/topic/location/senior/42", 100L);
 
         // when
         Message<?> result = jwtChannelInterceptor.preSend(message, null);
@@ -65,7 +65,7 @@ class JwtChannelInterceptorTest {
     @DisplayName("가족으로 연결되지 않은 보호자가 위치 topic 구독 시 null을 반환한다")
     void 비가족_보호자가_위치_topic_구독_시_null을_반환한다() {
         // given
-        Message<?> message = buildSubscribeMessage("/topic/location/42", 100L);
+        Message<?> message = buildSubscribeMessage("/topic/location/senior/42", 100L);
         willThrow(new BusinessException(ErrorCode.FORBIDDEN, "가족으로 연결된 시니어만 접근할 수 있습니다."))
                 .given(familyAccessService).verifyFamilyAccess(anyLong(), anyLong());
 
@@ -95,7 +95,7 @@ class JwtChannelInterceptorTest {
     @DisplayName("인증 정보 없이 위치 topic 구독 시 null을 반환한다")
     void 인증_정보_없이_위치_topic_구독_시_null을_반환한다() {
         // given
-        Message<?> message = buildSubscribeMessageWithNoAuth("/topic/location/42");
+        Message<?> message = buildSubscribeMessageWithNoAuth("/topic/location/senior/42");
 
         // when
         Message<?> result = jwtChannelInterceptor.preSend(message, null);
@@ -108,7 +108,7 @@ class JwtChannelInterceptorTest {
     @DisplayName("세션 속성으로 인증된 보호자가 위치 topic 구독 시 메시지를 통과시킨다")
     void 세션_속성_인증_보호자가_위치_topic_구독_시_메시지를_통과시킨다() {
         // given
-        Message<?> message = buildSubscribeMessageWithSessionAttrs("/topic/location/42", 100L);
+        Message<?> message = buildSubscribeMessageWithSessionAttrs("/topic/location/senior/42", 100L);
 
         // when
         Message<?> result = jwtChannelInterceptor.preSend(message, null);


### PR DESCRIPTION
## 개요

실시간 위치 WebSocket 구독 시 가족 관계 인가 검사가 동작하지 않던 문제를 수정합니다. `JwtChannelInterceptor`의 SUBSCRIBE 인가 검사가 참조하는 위치 목적지 정규식이 실제 브로드캐스트 목적지와 달라, 인증된 사용자라면 임의 `memberId`로 남의 실시간 위치를 구독할 수 있었습니다.

## 관련 문서
- LLD: docs/lld/LLD-0001-websocket-realtime-location.md (인수조건 L275: `/topic/location/senior/{memberId}` 브로드캐스트)
- ADR: -

## 관련 이슈
Closes #539

## 변경 사항
- 변경 모듈: widyu-api
- `JwtChannelInterceptor`의 위치 목적지 정규식을 실제 발행 경로에 맞췄습니다: `^/topic/location/(\d+)$` → `^/topic/location/senior/(\d+)$` (`RealtimeLocationService.java:115`, LLD-0001 기준).
- 기존 정규식은 실제 목적지 `/topic/location/senior/{id}`와 매칭되지 않아 `extractProtectedMemberId()`가 `null`을 반환하고 인가 없이 통과시켰습니다.
- `JwtChannelInterceptorTest`의 위치 목적지를 실제 경로(`/topic/location/senior/42`)로 교정했습니다. 이제 "가족 통과 / 비가족 거부" 테스트가 정규식-브로드캐스트 불일치 회귀를 막습니다.

## 의도적으로 하지 않은 것
- **fail-open 구조는 그대로 두었습니다.** 현재 인터셉터는 알려진 보호 패턴이 아니면 통과시키는 방식이라, 향후 `/topic/*` 토픽 추가 시 패턴 등록 누락으로 같은 문제가 재발할 수 있습니다. fail-closed 전환은 공개 토픽 정책 결정이 필요해 별도 이슈로 분리하는 것을 권고합니다(이슈 #539 본문에 기재).
- 심박 목적지(`/topic/heart-rate/{id}`)는 정규식과 이미 일치해 정상 동작하므로 변경하지 않았습니다.

## 테스트
- `./gradlew :backend:widyu-api:test --tests "com.widyu.global.websocket.JwtChannelInterceptorTest"`: 통과

## 체크리스트
- [x] 엔티티 변경 없음
- [x] MySQL ENUM 변경 없음
- [x] `@Async`/`@Transactional` 해당 없음
- [x] LLD 인수조건(위치 브로드캐스트 목적지) 기준 정합

## 리뷰 포인트
정규식을 브로드캐스트 경로에 맞추는 방향(서버만 수정)이 맞을까요? — 반대로 브로드캐스트 경로를 정규식에 맞추면 프론트·LLD·`socket-test.html`의 구독 계약까지 바꿔야 해 파급이 크다고 판단했습니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **변경 사항**
  * 위치 정보 구독 경로가 `/topic/location/senior/{memberId}` 형식으로 변경되었습니다.
  * 심박수 정보 구독 경로와 구독 인증 방식은 기존과 동일합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->